### PR TITLE
Fix for system.py not sending email when to = ['']

### DIFF
--- a/gui/common/system.py
+++ b/gui/common/system.py
@@ -137,7 +137,7 @@ def send_mail(subject=None,
     error = False
     errmsg = ''
     em = Email.objects.all().order_by('-id')[0]
-    if not to:
+    if not to or not to[0]:
         to = [bsdUsers.objects.get(bsdusr_username='root').bsdusr_email]
     if attachments:
         msg = MIMEMultipart()


### PR DESCRIPTION
Reassign email to the root address when:
```python
    to == '' or to[0] == ''
```

`send_mail` now works when `to` is an array of a blank/null string (`to = ['']`).

Previously, it failed when the UPS email was blank:
```
    Apr 16 15:26:03 freenas upsmon[3205]: UPS ups on battery
    Apr 16 15:26:08 freenas freenas[3691]: Traceback (most recent call last):
    Apr 16 15:26:08 freenas freenas[3691]:   File "/usr/local/www/freenasUI/common/system.py", line 205, in send_mail
    Apr 16 15:26:08 freenas freenas[3691]:     server.sendmail(em.em_fromemail, to, msg)
    Apr 16 15:26:08 freenas freenas[3691]:   File "/usr/local/lib/python2.7/smtplib.py", line 735, in sendmail
    Apr 16 15:26:08 freenas freenas[3691]:     raise SMTPRecipientsRefused(senderrs)
    Apr 16 15:26:08 freenas freenas[3691]: SMTPRecipientsRefused: {'': (555, '5.5.2 Syntax error. 15 - gsmtp')}
```