### PR TITLE
Add 'comments' column to zvol/dataset

### DIFF
--- a/gui/api/resources.py
+++ b/gui/api/resources.py
@@ -909,6 +909,11 @@ class VolumeResourceMixin(NestedMixin):
                     {},
                 ).get('compressratio', ('', '-'))[1]
 
+		data['comments'] = self.__zfsopts.get(
+                    child.path,
+                    {},
+                ).get('volume_entity:comments', ('', '-'))[1]
+
                 data['used'] = "%s (%s%%)" % (
                     humanize_size(data['used']),
                     data['used_pct'],
@@ -993,7 +998,7 @@ class VolumeResourceMixin(NestedMixin):
         if self.is_webclient(request):
             self.__zfsopts = notifier().zfs_get_options(
                 recursive=True,
-                props=['compression', 'compressratio'],
+                props=['compression', 'compressratio', 'volume_entity:comments'],
             )
         self._uid = Uid(100)
         return super(VolumeResourceMixin, self).dispatch_list(

--- a/gui/middleware/notifier.py
+++ b/gui/middleware/notifier.py
@@ -3874,9 +3874,9 @@ class notifier:
         item = str(item)
         value = str(value)
         if recursive:
-            zfsproc = self._pipeopen("zfs set -r '%s'='%s' '%s'" % (item, value, name))
+            zfsproc = self._pipeopen("/sbin/zfs set -r '%s'='%s' '%s'" % (item, value, name))
         else:
-            zfsproc = self._pipeopen("zfs set '%s'='%s' '%s'" % (item, value, name))
+            zfsproc = self._pipeopen("/sbin/zfs set '%s'='%s' '%s'" % (item, value, name))
         err = zfsproc.communicate()[1]
         if zfsproc.returncode == 0:
             return True, None

--- a/gui/storage/admin.py
+++ b/gui/storage/admin.py
@@ -132,6 +132,13 @@ class VolumeFAdmin(BaseFreeAdmin):
             'label': _('Status'),
             'sortable': False,
         })
+
+	columns.append({
+            'name': 'comments',
+            'label': _('Comments'),
+            'sortable': False,
+        })
+
         return columns
 
     def _action_builder(

--- a/gui/storage/forms.py
+++ b/gui/storage/forms.py
@@ -1286,6 +1286,9 @@ class ZFSDataset(Form):
     dataset_name = forms.CharField(
         max_length=128,
         label=_('Dataset Name'))
+    dataset_comments = forms.CharField(
+        max_length = 1024,
+        label = _('Comments'))
     dataset_compression = forms.ChoiceField(
         choices=choices.ZFS_CompressionChoices,
         widget=forms.Select(attrs=attrs_dict),
@@ -1530,6 +1533,7 @@ class ZVol_EditForm(Form):
 
 class ZVol_CreateForm(Form):
     zvol_name = forms.CharField(max_length=128, label=_('zvol name'))
+    zvol_comments = forms.CharField(max_length=120, label=_('Comments'))
     zvol_size = forms.CharField(
         max_length=128,
         label=_('Size for this zvol'),

--- a/gui/storage/views.py
+++ b/gui/storage/views.py
@@ -387,6 +387,7 @@ def dataset_create(request, fs):
             props['casesensitivity'] = cleaned_data.get(
                 'dataset_case_sensitivity'
             )
+	    dataset_comments = cleaned_data.get('dataset_comments')
             props['compression'] = dataset_compression.__str__()
             dataset_atime = cleaned_data.get('dataset_atime')
             props['atime'] = dataset_atime.__str__()
@@ -411,6 +412,7 @@ def dataset_create(request, fs):
             errno, errmsg = notifier().create_zfs_dataset(
                 path=str(dataset_name),
                 props=props)
+	    notifier().zfs_set_option(name = str(dataset_name),item = "volume_entity:comments",value = dataset_comments)
             if errno == 0:
                 if dataset_share_type == "unix":
                     notifier().dataset_init_unix(dataset_name)
@@ -510,6 +512,7 @@ def zvol_create(request, parent):
             zvol_name = "%s/%s" % (parent, cleaned_data.get('zvol_name'))
             zvol_compression = cleaned_data.get('zvol_compression')
             props['compression'] = str(zvol_compression)
+	    zvol_comments = cleaned_data.get('zvol_comments')
             if zvol_blocksize:
                 props['volblocksize'] = zvol_blocksize
             errno, errmsg = notifier().create_zfs_vol(
@@ -517,6 +520,7 @@ def zvol_create(request, parent):
                 size=str(zvol_size),
                 sparse=cleaned_data.get("zvol_sparse", False),
                 props=props)
+	    notifier().zfs_set_option(name = str(zvol_name),item = "volume_entity:comments",value = zvol_comments)
             if errno == 0:
                 return JsonResp(
                     request,


### PR DESCRIPTION
I have added a user-defined property 'volume_entity:comments' to zfs.
I have also added 'comments' field to the dataset/zvol forms.