### PR TITLE
Hide syncthing files by default in SMB shares

### DIFF
--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -1047,7 +1047,7 @@ def generate_smb4_shares(smb4_shares):
             confset2(smb4_shares, "comment = %s",
                      share.cifs_comment.encode('utf8'))
         confset1(smb4_shares, "printable = no")
-        confset1(smb4_shares, "veto files = /.snapshot/.windows/.mac/.zfs/")
+        confset1(smb4_shares, "veto files = /.snapshot/.windows/.mac/.zfs/.stfolder/.stignore")
         confset2(smb4_shares, "writeable = %s",
                  "no" if share.cifs_ro else "yes")
         confset2(smb4_shares, "browseable = %s",


### PR DESCRIPTION
If these files are not hidden a user can delete them, or edit them.