### PR TITLE
Fix for system.py not sending email when to = ['']

### DIFF
--- a/gui/common/system.py
+++ b/gui/common/system.py
@@ -139,7 +139,7 @@ def send_mail(subject=None,
     error = False
     errmsg = ''
     em = Email.objects.all().order_by('-id')[0]
-    if not to:
+    if not to or not to[0]:
         to = [bsdUsers.objects.get(bsdusr_username='root').bsdusr_email]
     if attachments:
         msg = MIMEMultipart()


### PR DESCRIPTION
Reassign email to the root address when:
```python
    to == '' or to[0] == ''
```

`send_mail` now works when `to` is an array of a blank/null string (`to = ['']`).

Previously, it failed when the UPS email was blank.
(See https://github.com/freenas/freenas/compare/master...jstephanoff:patch-1)