### PR TITLE
Make etc/find_alias_for_smtplib.py default to root email

### DIFF
--- a/src/freenas/etc/find_alias_for_smtplib.py
+++ b/src/freenas/etc/find_alias_for_smtplib.py
@@ -39,6 +39,9 @@ def do_sendmail(msg, to_addrs=None, parse_recipients=False):
         # Strip away the comma based delimiters and whitespace.
         to_addrs = map(str.strip, em.get('To').split(','))
 
+    if not to_addrs or not to_addrs[0]:
+        to_addrs = ['root']
+
     if to_addrs:
         aliases = get_aliases()
         to_addrs_repl = []


### PR DESCRIPTION
 - /etc/mail/mailer.conf uses this for `sendmail` and `send-mail`
 - services can save a blank email address, and some use this file for email
 - `to_addrs = map(str.strip, em.get('To').split(','))` could  == `['']`
 - this should default to the root email address, and rewrite the message headers
 - this prevents `send_mail` from receiving `to = ['']` (see `freenasUI.common.system`)