### PR TITLE
Code simplification, remotefs_parent variable no longer used

### DIFF
--- a/gui/tools/autorepl.py
+++ b/gui/tools/autorepl.py
@@ -173,17 +173,7 @@ for replication in replication_tasks:
     known_latest_snapshot = ''
     expected_local_snapshot = ''
 
-    localfs_split = localfs.split('/')
-
-    if len(localfs_split) > 1:
-        remotefs_final = "%s/%s" % (remotefs, "/".join(localfs_split[1:]))
-        if len(localfs_split) > 2:
-            remotefs_parent = "%s/%s" % (remotefs, "/".join(localfs_split[1:-1]))
-        else:
-            remotefs_parent = "%s/%s" % (remotefs, localfs_split[1])
-    else:
-        remotefs_final = remotefs
-        remotefs_parent = remotefs
+    remotefs_final = "%s%s%s" % (remotefs, localfs.partition('/')[1],localfs.partition('/')[2])
 
     # Test if there is work to do, if so, own them
     MNTLOCK.lock()


### PR DESCRIPTION
Code simplification also remove 'remotefs_parent' variable which is no longer used
