### PR TITLE
fix secrets.tdb being overwritten starting from commit d914194f

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-pre-samba
+++ b/src/freenas/etc/ix.rc.d/ix-pre-samba
@@ -61,17 +61,6 @@ generate_smb_config()
 	/usr/local/libexec/nas/generate_smb4_conf.py
 }
 
-backup_secrets_tdb()
-{
-	cp /var/db/samba4/private/secrets.tdb /root/secrets.tdb
-}
-
-
-restore_secrets_tdb()
-{
-	mv /root/secrets.tdb /var/db/samba4/private/secrets.tdb
-}
-
 samba_pre_init()
 {
 	local sambaSID="$(get_sambaSID)"
@@ -82,9 +71,7 @@ samba_pre_init()
 	fi
 
 	set_sambaSID
-	backup_secrets_tdb
 	generate_smb_config
-	restore_secrets_tdb
 }
 
 name="ix-pre-samba"


### PR DESCRIPTION
generate_smb4_conf.py set the ldap password [here](https://github.com/freenas/freenas/blob/396ebf89462994291321419a149c0e9e1d3367bc/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py#L673-L676), which will modify secrets.tdb located at `/var/db/samba4/private/secrets.tdb`. Backup and restore makes the modification invalid. 

Is this procedure related to the bug that mentioned in the commit message in d914194f?

```bash
generate_smb_config()
{
	/usr/local/libexec/nas/generate_smb4_conf.py
}

backup_secrets_tdb()
{
	cp /var/db/samba4/private/secrets.tdb /root/secrets.tdb
}

restore_secrets_tdb()
{
	mv /root/secrets.tdb /var/db/samba4/private/secrets.tdb
}

samba_pre_init()
{
    ...

	backup_secrets_tdb
	generate_smb_config
	restore_secrets_tdb
}
```

Ticket: [#12407](https://bugs.freenas.org/issues/12407)
Ticket: [#4624](https://bugs.freenas.org/issues/4624)

@jhixson74 