### PR TITLE
Save/restore root fs read/write status via VERSION.

### DIFF
--- a/nanobsd/Files/etc/ix.rc.d/ix-loader
+++ b/nanobsd/Files/etc/ix.rc.d/ix-loader
@@ -37,11 +37,11 @@ update_persistent_file()
 		rm -f "$new"
 	else
 		rc=2
-		if mount -uw -onoatime /; then
+		if mount_root_rw -onoatime ; then
 			if mv "$new" "$old"; then
 				rc=0
 			fi
-			mount -ur /
+			mount_root_restore
 		fi
 	fi
 	return $rc

--- a/nanobsd/Files/etc/ix.rc.d/ix-savehostid
+++ b/nanobsd/Files/etc/ix.rc.d/ix-savehostid
@@ -20,9 +20,9 @@ ix_save_hostid()
 	# so we don't create another dependency on /cfg which we're trying
 	# to eliminate to support 1 spindle systems.
 	if ! cmp -s /etc/hostid /conf/base/etc/hostid; then
-		mount -uw -onoatime /
+		mount_root_rw -onoatime
 		cp /etc/hostid /conf/base/etc/hostid
-		mount -ur /
+		mount_root_restore
 	fi
 }
 

--- a/nanobsd/Files/etc/ix.rc.d/ix-sercons
+++ b/nanobsd/Files/etc/ix.rc.d/ix-sercons
@@ -23,29 +23,29 @@ update_sercons()
 	0)
 		if [ -f ${bc} ]; then
 			if [ -s ${bc} ]; then
-				mount -uw -onoatime /
+				mount_root_rw -onoatime
 				rm -f ${bc}
 				touch ${bc}
-				mount -ur /
+				mount_root_restore
 			fi
 		else
-			mount -uw -onoatime /
+			mount_root_rw -onoatime
 			touch ${bc}
-			mount -ur /
+			mount_root_restore
 		fi
 		;;
 	1)
 		echo "-Dh -S${serspeed}" > ${tmp}
 		if [ -f ${bc} ] ; then
 			if ! [ $(sha256 -q ${tmp}) == $(sha256 -q ${bc}) ] ; then
-				mount -uw -onoatime /
+				mount_root_rw -onoatime
 				mv ${tmp} ${bc}
-				mount -ur /
+				mount_root_restore
 			fi
 		else
-			mount -uw -onoatime /
+			mount_root_rw -onoatime
 			mv ${tmp} ${bc}
-			mount -ur /
+			mount_root_restore
 		fi
 		;;
         esac

--- a/nanobsd/Files/etc/rc.freenas
+++ b/nanobsd/Files/etc/rc.freenas
@@ -840,3 +840,22 @@ jail_post_delete()
 {
 	:
 }
+
+mount_root_rw()
+{
+    local opts="$@"
+
+    mount -uw $opts /
+}
+
+# set root mount back to read only if !Developer
+mount_root_restore()
+{
+
+    if sh -c '. /etc/avatar.conf && echo $AVATAR_VERSION' | grep -q 'DEVELOPER$' ; then
+	mount -uw /
+    else
+	mount -ur /
+    fi
+
+}


### PR DESCRIPTION
Folks, this is the first of a few commits needed for the
norse "developer mode". 

Developer mode eases development of FreeNAS to
the point where a webdev can just point their IDE
at the FreeNAS vm and develop against it.

First of these patches is to make root rw in 
"developer mode".

Other parts to come are:
Modifications to increase image size for developer only builds.
Scripts to checkout the git repo into /data and to run the gui from /data.
Ability to selectively add packages to the system for development mode.

First we just make root read/write because otherwise it confuses and
frustrates development newbies.  In our experience it has not caused
any problems due to people mistakenly writing code that assumes
a read-write root, only faster development as people can quickly
make hacks to setup dev environments.

Commit message is as follows:


A few scripts unconditionally set root to read-only
after temporarily setting it read-write to tweak data.

To fix this abstract away the mount opts into functions
that look at the avatar version.  basically: if(DEVELOPER)
is set we keep the mount read-write as opposed to
unconditionally making it read-only.

Conflicts:
	nanobsd/Files/etc/ix.rc.d/ix-sercons