### PR TITLE
Fix-10795 : Need to prune old boot environments when space is running low and need to create new one

### DIFF
--- a/gui/system/forms.py
+++ b/gui/system/forms.py
@@ -168,18 +168,15 @@ class BootEnvAddForm(Form):
         return name
 
     def save(self, *args, **kwargs):
-        if Update.PruneClones() is False:
-            raise MiddlewareError(_('No Boot environments could be deleted due to keep flag settings, and boot-pool is out of space. Failed to create a new Boot.'))
-        else:
-            kwargs = {}
-            if self._source:
-                kwargs['bename'] = self._source
-            clone = Update.CreateClone(
-                self.cleaned_data.get('name'),
-                **kwargs
-            )
-            if clone is False:
-                raise MiddlewareError(_('Failed to create a new Boot.'))
+        kwargs = {}
+        if self._source:
+            kwargs['bename'] = self._source
+        clone = Update.CreateClone(
+            self.cleaned_data.get('name'),
+            **kwargs
+        )
+        if clone is False:
+            raise MiddlewareError(_('Failed to create a new Boot.'))
 
 
 class BootEnvRenameForm(Form):


### PR DESCRIPTION
In this commit I have removed the calling of PruneClones before
creation of a new boot environment and calling the same before
system update in Update.py in pull request https://github.com/freenas/freenas-pkgtools/pull/2 .