### PR TITLE
FIX-15161: rsync over ssh on host, no matching host key fingerprint

### DIFF
--- a/gui/freeadmin/static/lib/js/freeadmin.js
+++ b/gui/freeadmin/static/lib/js/freeadmin.js
@@ -1358,20 +1358,24 @@ require([
         var rpathval = registry.byId("id_rsync_validate_rpath");
         var path = registry.byId("id_rsync_remotepath");
         var port = registry.byId("id_rsync_remoteport");
+        var keyscan = registry.byId("id_rsync_remotekeyscan");
         var trm = modname.domNode.parentNode.parentNode;
         var trp = path.domNode.parentNode.parentNode;
         var trpo = port.domNode.parentNode.parentNode;
         var trpa = rpathval.domNode.parentNode.parentNode;
+        var trs = keyscan.domNode.parentNode.parentNode;
         if(select.get('value') == 'ssh') {
             domStyle.set(trm, "display", "none");
             domStyle.set(trp, "display", "table-row");
             domStyle.set(trpo, "display", "table-row");
             domStyle.set(trpa, "display", "table-row");
+            domStyle.set(trs, "display", "table-row");
         } else {
             domStyle.set(trm, "display", "table-row");
             domStyle.set(trp, "display", "none");
             domStyle.set(trpo, "display", "none");
             domStyle.set(trpa, "display", "none");
+            domStyle.set(trs, "display", "none");
         }
 
     }

--- a/gui/tasks/forms.py
+++ b/gui/tasks/forms.py
@@ -2,7 +2,6 @@ import glob
 import os
 import pwd
 import subprocess
-from subprocess import Popen, PIPE
 
 from django.utils.translation import ugettext_lazy as _
 


### PR DESCRIPTION
In this commit, I have added a ssh_host_keyscan() method which saves the host key of the remote host into /root/.ssh/known_hosts file.
Hence, path validation onto the remote host does not fail even if the destination host has never been accessed from FreeNAS.