### PR TITLE
Add NANO_BREAKPOINT to shell out during build.

### DIFF
--- a/build/nanobsd/nanobsd.sh
+++ b/build/nanobsd/nanobsd.sh
@@ -346,7 +346,11 @@ run_customize() (
 		pprint 2 "[$i/$num_steps] customize \"$c\""
 		log_file "${NANO_OBJ}/_.cust.$c"
 		pprint 4 "`type $c`"
-		( set -x ; $c ) > ${NANO_OBJ}/_.cust.$c 2>&1
+		if [ "x${NANO_BREAKPOINT}" != "x" ] ; then
+		    $c
+		else
+		    ( set -x ; $c ) > ${NANO_OBJ}/_.cust.$c 2>&1
+		fi
 		shift
 		: $(( i += 1 ))
 	done

--- a/nanobsd/common
+++ b/nanobsd/common
@@ -319,6 +319,24 @@ do_add_port ()
 		envargs="$envargs MAKEOBJDIRPREFIX=$makeobjdirprefix"
 	fi
 
+	if [ "x${NANO_BREAKPOINT}" = "xadd_port${port_repo}${port_path}" ] ; then
+	    echo "env \
+	    TARGET=${NANO_ARCH} \
+	    TARGET_ARCH=${NANO_ARCH} \
+	    $envargs \
+	    make \
+	    __MAKE_CONF=${NANO_MAKE_CONF_BUILD} \
+	    SRC_BASE=/usr/src \
+	    WRKDIRPREFIX=/usr/workdir -C /usr/ports_dir/$port_path \
+	    clean all install package BATCH=yes -DUSE_PACKAGE_DEPENDS \
+	    $* -DFORCE_PACKAGE -DFORCE_PKG_REGISTER"
+	    CR "env \
+		TARGET=${NANO_ARCH} \
+		TARGET_ARCH=${NANO_ARCH} \
+		$envargs \
+		/bin/sh"
+	fi
+
 	# Improvement: Don't know why package-recursive don't works here
 	CR "env \
 	    TARGET=${NANO_ARCH} \


### PR DESCRIPTION
Right now this is used so that we can shell out while building a port in the port's environment.

By setting for example NANO_BREAKPOINT you can shell out instead of just building a port.  I've found this really handy for debugging ports because then all of the nullfs mounts and other environment variables are set for me.  

This lets me just directly build the port and instead of running "make" at the top level over and over.

An example usage would be:
export NANO_BREAKPOINT="add_port${NAS_PORTS}sysutils/zfsd"

This would shell out right before building zfsd.


