### PR TITLE
Update ssl.py

### DIFF
--- a/gui/common/ssl.py
+++ b/gui/common/ssl.py
@@ -62,7 +62,7 @@ def create_self_signed_CA(cert_info):
     cert.set_pubkey(key)
     cert.add_extensions([
         crypto.X509Extension("basicConstraints", True,
-                             "CA:TRUE, pathlen:0"),
+                             "CA:TRUE"),
         crypto.X509Extension("keyUsage", True,
                              "keyCertSign, cRLSign"),
         crypto.X509Extension("subjectKeyIdentifier", False, "hash",


### PR DESCRIPTION
pathlen:0 is optional parameter (https://www.openssl.org/docs/apps/x509v3_config.html). See http://blogs.technet.com/b/pki/archive/2014/03/05/constraints-what-they-are-and-how-they-re-used-1.aspx for best practices regarding pathlen.

Should fix issues people are still reporting with #6864 (https://bugs.freenas.org/issues/6864) - It did for me.