### PR TITLE
Bug-#14432: Fix to prevent /dev/adax disks from being accessed inside a jail.

### DIFF
--- a/src/pcbsd/warden/scripts/backend/startjail.sh
+++ b/src/pcbsd/warden/scripts/backend/startjail.sh
@@ -518,7 +518,8 @@ if is_symlinked_mountpoint "${JAILDIR}/dev"; then
    warden_print "${JAILDIR}/dev has symlink as parent, not mounting"
 else
    mount -t devfs devfs "${JAILDIR}/dev"
-   #devfs -m "${JAILDIR}/dev" rule -s 4 applyset
+   devfs rule -s 4 add path 'bpf*' unhide
+   devfs -m "${JAILDIR}/dev" rule -s 4 applyset
 fi
 
 if [ "$LINUXJAIL" = "YES" ] ; then


### PR DESCRIPTION
In this commit, I have added the device "bpf*", needed for DHCP jails, to devfs rule #4 and then applied the rule to jails so that /dev/adax disks are no longer reachable from inside a jail.