### PR TITLE
Add 'comments' column to zvol/dataset

### DIFF
--- a/gui/api/resources.py
+++ b/gui/api/resources.py
@@ -915,6 +915,11 @@ class VolumeResourceMixin(NestedMixin):
                 )
                 data['avail'] = humanize_size(data['avail'])
 
+                data['comments'] = self.__zfsopts.get(
+                    child.path,
+                    {},
+                ).get('storage:comments', ('', '-'))[1]
+
             if self.is_webclient(bundle.request):
                 data['_add_zfs_volume_url'] = reverse(
                     'storage_zvol',
@@ -993,7 +998,7 @@ class VolumeResourceMixin(NestedMixin):
         if self.is_webclient(request):
             self.__zfsopts = notifier().zfs_get_options(
                 recursive=True,
-                props=['compression', 'compressratio'],
+                props=['compression', 'compressratio', 'storage:comments'],
             )
         self._uid = Uid(100)
         return super(VolumeResourceMixin, self).dispatch_list(

--- a/gui/middleware/notifier.py
+++ b/gui/middleware/notifier.py
@@ -3874,9 +3874,9 @@ class notifier:
         item = str(item)
         value = str(value)
         if recursive:
-            zfsproc = self._pipeopen("zfs set -r '%s'='%s' '%s'" % (item, value, name))
+            zfsproc = self._pipeopen("/sbin/zfs set -r '%s'='%s' '%s'" % (item, value, name))
         else:
-            zfsproc = self._pipeopen("zfs set '%s'='%s' '%s'" % (item, value, name))
+            zfsproc = self._pipeopen("/sbin/zfs set '%s'='%s' '%s'" % (item, value, name))
         err = zfsproc.communicate()[1]
         if zfsproc.returncode == 0:
             return True, None

--- a/gui/storage/admin.py
+++ b/gui/storage/admin.py
@@ -132,6 +132,12 @@ class VolumeFAdmin(BaseFreeAdmin):
             'label': _('Status'),
             'sortable': False,
         })
+
+        columns.append({
+            'name': 'comments',
+            'label': _('Comments'),
+            'sortable': False,
+        })
         return columns
 
     def _action_builder(

--- a/gui/storage/forms.py
+++ b/gui/storage/forms.py
@@ -1286,6 +1286,9 @@ class ZFSDataset(Form):
     dataset_name = forms.CharField(
         max_length=128,
         label=_('Dataset Name'))
+    dataset_comments = forms.CharField(
+        max_length = 1024,
+        label = _('Comments'))
     dataset_compression = forms.ChoiceField(
         choices=choices.ZFS_CompressionChoices,
         widget=forms.Select(attrs=attrs_dict),
@@ -1530,6 +1533,7 @@ class ZVol_EditForm(Form):
 
 class ZVol_CreateForm(Form):
     zvol_name = forms.CharField(max_length=128, label=_('zvol name'))
+    zvol_comments = forms.CharField(max_length=120, label=_('Comments'))
     zvol_size = forms.CharField(
         max_length=128,
         label=_('Size for this zvol'),

--- a/gui/storage/views.py
+++ b/gui/storage/views.py
@@ -408,9 +408,11 @@ def dataset_create(request, fs):
             recordsize = cleaned_data.get('dataset_recordsize')
             if recordsize:
                 props['recordsize'] = recordsize
+            dataset_comments = cleaned_data.get('dataset_comments')
             errno, errmsg = notifier().create_zfs_dataset(
                 path=str(dataset_name),
                 props=props)
+            notifier().zfs_set_option(name = str(dataset_name),item = "storage:comments",value = dataset_comments)
             if errno == 0:
                 if dataset_share_type == "unix":
                     notifier().dataset_init_unix(dataset_name)
@@ -505,6 +507,7 @@ def zvol_create(request, parent):
         if zvol_form.is_valid():
             props = {}
             cleaned_data = zvol_form.cleaned_data
+            zvol_comments = cleaned_data.get('zvol_comments')
             zvol_size = cleaned_data.get('zvol_size')
             zvol_blocksize = cleaned_data.get("zvol_blocksize")
             zvol_name = "%s/%s" % (parent, cleaned_data.get('zvol_name'))
@@ -517,6 +520,7 @@ def zvol_create(request, parent):
                 size=str(zvol_size),
                 sparse=cleaned_data.get("zvol_sparse", False),
                 props=props)
+            notifier().zfs_set_option(name = str(zvol_name),item = "storage:comments",value = zvol_comments)
             if errno == 0:
                 return JsonResp(
                     request,


### PR DESCRIPTION
I have added a user-defined property 'storage:comments' to zfs.
I have also added 'comments' field to the dataset/zvol forms.