### PR TITLE
Revert "Removed "Utilities" because it is no longer part of the process."

### DIFF
--- a/docs/userguide/freenas_install.rst
+++ b/docs/userguide/freenas_install.rst
@@ -113,7 +113,7 @@ When using the :command:`dd` command:
 On OS X
 ~~~~~~~
 
-Insert the USB thumb drive and go to :menuselection:`Launchpad --> Disk Utility`. Unmount any mounted partitions on the USB thumb drive. Check
+Insert the USB thumb drive and go to :menuselection:`Launchpad --> Utilities --> Disk Utility`. Unmount any mounted partitions on the USB thumb drive. Check
 that the USB thumb drive has only one partition, otherwise you will get partition table errors on boot. If needed, use Disk Utility to setup one partition on
 the USB drive; selecting "free space" when creating the partition works fine.
 


### PR DESCRIPTION
Reverts freenas/freenas#146

It's actually now called the "other folder" in Launchpad.  We could just say, "To access the Disk Utility, press Command+Space to open Spotlight Search, type Disk Utility, and click Enter." Or we can say, "Go to Launchpad ‣ Other folder ‣ Disk Utility."