### PR TITLE
Fix to prevent duplicate MAC addresses for jails

### DIFF
--- a/gui/jails/forms.py
+++ b/gui/jails/forms.py
@@ -417,21 +417,20 @@ class JailCreateForm(ModelForm):
                     jail_flags |= WARDEN_SET_FLAGS_FLAGS
                     jail_set_args['jflags'] = val
 
-            else:
-                if key == 'jail_mac':
+            elif key == 'jail_mac':
+                jail_list = Jails.objects.all()
+                while True:
                     duplicate_mac = 0
-                    while True:
-                        mac_address = generate_randomMAC()
-                        jail_list = Jails.objects.all()
-                        for jail in jail_list:
-                            if jail.jail_mac == mac_address:
-                                duplicate_mac = 1
-                                break
-                        if duplicate_mac != 1:
+                    mac_address = generate_randomMAC()
+                    for jail in jail_list:
+                        if jail.jail_mac == mac_address:
+                            duplicate_mac = 1
                             break
+                    if duplicate_mac != 1:
+                        break
 
-                    jail_flags |= WARDEN_SET_FLAGS_MAC
-                    jail_set_args['mac'] = mac_address
+                jail_flags |= WARDEN_SET_FLAGS_MAC
+                jail_set_args['mac'] = mac_address
 
             jail_set_args['flags'] = jail_flags
             try:

--- a/gui/jails/forms.py
+++ b/gui/jails/forms.py
@@ -227,6 +227,17 @@ class JailCreateForm(ModelForm):
             ))
         return jail_host.lower()
 
+    def clean_jail_mac(self):
+        jail_mac = self.cleaned_data.get('jail_mac')
+        jobs = Jails.objects.all()
+        for jail in jobs:
+            if jail.jail_mac == jail_mac:
+                raise forms.ValidationError(_(
+                    "You have entered an existing MAC Address."
+                    "Please enter a new one."
+                ))
+        return jail_mac
+
     def save(self):
         jc = self.jc
 
@@ -405,12 +416,28 @@ class JailCreateForm(ModelForm):
                     jail_flags |= WARDEN_SET_FLAGS_FLAGS
                     jail_set_args['jflags'] = val
 
-                jail_set_args['flags'] = jail_flags
-                try:
-                    w.set(**jail_set_args)
-                except Exception as e:
-                    self.errors['__all__'] = self.error_class([_(e.message)])
-                    return
+            else:
+                if key == 'jail_mac':
+                    duplicate_mac = 0
+                    while True:
+                        mac_address = generate_randomMAC()
+                        jail_list = Jails.objects.all()
+                        for jail in jail_list:
+                            if jail.jail_mac == mac_address:
+                                duplicate_mac = 1
+                                break
+                        if duplicate_mac != 1:
+                            break
+
+                    jail_flags |= WARDEN_SET_FLAGS_MAC
+                    jail_set_args['mac'] = mac_address
+
+            jail_set_args['flags'] = jail_flags
+            try:
+                w.set(**jail_set_args)
+            except Exception as e:
+                self.errors['__all__'] = self.error_class([_(e.message)])
+                return
 
         jail_nat = self.cleaned_data.get('jail_nat', None)
         jail_vnet = self.cleaned_data.get('jail_vnet', None)
@@ -466,6 +493,16 @@ class JailCreateForm(ModelForm):
         # Requery instance so we have everything up-to-date after save
         # See #14686
         self.instance = Jails.objects.get(jail_host=jail_host)
+
+
+def generate_randomMAC():
+    local_list = [0x02, 0x06, 0x0a, 0x0e]
+    first_byte = random.randint(0x00, 0x0f)
+    first = first_byte << 4
+    first = first | random.choice(local_list)
+    val = [first, random.randint(0x00, 0xff), random.randint(0x00, 0xff), random.randint(0x00, 0xff), random.randint(0x00, 0xff), random.randint(0x00, 0xff)]
+    mac_address = ':'.join(map(lambda x: "%02x" % x, val))
+    return mac_address
 
 
 class JailsConfigurationForm(ModelForm):
@@ -796,6 +833,17 @@ class JailsEditForm(ModelForm):
 
         self.__set_ro(instance, 'jail_host')
         self.__set_ro(instance, 'jail_type')
+
+    def clean_jail_mac(self):
+        jail_mac = self.cleaned_data.get('jail_mac')
+        jobs = Jails.objects.all()
+        for jail in jobs:
+            if jail.jail_mac == jail_mac:
+                raise forms.ValidationError(_(
+                    "You have entered an existing MAC Address."
+                    "Please enter a new one."
+                ))
+        return jail_mac
 
     def save(self):
         jail_host = self.cleaned_data.get('jail_host')

--- a/gui/jails/forms.py
+++ b/gui/jails/forms.py
@@ -833,11 +833,14 @@ class JailsEditForm(ModelForm):
 
     def clean_jail_mac(self):
         jail_mac = self.cleaned_data.get('jail_mac')
-        if is_jail_mac_duplicate(jail_mac):
-            raise forms.ValidationError(_(
-                "You have entered an existing MAC Address."
-                "Please enter a new one."
-            ))
+        curr_host = self.cleaned_data.get('jail_host')
+        jail = Jails.objects.get(jail_host=curr_host)
+        if jail_mac != jail.jail_mac:
+            if is_jail_mac_duplicate(jail_mac):
+                raise forms.ValidationError(_(
+                    "You have entered an existing MAC Address."
+                    "Please enter a new one."
+                ))
         return jail_mac
 
     def save(self):

--- a/gui/jails/forms.py
+++ b/gui/jails/forms.py
@@ -28,6 +28,7 @@ import os
 import platform
 import re
 import logging
+import random
 
 from django.utils.translation import ugettext_lazy as _
 

--- a/gui/jails/forms.py
+++ b/gui/jails/forms.py
@@ -230,13 +230,11 @@ class JailCreateForm(ModelForm):
 
     def clean_jail_mac(self):
         jail_mac = self.cleaned_data.get('jail_mac')
-        jobs = Jails.objects.all()
-        for jail in jobs:
-            if jail.jail_mac == jail_mac:
-                raise forms.ValidationError(_(
-                    "You have entered an existing MAC Address."
-                    "Please enter a new one."
-                ))
+        if is_jail_mac_duplicate(jail_mac):
+            raise forms.ValidationError(_(
+                "You have entered an existing MAC Address."
+                "Please enter a new one."
+            ))
         return jail_mac
 
     def save(self):
@@ -418,16 +416,10 @@ class JailCreateForm(ModelForm):
                     jail_set_args['jflags'] = val
 
             elif key == 'jail_mac':
-                jail_list = Jails.objects.all()
-                while True:
-                    duplicate_mac = 0
+                jail_mac_list = [jail.jail_mac for jail in Jails.objects.all()]
+                mac_address = generate_randomMAC()
+                while mac_address in jail_mac_list:
                     mac_address = generate_randomMAC()
-                    for jail in jail_list:
-                        if jail.jail_mac == mac_address:
-                            duplicate_mac = 1
-                            break
-                    if duplicate_mac != 1:
-                        break
 
                 jail_flags |= WARDEN_SET_FLAGS_MAC
                 jail_set_args['mac'] = mac_address
@@ -493,6 +485,11 @@ class JailCreateForm(ModelForm):
         # Requery instance so we have everything up-to-date after save
         # See #14686
         self.instance = Jails.objects.get(jail_host=jail_host)
+
+
+def is_jail_mac_duplicate(mac):
+    jail_macs = [jail.jail_mac for jail in Jails.objects.all()]
+    return mac in jail_macs
 
 
 def generate_randomMAC():
@@ -836,13 +833,11 @@ class JailsEditForm(ModelForm):
 
     def clean_jail_mac(self):
         jail_mac = self.cleaned_data.get('jail_mac')
-        jobs = Jails.objects.all()
-        for jail in jobs:
-            if jail.jail_mac == jail_mac:
-                raise forms.ValidationError(_(
-                    "You have entered an existing MAC Address."
-                    "Please enter a new one."
-                ))
+        if is_jail_mac_duplicate(jail_mac):
+            raise forms.ValidationError(_(
+                "You have entered an existing MAC Address."
+                "Please enter a new one."
+            ))
         return jail_mac
 
     def save(self):


### PR DESCRIPTION
In this commit, I have added a validation code for duplicate MAC addresses
assigned to jails by the user.
Also, in case the user lets freenas auto-assign MAC, I have added a
'generate_randomMAC' method which generates random unique locally
administered MAC addresses for jails.