### PR TITLE
Fix-15927: Replace default space delimiter with tab while splitting zfs mountpoint and name

### DIFF
--- a/gui/storage/views.py
+++ b/gui/storage/views.py
@@ -1414,7 +1414,7 @@ def tasks_json(request, dataset=None):
                 continue
 
             try:
-                zfs_mp, zfs_ds = line.split()
+                zfs_mp, zfs_ds = line.split('\t')
                 if mp == zfs_mp or mp.startswith("/%s/" % zfs_mp):
                     if mp == zfs_mp:
                         task_list = models.Task.objects.filter(


### PR DESCRIPTION
'zfs list -H -o mountpoint,name' command separates mountpoint and name with a tab (\t) at each line. Let us be specific while splitting it so that such errors do not occur.