### PR TITLE
Cleaned up the geli encryption methods

### DIFF
--- a/gui/storage/forms.py
+++ b/gui/storage/forms.py
@@ -958,7 +958,10 @@ class AutoImportChoiceForm(Form):
         # This makes sure do not import pools without proper key
         _notifier = notifier()
         for dev, name in notifier().geli_get_all_providers():
-            _notifier.geli_detach(dev)
+            try:
+                _notifier.geli_detach(dev)
+            except Exception as ee:
+                log.warn(str(ee))
 
 
 class AutoImportDecryptForm(Form):
@@ -1012,11 +1015,13 @@ class AutoImportDecryptForm(Form):
         _notifier = notifier()
         failed = []
         for disk in disks:
-            if not _notifier.geli_attach_single(
-                disk,
-                keyfile,
-                passphrase=passphrase
-            ):
+            try:
+                _notifier.geli_attach_single(
+                    disk,
+                    keyfile,
+                    passphrase=passphrase
+                )
+            except:
                 failed.append(disk)
         if failed:
             self._errors['__all__'] = self.error_class([
@@ -2393,7 +2398,7 @@ class CreatePassphraseForm(Form):
                 f.write(passphrase)
         else:
             passfile = None
-        notifier().geli_passphrase(volume, passfile, rmrecovery=True)
+        notifier().geli_passphrase(volume, passfile)
         if passfile is not None:
             os.unlink(passfile)
         volume.vol_encrypt = 2

--- a/gui/templates/storage/create_passphrase.html
+++ b/gui/templates/storage/create_passphrase.html
@@ -2,7 +2,7 @@
 {% block form %}
     <tr>
         <td colspan="2">
-        <p style="color: red">{% trans "Remember to add a new recovery key as this action invalidates the previous recovery key" %}</p>
+        <p style="color: red">{% trans "If you haven't done so already, don't forget to add a recovery key" %}</p>
         </td>
     </tr>
 {{ block.super }}


### PR DESCRIPTION
- Moved redundant geli calls into reusable methods
- Implemented feature #8325 (don't remove recovery key when setting passphrase)
- Fixed a bug where geli_detach would always return that it failed
- Don't ignore status from geli commands
- Try to provide meaningful recovery output if a re-key goes horribly wrong
- If the user clicks "destroy data" when detaching a volume, clear the geli metadata and delete the key
- Create a reusable method for creating key files
- Log to debug all geli commands, include the return status and stderr if they fail
- Give the key slots meaningful names