### PR TITLE
FIX-16597: Removed Community string characters validation from SNMP service form to accept all the characters

### DIFF
--- a/gui/services/forms.py
+++ b/gui/services/forms.py
@@ -839,6 +839,11 @@ class SNMPForm(ModelForm):
                 raise forms.ValidationError(_('This field is required.'))
             else:
                 return community
+        if not re.match(r'^[-_,.a-zA-Z0-9\s]+$', community):
+            raise forms.ValidationError(
+                _(u"The community must contain only alphanumeric characters ,"
+                    "_ . or -")
+            )
         return community
 
     def clean_snmp_v3_password(self):

--- a/gui/services/forms.py
+++ b/gui/services/forms.py
@@ -839,11 +839,6 @@ class SNMPForm(ModelForm):
                 raise forms.ValidationError(_('This field is required.'))
             else:
                 return community
-        if not re.match(r'^[-_a-zA-Z0-9\s]+$', community):
-            raise forms.ValidationError(
-                _(u"The community must contain only alphanumeric characters, "
-                    "_ or -")
-            )
         return community
 
     def clean_snmp_v3_password(self):

--- a/gui/services/forms.py
+++ b/gui/services/forms.py
@@ -839,9 +839,9 @@ class SNMPForm(ModelForm):
                 raise forms.ValidationError(_('This field is required.'))
             else:
                 return community
-        if not re.match(r'^[-_,.a-zA-Z0-9\s]+$', community):
+        if not re.match(r'^[-_.a-zA-Z0-9\s]+$', community):
             raise forms.ValidationError(
-                _(u"The community must contain only alphanumeric characters ,"
+                _(u"The community must contain only alphanumeric characters "
                     "_ . or -")
             )
         return community


### PR DESCRIPTION
I talked to Josh who had added this validation because there was some problem in middleware back then accepting some characters. I suppose now this validation is no longer needed as I could not find any constraint/convention for Community string in RFC or anywhere on the web.  