### PR TITLE
Bug #6721: Don't delete LUNs that are in use

### DIFF
--- a/gui/freeadmin/options.py
+++ b/gui/freeadmin/options.py
@@ -73,7 +73,6 @@ class BaseFreeAdmin(object):
     create_modelform = None
     edit_modelform = None
     delete_form = None
-    delete_form_filter = {}  # Ugly workaround for Extent/DeviceExtent
     deletable = True
     menu_child_of = None
 
@@ -748,12 +747,6 @@ class BaseFreeAdmin(object):
         instance = get_object_or_404(m, pk=oid)
 
         try:
-            if m._admin.delete_form_filter:
-                find = m.objects.filter(
-                    pk=instance.pk,
-                    **m._admin.delete_form_filter)
-                if find.count() == 0:
-                    raise
             _temp = __import__(
                 '%s.forms' % m._meta.app_label,
                 globals(),

--- a/gui/middleware/notifier.py
+++ b/gui/middleware/notifier.py
@@ -6046,6 +6046,24 @@ class notifier:
 
         return True
 
+    def iscsi_connected_targets(self):
+        '''
+        Returns the list of connected iscsi targets
+        '''
+        from lxml import etree
+        proc = self._pipeopen('ctladm islist -x')
+        xml = proc.communicate()[0]
+        connections = etree.fromstring(xml)
+        connected_targets = []
+        for connection in connections:
+            # Get full target name (Base name:target name) for each connection
+            target_name = connection[3].text
+            # Get target name from full name
+            target = target_name.split(':')[1]
+            if target not in connected_targets:
+                connected_targets.append(target)
+        return connected_targets
+
     def iscsi_active_connections(self):
         from lxml import etree
         proc = self._pipeopen('ctladm islist -x')

--- a/gui/services/admin.py
+++ b/gui/services/admin.py
@@ -59,6 +59,7 @@ class FTPFAdmin(BaseFreeAdmin):
 
 class ISCSITargetFAdmin(BaseFreeAdmin):
 
+    delete_form = "TargetExtentDelete"
     menu_child_of = "sharing.ISCSI"
     icon_object = u"TargetIcon"
     icon_model = u"TargetIcon"
@@ -133,6 +134,7 @@ class ISCSIAuthCredentialFAdmin(BaseFreeAdmin):
 
 class ISCSITargetToExtentFAdmin(BaseFreeAdmin):
 
+    delete_form = "TargetExtentDelete"
     menu_child_of = "sharing.ISCSI"
     icon_object = u"TargetExtentIcon"
     icon_model = u"TargetExtentIcon"
@@ -146,7 +148,6 @@ class ISCSITargetToExtentFAdmin(BaseFreeAdmin):
 class ISCSITargetExtentFAdmin(BaseFreeAdmin):
 
     delete_form = "ExtentDelete"
-    delete_form_filter = {'iscsi_target_extent_type__exact': 'File'}
     menu_child_of = "sharing.ISCSI"
     icon_object = u"ExtentIcon"
     icon_model = u"ExtentIcon"

--- a/gui/services/forms.py
+++ b/gui/services/forms.py
@@ -1823,6 +1823,22 @@ class iSCSITargetGroupsForm(ModelForm):
         return int(group)
 
 
+class TargetExtentDelete(Form):
+    '''
+    Delete form for Targets/Associated Targets
+    '''
+    def __init__(self, *args, **kwargs):
+        self.instance = kwargs.pop('instance', None)
+        super(TargetExtentDelete, self).__init__(*args, **kwargs)
+        if not self.data:
+            connected_targets = notifier().iscsi_connected_targets()
+            # Get target name from targetname/extentname combination
+            target_to_be_deleted = str(self.instance).split(' / ')[0]
+            if target_to_be_deleted in connected_targets:
+                self.errors['__all__'] = self.error_class(
+                    ["Warning: Target is in use"])
+
+
 class ExtentDelete(Form):
     delete = forms.BooleanField(
         label=_("Delete underlying file"),
@@ -1833,12 +1849,30 @@ class ExtentDelete(Form):
     def __init__(self, *args, **kwargs):
         self.instance = kwargs.pop('instance', None)
         super(ExtentDelete, self).__init__(*args, **kwargs)
+        if self.instance.iscsi_target_extent_type != 'File':
+            self.fields.pop('delete')
+        if not self.data:
+            targets_in_use = notifier().iscsi_connected_targets()
+            is_extent_active = False
+            target_to_extent_list = models.iSCSITargetToExtent.objects.filter(
+                iscsi_extent__iscsi_target_extent_name=str(
+                    self.instance).split()[0])
+            for target_to_extent in target_to_extent_list:
+                # Get target name from target:extent association
+                target = str(target_to_extent).split(' / ')[0]
+                if target in targets_in_use:
+                    is_extent_active = True
+                    # Extent is active. No need to check other targets.
+                    break
+            if is_extent_active:
+                self.errors['__all__'] = self.error_class(
+                    ["Warning: Associated Target is in use"])
 
     def done(self, *args, **kwargs):
         if (
-            self.cleaned_data['delete']
-            and
             self.instance.iscsi_target_extent_type == 'File'
+            and
+            self.cleaned_data['delete']
             and
             os.path.exists(self.instance.iscsi_target_extent_path)
         ):


### PR DESCRIPTION
Added a warning message while deleting active iscsi target/Associated extent. Removed the ExtentDelete hack.