### PR TITLE
ticket-10795: Need to prune old boot environments when space is running low and need to create new one

### DIFF
--- a/gui/system/forms.py
+++ b/gui/system/forms.py
@@ -176,7 +176,7 @@ class BootEnvAddForm(Form):
             **kwargs
         )
         if clone is False:
-            raise MiddlewareError(_('Failed to create a new Boot.'))
+            raise MiddlewareError(_('No Boot environments could be deleted due to keep flag settings, and boot-pool is out of space. Failed to create a new Boot.'))
 
 
 class BootEnvRenameForm(Form):

--- a/gui/system/forms.py
+++ b/gui/system/forms.py
@@ -168,15 +168,18 @@ class BootEnvAddForm(Form):
         return name
 
     def save(self, *args, **kwargs):
-        kwargs = {}
-        if self._source:
-            kwargs['bename'] = self._source
-        clone = Update.CreateClone(
-            self.cleaned_data.get('name'),
-            **kwargs
-        )
-        if clone is False:
+        if Update.PruneClones() is False:
             raise MiddlewareError(_('No Boot environments could be deleted due to keep flag settings, and boot-pool is out of space. Failed to create a new Boot.'))
+        else:
+            kwargs = {}
+            if self._source:
+                kwargs['bename'] = self._source
+            clone = Update.CreateClone(
+                self.cleaned_data.get('name'),
+                **kwargs
+            )
+            if clone is False:
+                raise MiddlewareError(_('Failed to create a new Boot.'))
 
 
 class BootEnvRenameForm(Form):


### PR DESCRIPTION
 After deleting the unkept old Boot Environments in pull request "https://github.com/freenas/freenas-pkgtools/pull/1", if there is still not enough storage space, then kept BE should be deleted manually
 by user. So printing an error message for the same.