### PR TITLE
Lmhosts fix

### DIFF
--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -637,7 +637,7 @@ def add_nt4_conf(smb4_conf):
     nt4_workgroup = nt4.nt4_workgroup.upper()
 
     with open("/usr/local/etc/lmhosts", "w") as f:
-        f.write("%s\t%s\n" % (dc_ip, nt4_dcname.upper()))
+        f.write("%s\t%s\n" % (dc_ip, nt4.nt4_dcname.upper()))
         f.close()
 
     set_netbiosname(smb4_conf, nt4.nt4_netbiosname)

--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -637,7 +637,7 @@ def add_nt4_conf(smb4_conf):
     nt4_workgroup = nt4.nt4_workgroup.upper()
 
     with open("/usr/local/etc/lmhosts", "w") as f:
-        f.write("%s\t%s\n" % (dc_ip, nt4_workgroup.upper))
+        f.write("%s\t%s\n" % (dc_ip, nt4_dcname.upper()))
         f.close()
 
     set_netbiosname(smb4_conf, nt4.nt4_netbiosname)


### PR DESCRIPTION
Getting log entries like
```
getlmhostsent: too many columns in lmhosts file (obsolete syntax)
...
Mar 25 00:52:02 nas generate_smb4_conf.py: [common.pipesubr:71] Popen()ing: /usr/local/bin/net -d 0 getlocalsid
Mar 25 00:52:03 nas generate_smb4_conf.py: [common.pipesubr:71] Popen()ing: /sbin/sysctl -n 'kern.maxfilesperproc'
Mar 25 00:52:03 nas generate_smb4_conf.py: [common.pipesubr:71] Popen()ing: mount
Mar 25 00:52:03 nas generate_smb4_conf.py: [common.pipesubr:71] Popen()ing: mount
Mar 25 00:52:03 nas generate_smb4_conf.py: [common.pipesubr:71] Popen()ing: /usr/local/bin/net -d 0 getlocalsid
Mar 25 00:52:03 nas generate_smb4_conf.py: [common.pipesubr:71] Popen()ing: /usr/bin/getent passwd 'nas'
Mar 25 00:52:03 nas generate_smb4_conf.py: [common.pipesubr:71] Popen()ing: /usr/bin/getent passwd 'db'
Mar 25 00:52:09 nas nmbd[2894]: [2016/03/25 00:52:09.789247,  0] ../libcli/nbt/lmhosts.c:99(getlmhostsent)
Mar 25 00:52:09 nas nmbd[2894]:   getlmhostsent: too many columns in lmhosts file (obsolete syntax)
```

then looking at /usr/local/etc/lmhosts to find
```
10.0.0.2 <built-in method upper of unicode object at 0x80bc32f30>
```

so it was a minor bug in the `generate_smb4_conf.py` script.

It seems the function shouldn't be writing the `nt4_workgroup` name in the `lmhosts` file, so I've used `nt4.nt4_dcname`. However, If `dc_ip` is set to the DC name as well, it looks like the lmhosts file will still be invalid.