### PR TITLE
Fix userguide build warnings

### DIFF
--- a/docs/userguide/freenas_cli.rst
+++ b/docs/userguide/freenas_cli.rst
@@ -409,7 +409,7 @@ FreeNAS® provides two command line scripts which an be manually run from Shell:
 The advantage of these scripts is that they can be used to provide real time (right now) information, whereas the current GUI reporting mechanism is designed
 to only provide graphs charted over time.
 
-This `forum post <https://forums.freenas.org/index.php?threads/benchmarking-zfs.7928/>`_
+This `forum post <https://forums.freenas.org/index.php?threads/benchmarking-zfs.7928/>`__
 demonstrates some examples of using these scripts with hints on how to interpret the results.
 
 To view the help for arcstat.py::
@@ -909,7 +909,7 @@ If you add some disks to the array and they are not showing up in the GUI, try r
 Use the drives to create units and export them to the operating system. When finished, run :command:`camcontrol rescan all` and they should now be available
 in the FreeNAS® GUI.
 
-This `forum post <https://forums.freenas.org/index.php?threads/3ware-drive-monitoring.13835/>`_
+This `forum post <https://forums.freenas.org/index.php?threads/3ware-drive-monitoring.13835/>`__
 contains a handy wrapper script that will notify you of errors.
 
 .. index:: MegaCli

--- a/docs/userguide/freenas_install.rst
+++ b/docs/userguide/freenas_install.rst
@@ -519,7 +519,7 @@ This section demonstrates how to create and access a virtual machine within the 
 VirtualBox
 ~~~~~~~~~~
 
-`VirtualBox <https://www.virtualbox.org/>`_ is an open source virtualization program originally created by Sun Microsystems. VirtualBox runs on Windows, BSD,
+`VirtualBox <https://www.virtualbox.org/>`__ is an open source virtualization program originally created by Sun Microsystems. VirtualBox runs on Windows, BSD,
 Linux, Macintosh, and OpenSolaris. It can be configured to use a downloaded FreeNAS® :file:`.iso` file, and makes a good testing environment for practicing
 configurations or learning how to use the features provided by FreeNAS®.
 

--- a/docs/userguide/freenas_intro.rst
+++ b/docs/userguide/freenas_intro.rst
@@ -126,13 +126,11 @@ Since FreeNAS® |version| is based on FreeBSD 10.2, it supports the same hardwar
 .. note:: FreeNAS® boots from a GPT partition. This means that the system BIOS must be able to boot using either the legacy BIOS firmware interface or EFI.
 
 Actual hardware requirements will vary depending upon what you are using your FreeNAS® system for. This section provides some guidelines to get you started.
-You can also skim through the
-`FreeNAS® Hardware Forum <https://forums.freenas.org/index.php?forums/hardware.18/>`_ for performance tips from other FreeNAS® users or to post questions
-regarding the hardware best suited to meet your requirements. This
-`forum post <https://forums.freenas.org/index.php?threads/hardware-recommendations-read-this-first.23069/>`_
-provides some specific recommendations if you are planning on purchasing hardware. Refer to
-`Building, Burn-In, and Testing your FreeNAS system <https://forums.freenas.org/index.php?threads/building-burn-in-and-testing-your-freenas-system.17750/>`_ for
-detailed instructions on how to test new hardware.
+You can also skim through the `FreeNAS® Hardware Forum <https://forums.freenas.org/index.php?forums/hardware.18/>`_ for performance tips from other FreeNAS®
+users or to post questions regarding the hardware best suited to meet your requirements. This `forum post
+<https://forums.freenas.org/index.php?threads/hardware-recommendations-read-this-first.23069/>`__ provides some specific recommendations if you are planning on
+purchasing hardware. Refer to `Building, Burn-In, and Testing your FreeNAS system
+<https://forums.freenas.org/index.php?threads/building-burn-in-and-testing-your-freenas-system.17750/>`_ for detailed instructions on how to test new hardware.
 
 .. _RAM:
 
@@ -211,7 +209,7 @@ If you need reliable disk alerting and immediate reporting of a failed drive, us
 MegaRAID controller or a 3Ware twa-compatible controller.
 
 Suggestions for testing disks before adding them to a RAID array can be found in this
-`forum post <https://forums.freenas.org/index.php?threads/checking-new-hdds-in-raid.12082/>`_.
+`forum post <https://forums.freenas.org/index.php?threads/checking-new-hdds-in-raid.12082/>`__.
 
 `This article <http://technutz.com/purpose-built-nas-hard-drives/>`_ provides a good overview of hard drives which are well suited for a NAS.
 

--- a/docs/userguide/freenas_jails.rst
+++ b/docs/userguide/freenas_jails.rst
@@ -22,7 +22,7 @@ Beginning with FreeNAS® 9.3, two types of jails are supported:
 
 #. A Virtualbox template is also provided. This template will install an instance of
    `phpVirtualBox <http://sourceforge.net/projects/phpvirtualbox/>`_, which provides a web-based front-end to
-   `VirtualBox <https://www.virtualbox.org/>`_ This can then be used to install any operating system and to use the software management tools provided by
+   `VirtualBox <https://www.virtualbox.org/>`__ This can then be used to install any operating system and to use the software management tools provided by
    that operating system.
 
 It is important to understand that any users, groups, installed software, and configurations within a jail are isolated from both the FreeNAS® operating

--- a/docs/userguide/freenas_sharing.rst
+++ b/docs/userguide/freenas_sharing.rst
@@ -728,7 +728,7 @@ Note the following regarding some of the "Advanced Mode" settings:
   Unchecking this option provides limited security and is not a substitute for proper permissions and password control.
 
 * If you wish some files on a shared volume to be hidden and inaccessible to users, put a *veto files=* line in the "Auxiliary Parameters" field. The syntax for
-  the "veto files" option and some examples can be found `here <http://www.sloop.net/smb.conf.html>`_.
+  the "veto files" option and some examples can be found `here <http://www.sloop.net/smb.conf.html>`__.
   
 To configure support for OS/2 clients, add this line to "Auxiliary Parameters"::
 
@@ -1504,10 +1504,10 @@ Connecting to iSCSI
 
 In order to access the iSCSI target, clients will need to use iSCSI initiator software.
 
-An iSCSI Initiator client is pre-installed with Windows 7. A detailed how-to for this client can be found
-`here <http://www.windowsnetworking.com/articles-tutorials/windows-7/Connecting-Windows-7-iSCSI-SAN.html>`_. A client for Windows 2000, XP, and 2003 can be found
-`here <http://www.microsoft.com/en-us/download/details.aspx?id=18986>`_. This `how-to <http://blog.pluralsight.com/freenas-8-iscsi-target-windows-7>`_
-shows how to create an iSCSI target for a Windows 7 system.
+An iSCSI Initiator client is pre-installed with Windows 7. A detailed how-to for this client can be found `here
+<http://www.windowsnetworking.com/articles-tutorials/windows-7/Connecting-Windows-7-iSCSI-SAN.html>`__. A client for Windows 2000, XP, and 2003 can be found
+`here <http://www.microsoft.com/en-us/download/details.aspx?id=18986>`__. This `how-to <http://blog.pluralsight.com/freenas-8-iscsi-target-windows-7>`_ shows
+how to create an iSCSI target for a Windows 7 system.
 
 Mac OS X does not include an initiator.
 `globalSAN <http://www.studionetworksolutions.com/globalsan-iscsi-initiator/>`_

--- a/docs/userguide/freenas_storage.rst
+++ b/docs/userguide/freenas_storage.rst
@@ -146,21 +146,19 @@ FreeNAS® system:
 
 .. warning:: the per-drive GELI master keys are not backed up along with the user keys. If a bit error occurs in the last sector of an encrypted disk, this
    may mean the data on that disk is completely lost. Until this issue is resolved, it is important to read
-   `this forum post <https://forums.freenas.org/index.php?threads/please-validate-my-backup-plan-rotating-offsite-backup-disks-from-single-freenas-primary-storage.17316/#post-93073>`_
+   `this forum post <https://forums.freenas.org/index.php?threads/please-validate-my-backup-plan-rotating-offsite-backup-disks-from-single-freenas-primary-storage.17316/#post-93073>`__
    which explains how to back up your master keys manually.
-   `This forum post <https://forums.freenas.org/index.php?threads/recover-encryption-key.16593/#post-85497>`_
+   `This forum post <https://forums.freenas.org/index.php?threads/recover-encryption-key.16593/#post-85497>`__
    gives an in-depth explanation of how the various key types are used by GELI.
    To track future progress on this issue, refer to `this bug report <https://bugs.freenas.org/issues/2375>`_.
 
 * The encryption key is per ZFS volume (pool). If you create multiple pools, each pool has its own encryption key.
 
-* If the system has a lot of disks, there will be a performance hit if the CPU does not support
-  `AES-NI <https://en.wikipedia.org/wiki/AES-NI#Supporting_CPUs>`_
+* If the system has a lot of disks, there will be a performance hit if the CPU does not support `AES-NI <https://en.wikipedia.org/wiki/AES-NI#Supporting_CPUs>`_
   or if no crypto hardware is installed. Without hardware acceleration, there will be about a 20% performance hit for a single disk. Performance degradation
-  will continue to increase with more disks. As data is written, it is automatically encrypted and as data is read, it is decrypted on the fly. If the
-  processor does support the AES-NI instruction set, there should be very little, if any, degradation in performance when using encryption. This
-  `forum post <https://forums.freenas.org/index.php?threads/encryption-performance-benchmarks.12157/>`_
-  compares the performance of various CPUs.
+  will continue to increase with more disks. As data is written, it is automatically encrypted and as data is read, it is decrypted on the fly. If the processor
+  does support the AES-NI instruction set, there should be very little, if any, degradation in performance when using encryption. This `forum post
+  <https://forums.freenas.org/index.php?threads/encryption-performance-benchmarks.12157/>`__ compares the performance of various CPUs.
 
 * Data in the ARC cache and the contents of RAM are unencrypted.
 
@@ -625,7 +623,7 @@ are described in Table 8.1f.
 |                                                        |                |                                                                                                                          |
 +--------------------------------------------------------+----------------+--------------------------------------------------------------------------------------------------------------------------+
 | HDD Standby                                            | drop-down menu | indicates the time of inactivity (in minutes) before the drive enters standby mode in order to conserve energy; this     |
-|                                                        |                | `forum post <https://forums.freenas.org/index.php?threads/how-to-find-out-if-a-drive-is-spinning-down-properly.2068/>`_  |
+|                                                        |                | `forum post <https://forums.freenas.org/index.php?threads/how-to-find-out-if-a-drive-is-spinning-down-properly.2068/>`__ |
 |                                                        |                | demonstrates how to determine if a drive has spun down                                                                   |
 |                                                        |                |                                                                                                                          |
 +--------------------------------------------------------+----------------+--------------------------------------------------------------------------------------------------------------------------+

--- a/docs/userguide/freenas_support.rst
+++ b/docs/userguide/freenas_support.rst
@@ -70,7 +70,7 @@ The following categories are available under **Help and Support:**
 * `Bug Reporting <https://forums.freenas.org/index.php?forums/bug-reporting.7/>`_: use this forum if you think you have found a bug in FreeNAS® and want to
   discuss it before creating a support ticket.
 
-* `Hardware <https://forums.freenas.org/index.php?forums/hardware.18/>`_: for the discussion of hardware and tips for getting the most out of your hardware.
+* `Hardware <https://forums.freenas.org/index.php?forums/hardware.18/>`__: for the discussion of hardware and tips for getting the most out of your hardware.
 
 * `User Authentication <https://forums.freenas.org/index.php?forums/user-authentication.19/>`_: LDAP and Active Directory.
 
@@ -81,7 +81,7 @@ The following categories are available under **Help and Support:**
 * `Networking <https://forums.freenas.org/index.php?forums/networking.22/>`_: networking hardware, performance, link aggregation, VLANs, DDNS, FTP, SNMP, SSH,
   and TFTP.
 
-* `Installation <https://forums.freenas.org/index.php?forums/installation.32/>`_: installing help or advice before performing the installation.
+* `Installation <https://forums.freenas.org/index.php?forums/installation.32/>`__: installing help or advice before performing the installation.
 
 * `Plugins <https://forums.freenas.org/index.php?forums/plugins.34/>`_: provides a discussion area for creating and troubleshooting PBIs.
 
@@ -100,11 +100,11 @@ The following categories are available under **How-To Guides:**
 
 * `Hacking <https://forums.freenas.org/index.php?forums/hacking.14/>`_: undocumented tricks for getting the most out of your FreeNAS® system.
 
-* `Installation <https://forums.freenas.org/index.php?forums/installation.15/>`_: specific installation scenarios (hardware and/or software).
+* `Installation <https://forums.freenas.org/index.php?forums/installation.15/>`__: specific installation scenarios (hardware and/or software).
 
 * `Configuration <https://forums.freenas.org/index.php?forums/configuration.16/>`_: specific configuration scenarios (e.g. software or client configuration).
 
-* `Hardware <https://forums.freenas.org/index.php?forums/hardware.17/>`_: instructions for setting up specific hardware.
+* `Hardware <https://forums.freenas.org/index.php?forums/hardware.17/>`__: instructions for setting up specific hardware.
 
 * `Useful Scripts <https://forums.freenas.org/index.php?forums/useful-scripts.47/>`_: user-contributed scripts.
 

--- a/docs/userguide/freenas_system.rst
+++ b/docs/userguide/freenas_system.rst
@@ -677,10 +677,10 @@ needed in a network with outbound firewall restrictions.
 The "Verify Install" button will go through the operating system files in the current installation, looking for any inconsistencies. When finished, a pop-up
 menu will list any files with checksum mismatches or permission errors.
 
-To see if any updates are available, make sure the desired train is selected and click the "Check Now" button. If there are any updates available, they will
-be listed. In the example shown in Figure 5.8b, the numbers which begin with a *#* represent the bug report number from
-`bugs.freenas.org <http://bugs.freenas.org>`_. Numbers which do not begin with a *#* represent a git commit. Click the "ChangeLog" hyperlink to open the log
-of changes in your web browser. Click the "ReleaseNotes" hyperlink to open the Release Notes in your web browser.
+To see if any updates are available, make sure the desired train is selected and click the "Check Now" button. If there are any updates available, they will be
+listed. In the example shown in Figure 5.8b, the numbers which begin with a *#* represent the bug report number from `bugs.freenas.org
+<https://bugs.freenas.org>`__. Numbers which do not begin with a *#* represent a git commit. Click the "ChangeLog" hyperlink to open the log of changes in your
+web browser. Click the "ReleaseNotes" hyperlink to open the Release Notes in your web browser.
 
 **Figure 5.8b: Reviewing Updates**
 
@@ -945,11 +945,11 @@ The FreeNAS® "Support" tab, shown in Figure 5.11a, provides a built-in ticketin
 
 .. image:: images/support1a.png
 
-This screen provides a built-in interface to the FreeNAS® bug tracker located at `bugs.freenas.org <https://bugs.freenas.org>`_. If you have not yet used the
+This screen provides a built-in interface to the FreeNAS® bug tracker located at `bugs.freenas.org <https://bugs.freenas.org>`__. If you have not yet used the
 FreeNAS® bug tracker, you must first go to that website, click the "Register" link, fill out the form, and reply to the register email. You will then have a
 username and password which can be used to create bug reports and receive notifications as your reports are actioned.
 
-Before creating a bug report or feature request, ensure that an existing report does not already exist at `bugs.freenas.org <https://bugs.freenas.org>`_. If
+Before creating a bug report or feature request, ensure that an existing report does not already exist at `bugs.freenas.org <https://bugs.freenas.org>`__. If
 you find a similar issue that is not yet marked as "closed" or "resolved", add a comment to that issue if you have new information to provide that can assist
 in resolving the issue. If you find a similar issue that is marked as "closed" or "resolved", you can create a new issue and refer to the earlier issue
 number.
@@ -958,7 +958,7 @@ number.
 
 To generate a report using the built-in "Support" screen, complete the following fields:
 
-* **Username:** input the login name you created when registering at `bugs.freenas.org <https://bugs.freenas.org>`_.
+* **Username:** input the login name you created when registering at `bugs.freenas.org <https://bugs.freenas.org>`__.
 
 * **Password:** input the password associated with the registered login name.
 
@@ -978,5 +978,5 @@ To generate a report using the built-in "Support" screen, complete the following
 * **Attachments:** this is the only optional field. It is useful for including configuration files or screenshots of any errors or tracebacks.
 
 Once you have finished completing the fields, click the "Submit" button to automatically generate and upload the report to
-`bugs.freenas.org <https://bugs.freenas.org>`_. A pop-up menu will provide a clickable URL so that you can view the status of or add additional information to
+`bugs.freenas.org <https://bugs.freenas.org>`__. A pop-up menu will provide a clickable URL so that you can view the status of or add additional information to
 the report.


### PR DESCRIPTION
Adding a second underscore to the end of a hyperlink makes it an
anonymous hyperlink reference. Otherwise Sphinx will keep track of the
hyperlink text and complain if more than one link has the same text.