### PR TITLE
Bug #16029: TLS FTP problem

### DIFF
--- a/gui/services/models.py
+++ b/gui/services/models.py
@@ -1537,6 +1537,7 @@ class FTP(Model):
     ftp_ssltls_certificate = models.ForeignKey(
         Certificate,
         verbose_name=_("Certificate"),
+        limit_choices_to={'cert_type': 16},
         on_delete=models.SET_NULL,
         blank=True,
         null=True,
@@ -2165,6 +2166,7 @@ class WebDAV(Model):
     webdav_certssl = models.ForeignKey(
         Certificate,
         verbose_name=_("Webdav SSL Certificate"),
+        limit_choices_to={'cert_type': 16},
         on_delete=models.SET_NULL,
         blank=True,
         null=True,

--- a/gui/system/models.py
+++ b/gui/system/models.py
@@ -80,6 +80,7 @@ class Settings(Model):
     stg_guicertificate = models.ForeignKey(
         "Certificate",
         verbose_name=_("Certificate"),
+        limit_choices_to={'cert_type': 16},
         on_delete=models.SET_NULL,
         blank=True,
         null=True


### PR DESCRIPTION
In this commit, I have added a filter to allow only Certificates(.crt)and not Certificate Signing Requests(.csr) in the drop-down menus of FTP, WebDAV and System->General as mentioned by Suraj.