### PR TITLE
Jail Security - /dev/adaX disks are readable from inside a jail

### DIFF
--- a/gui/api/resources.py
+++ b/gui/api/resources.py
@@ -920,7 +920,7 @@ class VolumeResourceMixin(NestedMixin):
                     data['used_pct'],
                 )
                 data['avail'] = humanize_size(data['avail'])
-                
+
                 data['readonly'] = self.__zfsopts.get(
                     child.path,
                     {},

--- a/gui/api/resources.py
+++ b/gui/api/resources.py
@@ -932,12 +932,12 @@ class VolumeResourceMixin(NestedMixin):
                     child.path,
                     {},
                 ).get('org.freenas:description', ('', '-'))[1]
-              
-                #Filtering out comments field for Jails
+
+                # Filtering out comments field for Jails
                 for jail in jails_list:
                     child_name = child.name.split('/')
                     length = len(child_name)
-                    if jail.jail_host == child_name[length-1] or "warden" in child_name[length-1]:
+                    if jail.jail_host == child_name[length - 1] or "warden" in child_name[length - 1]:
                         data['comments'] = '-'
 
             if self.is_webclient(bundle.request):

--- a/gui/api/resources.py
+++ b/gui/api/resources.py
@@ -926,6 +926,11 @@ class VolumeResourceMixin(NestedMixin):
                     {},
                 ).get('readonly', ('', '-'))[1]
 
+                data['comments'] = self.__zfsopts.get(
+                    child.path,
+                    {},
+                ).get('org.freenas:description', ('', '-'))[1]
+
             if self.is_webclient(bundle.request):
                 data['_add_zfs_volume_url'] = reverse(
                     'storage_zvol',
@@ -1004,7 +1009,7 @@ class VolumeResourceMixin(NestedMixin):
         if self.is_webclient(request):
             self.__zfsopts = notifier().zfs_get_options(
                 recursive=True,
-                props=['compression', 'compressratio', 'readonly'],
+                props=['compression', 'compressratio', 'readonly', 'org.freenas:description'],
             )
         self._uid = Uid(100)
         return super(VolumeResourceMixin, self).dispatch_list(

--- a/gui/api/resources.py
+++ b/gui/api/resources.py
@@ -62,6 +62,7 @@ from freenasUI.freeadmin.options import FreeBaseInlineFormSet
 from freenasUI.jails.forms import (
     JailCreateForm, JailsEditForm, JailTemplateCreateForm, JailTemplateEditForm
 )
+from freenasUI.jails.models import Jails
 from freenasUI.jails.models import JailTemplate
 from freenasUI.middleware import zfs
 from freenasUI.middleware.exceptions import MiddlewareError
@@ -889,6 +890,7 @@ class VolumeResourceMixin(NestedMixin):
     def _get_children(self, bundle, vol, children, uid):
         rv = []
         attr_fields = ('avail', 'used', 'used_pct')
+        jails_list = Jails.objects.all()
         for path, child in children.items():
             if child.name.startswith('.'):
                 continue
@@ -930,6 +932,13 @@ class VolumeResourceMixin(NestedMixin):
                     child.path,
                     {},
                 ).get('org.freenas:description', ('', '-'))[1]
+              
+                #Filtering out comments field for Jails
+                for jail in jails_list:
+                    child_name = child.name.split('/')
+                    length = len(child_name)
+                    if jail.jail_host == child_name[length-1] or "warden" in child_name[length-1]:
+                        data['comments'] = '-'
 
             if self.is_webclient(bundle.request):
                 data['_add_zfs_volume_url'] = reverse(

--- a/gui/middleware/notifier.py
+++ b/gui/middleware/notifier.py
@@ -3861,7 +3861,8 @@ class notifier:
             if (not data[1] in noinherit_fields) and (
                 data[3] == 'default' or data[3].startswith('inherited')
             ):
-                dval[data[1]] = (data[2], "inherit (%s)" % data[2], 'inherit')
+                if data[1] != 'org.freenas:description':
+                    dval[data[1]] = (data[2], "inherit (%s)" % data[2], 'inherit')
             else:
                 dval[data[1]] = (data[2], data[2], data[3])
         return retval

--- a/gui/middleware/notifier.py
+++ b/gui/middleware/notifier.py
@@ -3879,9 +3879,9 @@ class notifier:
         item = str(item)
         value = str(value)
         if recursive:
-            zfsproc = self._pipeopen("zfs set -r '%s'='%s' '%s'" % (item, value, name))
+            zfsproc = self._pipeopen("/sbin/zfs set -r '%s'='%s' '%s'" % (item, value, name))
         else:
-            zfsproc = self._pipeopen("zfs set '%s'='%s' '%s'" % (item, value, name))
+            zfsproc = self._pipeopen("/sbin/zfs set '%s'='%s' '%s'" % (item, value, name))
         err = zfsproc.communicate()[1]
         if zfsproc.returncode == 0:
             return True, None

--- a/gui/storage/admin.py
+++ b/gui/storage/admin.py
@@ -138,6 +138,12 @@ class VolumeFAdmin(BaseFreeAdmin):
             'label': _('Readonly'),
             'sortable': False,
         })
+
+        columns.append({
+            'name': 'comments',
+            'label': _('Comments'),
+            'sortable': False,
+        })
         return columns
 
     def _action_builder(

--- a/gui/storage/forms.py
+++ b/gui/storage/forms.py
@@ -1288,7 +1288,8 @@ class ZFSDataset(Form):
         label=_('Dataset Name'))
     dataset_comments = forms.CharField(
         max_length=1024,
-        label=_('Comments'))
+        label=_('Comments'),
+        required=False)
     dataset_compression = forms.ChoiceField(
         choices=choices.ZFS_CompressionChoices,
         widget=forms.Select(attrs=attrs_dict),
@@ -1463,6 +1464,10 @@ class ZFSDataset(Form):
 
 
 class ZVol_EditForm(Form):
+    volume_comments = forms.CharField(
+        max_length=128,
+        label=_('Comments'),
+        required=False)
     volume_compression = forms.ChoiceField(
         choices=choices.ZFS_CompressionChoices,
         widget=forms.Select(attrs=attrs_dict),
@@ -1532,7 +1537,7 @@ class ZVol_EditForm(Form):
 
 
 class ZVol_CreateForm(Form):
-    zvol_name = forms.CharField(max_length=128, label=_('zvol name'))
+    zvol_name = forms.CharField(max_length=128, label=_('zvol name'), required=False)
     zvol_comments = forms.CharField(max_length=120, label=_('Comments'))
     zvol_size = forms.CharField(
         max_length=128,

--- a/gui/storage/forms.py
+++ b/gui/storage/forms.py
@@ -1287,8 +1287,8 @@ class ZFSDataset(Form):
         max_length=128,
         label=_('Dataset Name'))
     dataset_comments = forms.CharField(
-        max_length = 1024,
-        label = _('Comments'))
+        max_length=1024,
+        label=_('Comments'))
     dataset_compression = forms.ChoiceField(
         choices=choices.ZFS_CompressionChoices,
         widget=forms.Select(attrs=attrs_dict),

--- a/gui/storage/forms.py
+++ b/gui/storage/forms.py
@@ -1286,6 +1286,9 @@ class ZFSDataset(Form):
     dataset_name = forms.CharField(
         max_length=128,
         label=_('Dataset Name'))
+    dataset_comments = forms.CharField(
+        max_length = 1024,
+        label = _('Comments'))
     dataset_compression = forms.ChoiceField(
         choices=choices.ZFS_CompressionChoices,
         widget=forms.Select(attrs=attrs_dict),
@@ -1530,6 +1533,7 @@ class ZVol_EditForm(Form):
 
 class ZVol_CreateForm(Form):
     zvol_name = forms.CharField(max_length=128, label=_('zvol name'))
+    zvol_comments = forms.CharField(max_length=120, label=_('Comments'))
     zvol_size = forms.CharField(
         max_length=128,
         label=_('Size for this zvol'),

--- a/gui/storage/views.py
+++ b/gui/storage/views.py
@@ -412,7 +412,7 @@ def dataset_create(request, fs):
             errno, errmsg = notifier().create_zfs_dataset(
                 path=str(dataset_name),
                 props=props)
-            notifier().zfs_set_option(name = str(dataset_name),item = "org.freenas:description",value = dataset_comments)
+            notifier().zfs_set_option(name=str(dataset_name),item="org.freenas:description",value=dataset_comments)
             if errno == 0:
                 if dataset_share_type == "unix":
                     notifier().dataset_init_unix(dataset_name)
@@ -520,7 +520,7 @@ def zvol_create(request, parent):
                 size=str(zvol_size),
                 sparse=cleaned_data.get("zvol_sparse", False),
                 props=props)
-            notifier().zfs_set_option(name = str(zvol_name),item = "org.freenas:description",value = zvol_comments)
+            notifier().zfs_set_option(name=str(zvol_name),item="org.freenas:description",value=zvol_comments)
             if errno == 0:
                 return JsonResp(
                     request,

--- a/gui/storage/views.py
+++ b/gui/storage/views.py
@@ -408,9 +408,11 @@ def dataset_create(request, fs):
             recordsize = cleaned_data.get('dataset_recordsize')
             if recordsize:
                 props['recordsize'] = recordsize
+            dataset_comments = cleaned_data.get('dataset_comments')
             errno, errmsg = notifier().create_zfs_dataset(
                 path=str(dataset_name),
                 props=props)
+            notifier().zfs_set_option(name = str(dataset_name),item = "org.freenas:description",value = dataset_comments)
             if errno == 0:
                 if dataset_share_type == "unix":
                     notifier().dataset_init_unix(dataset_name)
@@ -505,6 +507,7 @@ def zvol_create(request, parent):
         if zvol_form.is_valid():
             props = {}
             cleaned_data = zvol_form.cleaned_data
+            zvol_comments = cleaned_data.get('zvol_comments')
             zvol_size = cleaned_data.get('zvol_size')
             zvol_blocksize = cleaned_data.get("zvol_blocksize")
             zvol_name = "%s/%s" % (parent, cleaned_data.get('zvol_name'))
@@ -517,6 +520,7 @@ def zvol_create(request, parent):
                 size=str(zvol_size),
                 sparse=cleaned_data.get("zvol_sparse", False),
                 props=props)
+            notifier().zfs_set_option(name = str(zvol_name),item = "org.freenas:description",value = zvol_comments)
             if errno == 0:
                 return JsonResp(
                     request,

--- a/gui/storage/views.py
+++ b/gui/storage/views.py
@@ -451,6 +451,7 @@ def dataset_edit(request, dataset_name):
             errors = {}
 
             for attr in (
+                'org.freenas:description',
                 'compression',
                 'atime',
                 'dedup',
@@ -460,7 +461,10 @@ def dataset_edit(request, dataset_name):
                 'refquota',
                 'share_type'
             ):
-                formfield = 'dataset_%s' % attr
+                if attr == 'org.freenas:description':
+                    formfield = 'dataset_comments'
+                else:
+                    formfield = 'dataset_%s' % attr
                 val = dataset_form.cleaned_data[formfield]
 
                 if val == "inherit":
@@ -572,11 +576,15 @@ def zvol_edit(request, name):
             _n = notifier()
             error, errors = False, {}
             for attr in (
+                'org.freenas:description',
                 'compression',
                 'dedup',
                 'volsize',
             ):
-                formfield = 'volume_%s' % attr
+                if attr == 'org.freenas:description':
+                    formfield = 'volume_comments'
+                else:
+                    formfield = 'volume_%s' % attr
                 if form.cleaned_data[formfield] == "inherit":
                     success, err = _n.zfs_inherit_option(
                         name,

--- a/gui/storage/views.py
+++ b/gui/storage/views.py
@@ -412,7 +412,7 @@ def dataset_create(request, fs):
             errno, errmsg = notifier().create_zfs_dataset(
                 path=str(dataset_name),
                 props=props)
-            notifier().zfs_set_option(name=str(dataset_name),item="org.freenas:description",value=dataset_comments)
+            notifier().zfs_set_option(name=str(dataset_name), item="org.freenas:description", value=dataset_comments)
             if errno == 0:
                 if dataset_share_type == "unix":
                     notifier().dataset_init_unix(dataset_name)
@@ -520,7 +520,7 @@ def zvol_create(request, parent):
                 size=str(zvol_size),
                 sparse=cleaned_data.get("zvol_sparse", False),
                 props=props)
-            notifier().zfs_set_option(name=str(zvol_name),item="org.freenas:description",value=zvol_comments)
+            notifier().zfs_set_option(name=str(zvol_name), item="org.freenas:description", value=zvol_comments)
             if errno == 0:
                 return JsonResp(
                     request,

--- a/src/freenas/etc/rc.freenas
+++ b/src/freenas/etc/rc.freenas
@@ -703,6 +703,8 @@ jail_post_start()
 	ipv6=$(jail_get_ipv6 "${jail}")
 	jid="$(jail_get_jid "${jail}")"
 
+        mount -t devfs | grep -v '^devfs on /dev ' | awk '{print $3;}' | xargs -n 1 -J % devfs -m % rule -s 4 applyset
+
 	if [ -n "${ipv4}" ]
 	then
 		jail_get_ip_and_netmask "${ipv4}"


### PR DESCRIPTION
I have added a command to set the devfs ruleset over all devfs mountpoints/jails except the host one; so that, /dev/adax disks are no longer readable from inside a jail.