### PR TITLE
Bug #16101: Reporting history gone after reboot

### DIFF
--- a/src/freenas/usr/local/sbin/save_rrds.sh
+++ b/src/freenas/usr/local/sbin/save_rrds.sh
@@ -51,7 +51,7 @@ use_rrd_dataset()
 	do
 		if [ "${rrd_usedataset}" = "1" ]
 		then
-			echo "1"
+			return 1
 		else
 			if is_freenas; then
 				return 0	
@@ -60,7 +60,7 @@ use_rrd_dataset()
 				if [ "x${failover}" = "xMASTER" ]; then
 					return 0	
 				else
-					echo "1"
+					return 1
 				fi
 			fi
 		fi

--- a/src/freenas/usr/local/sbin/save_rrds.sh
+++ b/src/freenas/usr/local/sbin/save_rrds.sh
@@ -54,11 +54,11 @@ use_rrd_dataset()
 			echo "1"
 		else
 			if is_freenas; then
-				echo "0"
+				return 0	
 			else
 				local failover="$(/usr/local/bin/python /usr/local/www/freenasUI/middleware/notifier.py failover_status 2> /dev/null)"
 				if [ "x${failover}" = "xMASTER" ]; then
-					echo "0"
+					return 0	
 				else
 					echo "1"
 				fi


### PR DESCRIPTION
In this commit, I have replaced "echo "0"" with "return 0" in file
 save_rrds.sh, Now reporting data is not getting flush after
reboot.