### PR TITLE
Disable Sendfile

### DIFF
--- a/src/freenas/usr/local/etc/nginx/nginx.conf
+++ b/src/freenas/usr/local/etc/nginx/nginx.conf
@@ -12,7 +12,7 @@ http {
     # reserve 1MB under the name 'proxied' to track uploads
     upload_progress proxied 1m;
 
-    sendfile        on;
+    sendfile        off;
     #tcp_nopush     on;
     client_max_body_size 500m;
 


### PR DESCRIPTION
Sendfile should be disabled when serving files from ZFS (which FreeNAS is completely now).

Refrence (page 13)
http://blog.vx.sk/uploads/conferences/EuroBSDcon2012/zfs-tuning-handout.pdf