### PR TITLE
Default to root email (if `to` is blank)

### DIFF
--- a/src/freenas/etc/find_alias_for_smtplib.py
+++ b/src/freenas/etc/find_alias_for_smtplib.py
@@ -39,6 +39,9 @@ def do_sendmail(msg, to_addrs=None, parse_recipients=False):
         # Strip away the comma based delimiters and whitespace.
         to_addrs = map(str.strip, em.get('To').split(','))
 
+    if not to_addrs or not to_addrs[0]:
+        to_addrs = ['root']
+
     if to_addrs:
         aliases = get_aliases()
         to_addrs_repl = []


### PR DESCRIPTION
 - `sendmail` maps here (/etc/mail/mailer.conf)
 - `to_addrs` could be blank (Services - UPS Settings)
 - if blank, default to root (before `send_mail` in `freenasUI.common.system`)

reference https://github.com/jstephanoff/freenas/commit/2824fc091fbce3fb4bed2a89b75219e1cf26102f