### PR TITLE
fix-16963 : Change "CIFS" to "SMB" in the UI

### DIFF
--- a/gui/account/forms.py
+++ b/gui/account/forms.py
@@ -371,7 +371,7 @@ class bsdUsersForm(ModelForm, bsdUserGroupMixin):
         if bsdusr_password and '?' in bsdusr_password:
             raise forms.ValidationError(_(
                 'Passwords containing a question mark (?) are currently not '
-                'allowed due to problems with CIFS.'
+                'allowed due to problems with SMB.'
             ))
         return bsdusr_password
 

--- a/gui/freeadmin/static/lib/js/freeadmin/templates/wizardshares.html
+++ b/gui/freeadmin/static/lib/js/freeadmin/templates/wizardshares.html
@@ -8,7 +8,7 @@
       <table style="padding: 0;" width="100%">
         <tr>
           <td style="border-right: 1px solid #ccc; padding-right: 5px;">
-            <span data-dojo-attach-point="dapShareCIFS"></span> Windows (CIFS) &nbsp; <span data-dojo-attach-point="dapShareGuest"></span> Allow Guest<br />
+            <span data-dojo-attach-point="dapShareCIFS"></span> Windows (SMB) &nbsp; <span data-dojo-attach-point="dapShareGuest"></span> Allow Guest<br />
             <span data-dojo-attach-point="dapShareAFP"></span> Mac OS X (AFP) &nbsp; <span data-dojo-attach-point="dapShareAFP_TM"></span> Time Machine<br />
             <span data-dojo-attach-point="dapShareNFS"></span> Generic Unix (NFS)<br />
             <span data-dojo-attach-point="dapShareiSCSI"></span> Block Storage (iSCSI) &nbsp; &nbsp;Size: <span data-dojo-attach-point="dapShareiSCSI_size"></span><br />

--- a/gui/locale/af/LC_MESSAGES/django.po
+++ b/gui/locale/af/LC_MESSAGES/django.po
@@ -1338,7 +1338,7 @@ msgid "This field is required for \"Home directories\"."
 msgstr ""
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr ""
 
 #: services/forms.py:118
@@ -1771,7 +1771,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1808,13 +1808,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:203
@@ -3164,11 +3164,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5283,7 +5283,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5543,7 +5543,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5567,19 +5567,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -9012,7 +9012,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -9668,7 +9668,7 @@ msgstr ""
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%s suksesvol opgedateer."
 
 #: sharing/models.py:290
@@ -12551,7 +12551,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/ar/LC_MESSAGES/django.po
+++ b/gui/locale/ar/LC_MESSAGES/django.po
@@ -1350,7 +1350,7 @@ msgid "This field is required for \"Home directories\"."
 msgstr ""
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr ""
 
 #: services/forms.py:118
@@ -1788,7 +1788,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1825,13 +1825,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:203
@@ -3182,11 +3182,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5308,7 +5308,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5568,7 +5568,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5592,19 +5592,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -9011,9 +9011,9 @@ msgstr "محمل"
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
-"كلمات السر التي تحتوي على علامة استفهام (؟) لا يسمح حاليا بسبب مشاكل مع CIFS."
+"كلمات السر التي تحتوي على علامة استفهام (؟) لا يسمح حاليا بسبب مشاكل مع SMB."
 
 #: directoryservice/forms.py:104
 #, fuzzy
@@ -9683,7 +9683,7 @@ msgstr ""
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%s تحدث بنجاح."
 
 #: sharing/models.py:290
@@ -12593,7 +12593,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/az/LC_MESSAGES/django.po
+++ b/gui/locale/az/LC_MESSAGES/django.po
@@ -1342,7 +1342,7 @@ msgid "This field is required for \"Home directories\"."
 msgstr ""
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr ""
 
 #: services/forms.py:118
@@ -1775,7 +1775,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1812,13 +1812,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:203
@@ -3168,11 +3168,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5290,7 +5290,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5550,7 +5550,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5574,19 +5574,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -8961,7 +8961,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -9607,7 +9607,7 @@ msgid "Kerberos Realm"
 msgstr ""
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr ""
 
 #: sharing/models.py:290
@@ -12424,7 +12424,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/bg/LC_MESSAGES/django.po
+++ b/gui/locale/bg/LC_MESSAGES/django.po
@@ -1360,7 +1360,7 @@ msgstr "Това поле е задължително за \"Стартови д
 
 #: services/forms.py:106
 #, fuzzy
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr "Услугата NFS не успя да се презареди."
 
 #: services/forms.py:118
@@ -1821,7 +1821,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1858,14 +1858,14 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "Име на сървъра"
@@ -3232,12 +3232,12 @@ msgstr ""
 
 #: sharing/models.py:94
 #, fuzzy
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr "Добавяне на споделени ресурси за Windows"
 
 #: sharing/models.py:95
 #, fuzzy
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr "Споделени ресурси за UNIX"
 
 #: sharing/models.py:114
@@ -5356,8 +5356,8 @@ msgstr "AFP настройки"
 #~ msgstr "Настройки на Активната директория"
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
-msgstr "CIFS настройки"
+msgid "SMB Settings"
+msgstr "SMB настройки"
 
 #: templates/services/core.html:45
 msgid "Dynamic DNS Settings"
@@ -5602,8 +5602,8 @@ msgstr "Добавяне на споделени ресурси за UNIX (NFS)"
 
 #: templates/sharing/index.html:12
 #, fuzzy
-msgid "Windows (CIFS)"
-msgstr "Добавяне на споделени ресурси за Windows (CIFS)"
+msgid "Windows (SMB)"
+msgstr "Добавяне на споделени ресурси за Windows (SMB)"
 
 #: templates/sharing/unix.html:7
 msgid "There are no active UNIX (NFS) shares."
@@ -5625,19 +5625,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr "Добавяне на споделени ресурси за UNIX"
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr "Няма активни Windows споделени ресурси."
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr "Редактиране на Windows споделени ресурси"
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr "Изтриване на споделени ресурси за Windows"
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr "Добавяне на споделени ресурси за Windows"
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -6259,7 +6259,7 @@ msgstr "Показва лоудерите"
 #~ msgid "Close"
 #~ msgstr "Затваряне"
 
-msgid "Add Apple (CIFS) Share"
+msgid "Add Apple (SMB) Share"
 msgstr "Добавяне на споделени ресурси за Apple"
 
 #~ msgid "Apply Service Pack"
@@ -6335,7 +6335,7 @@ msgstr "Добавяне на споделени ресурси за Apple"
 #~ msgid "Guest Account"
 #~ msgstr "Гост"
 
-msgid "CIFS Share"
+msgid "SMB Share"
 msgstr "Редактиране на NFS споделени ресурси"
 
 msgid "NFS Share"
@@ -9463,7 +9463,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -10147,7 +10147,7 @@ msgstr "Брой на сървърите"
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%s успешно обновени."
 
 #: sharing/models.py:290
@@ -13231,7 +13231,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/bn/LC_MESSAGES/django.po
+++ b/gui/locale/bn/LC_MESSAGES/django.po
@@ -1340,7 +1340,7 @@ msgid "This field is required for \"Home directories\"."
 msgstr ""
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr ""
 
 #: services/forms.py:118
@@ -1773,7 +1773,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1810,13 +1810,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:203
@@ -3166,11 +3166,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5284,7 +5284,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5544,7 +5544,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5568,19 +5568,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -8975,7 +8975,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -9619,7 +9619,7 @@ msgid "Kerberos Realm"
 msgstr ""
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr ""
 
 #: sharing/models.py:290
@@ -12448,7 +12448,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/bs/LC_MESSAGES/django.po
+++ b/gui/locale/bs/LC_MESSAGES/django.po
@@ -1343,7 +1343,7 @@ msgid "This field is required for \"Home directories\"."
 msgstr ""
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr ""
 
 #: services/forms.py:118
@@ -1777,7 +1777,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1814,13 +1814,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:203
@@ -3170,11 +3170,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5288,7 +5288,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5548,7 +5548,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5572,19 +5572,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -8951,7 +8951,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -9590,7 +9590,7 @@ msgid "Kerberos Realm"
 msgstr ""
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr ""
 
 #: sharing/models.py:290
@@ -12378,7 +12378,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/ca/LC_MESSAGES/django.po
+++ b/gui/locale/ca/LC_MESSAGES/django.po
@@ -1362,8 +1362,8 @@ msgid "This field is required for \"Home directories\"."
 msgstr "Aquest camp és requereix per \"Home directories\"."
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
-msgstr "El servei CIFS ha fallat la recàrrega."
+msgid "The SMB service failed to reload."
+msgstr "El servei SMB ha fallat la recàrrega."
 
 #: services/forms.py:118
 msgid "The AFP service failed to reload."
@@ -1829,7 +1829,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1872,14 +1872,14 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "Nom del servidor"
@@ -3352,12 +3352,12 @@ msgstr "Aquests paràmetres s'afegiran a la secció [Share] de smb.conf"
 
 #: sharing/models.py:94
 #, fuzzy
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr "Compartició de Windows"
 
 #: sharing/models.py:95
 #, fuzzy
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr "Compartició de Windows"
 
 #: sharing/models.py:114
@@ -5534,8 +5534,8 @@ msgstr "paràmetres AFP"
 #~ msgstr "Paràmetres del directori actiu"
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
-msgstr "Paràmetres CIFS"
+msgid "SMB Settings"
+msgstr "Paràmetres SMB"
 
 #: templates/services/core.html:45
 msgid "Dynamic DNS Settings"
@@ -5778,8 +5778,8 @@ msgstr "Afegir la compartició (share) de NFS"
 
 #: templates/sharing/index.html:12
 #, fuzzy
-msgid "Windows (CIFS)"
-msgstr "Afegir finestra de compartició (CIFS)"
+msgid "Windows (SMB)"
+msgstr "Afegir finestra de compartició (SMB)"
 
 #: templates/sharing/unix.html:7
 msgid "There are no active UNIX (NFS) shares."
@@ -5801,19 +5801,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr "Afegir la compartició UNIX"
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr "No hi ha cap finestra activa de compartició"
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr "Editar finestra de compartició"
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr "Eliminar finestra de compartició"
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr "Afegir finestra de compartició"
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -6459,7 +6459,7 @@ msgstr "Veure tots els usuaris"
 #~ msgid "Close"
 #~ msgstr "Tancar"
 
-msgid "Add Apple (CIFS) Share"
+msgid "Add Apple (SMB) Share"
 msgstr "Afegir Apple share"
 
 #~ msgid "Apply Service Pack"
@@ -6567,11 +6567,11 @@ msgstr "Afegir Apple share"
 #~ "usuari ha d'existir al fitxer password, però no requereix tenir un login "
 #~ "vàlid."
 
-msgid "CIFS Share"
+msgid "SMB Share"
 msgstr "UNIX Share"
 
-#~ msgid "CIFS Shares"
-#~ msgstr "Comparticions CIFS"
+#~ msgid "SMB Shares"
+#~ msgstr "Comparticions SMB"
 
 #~ msgid "NFS Share"
 #~ msgstr "Compartició NFS"
@@ -9910,7 +9910,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -10601,7 +10601,7 @@ msgstr "Fitxer Keytab de kerberos"
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%s actualitzat amb èxit."
 
 #: sharing/models.py:290
@@ -13706,7 +13706,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/cs/LC_MESSAGES/django.po
+++ b/gui/locale/cs/LC_MESSAGES/django.po
@@ -1348,8 +1348,8 @@ msgid "This field is required for \"Home directories\"."
 msgstr "Vyplnění této kolonky je vyžadováno pro volbu „Domovské složky“."
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
-msgstr "Znovunačtení služby CIFS se nezdařilo."
+msgid "The SMB service failed to reload."
+msgstr "Znovunačtení služby SMB se nezdařilo."
 
 #: services/forms.py:118
 msgid "The AFP service failed to reload."
@@ -1822,10 +1822,10 @@ msgstr "Unixová rozšíření"
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
-"Tato rozšíření umožňují službě Samba lépe obsluhovat unixové CIFS klienty "
+"Tato rozšíření umožňují službě Samba lépe obsluhovat unixové SMB klienty "
 "poskytnutím funkcí jako jsou symbolické a pevné odkazy, atd…"
 
 #: services/models.py:171
@@ -1865,18 +1865,18 @@ msgstr "Nabízet sdílení pomocí technologie Zeroconf"
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 "Technologie Zeroconf (zde implementovaná službou Avahi) umožňuje klientům ("
-"konkrétně aplikaci finder v Mac OS X) automaticky objevit CIFS sdílení, "
+"konkrétně aplikaci finder v Mac OS X) automaticky objevit SMB sdílení, "
 "nabízené systémem – podobně jako je tomu u služby Procházení počítačů v "
 "systému Windows."
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "Jméno serveru"
@@ -3346,12 +3346,12 @@ msgstr ""
 "Tyto parametry jsou přidány do sekce [Share] v souboru s nastaveními smb.conf"
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
-msgstr "Windows (CIFS) sdílení"
+msgid "Windows (SMB) Share"
+msgstr "Windows (SMB) sdílení"
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
-msgstr "Windows (CIFS) sdílení"
+msgid "Windows (SMB) Shares"
+msgstr "Windows (SMB) sdílení"
 
 #: sharing/models.py:114
 msgid ""
@@ -5501,8 +5501,8 @@ msgstr "Nastavení služby AFP"
 #~ msgstr "Nastavení Active Directory"
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
-msgstr "Nastavení služby CIFS"
+msgid "SMB Settings"
+msgstr "Nastavení služby SMB"
 
 #: templates/services/core.html:45
 msgid "Dynamic DNS Settings"
@@ -5751,8 +5751,8 @@ msgid "UNIX (NFS)"
 msgstr "UNIX (NFS)"
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
-msgstr "Windows (CIFS)"
+msgid "Windows (SMB)"
+msgstr "Windows (SMB)"
 
 #~ msgid "There are no active UNIX (NFS) shares."
 #~ msgstr "Žádné sdílení UNIX (NFS) není aktivní."
@@ -5773,19 +5773,19 @@ msgstr ""
 msgid "Add UNIX (NFS) Share"
 msgstr "Přidat unixové (NFS) sdílení"
 
-#~ msgid "There are no active Windows (CIFS) shares."
-#~ msgstr "Žádná sdílení Windows (CIFS) nejsou aktivní."
+#~ msgid "There are no active Windows (SMB) shares."
+#~ msgstr "Žádná sdílení Windows (SMB) nejsou aktivní."
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -6385,8 +6385,8 @@ msgstr "Zobrazit S.M.A.R.T. testy"
 #~ msgid "View Tunables"
 #~ msgstr "Zobrazit vyladění"
 
-msgid "Add Apple (CIFS) Share"
-msgstr "Přidat Apple (CIFS) sdílení"
+msgid "Add Apple (SMB) Share"
+msgstr "Přidat Apple (SMB) sdílení"
 
 #~ msgid "Hourly"
 #~ msgstr "Hodinové"
@@ -9443,10 +9443,10 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 "Hesla obsahující znak „?“ (otazník) není v současnosti možné používat a to z "
-"důvodu problémů při použití s CIFS sdíleními."
+"důvodu problémů při použití s SMB sdíleními."
 
 #: directoryservice/forms.py:104
 msgid "NT4 failed to reload."
@@ -10145,8 +10145,8 @@ msgid "Kerberos Realm"
 msgstr "Oblast Kerbera"
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
-msgstr "CIFS bylo úspěšně zaktualizováno"
+msgid "SMB successfully updated."
+msgstr "SMB bylo úspěšně zaktualizováno"
 
 #: sharing/models.py:290
 msgid "Security"
@@ -13215,8 +13215,8 @@ msgstr ""
 "spojovníky a podtržítka."
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
-msgstr "Službu CIFS nelze vypnout, pokud zapnutá služba ActiveDirectory."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
+msgstr "Službu SMB nelze vypnout, pokud zapnutá služba ActiveDirectory."
 
 #: services/models.py:1295
 msgid "Shutdown Command"

--- a/gui/locale/cy/LC_MESSAGES/django.po
+++ b/gui/locale/cy/LC_MESSAGES/django.po
@@ -1342,7 +1342,7 @@ msgid "This field is required for \"Home directories\"."
 msgstr ""
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr ""
 
 #: services/forms.py:118
@@ -1775,7 +1775,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1812,13 +1812,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:203
@@ -3168,11 +3168,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5286,7 +5286,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5546,7 +5546,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5570,19 +5570,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -8939,7 +8939,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -9575,7 +9575,7 @@ msgid "Kerberos Realm"
 msgstr ""
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr ""
 
 #: sharing/models.py:290
@@ -12351,7 +12351,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/da/LC_MESSAGES/django.po
+++ b/gui/locale/da/LC_MESSAGES/django.po
@@ -1347,7 +1347,7 @@ msgstr "Dette felt er påkrævet for \"Hjemmemapper\"."
 
 #: services/forms.py:106
 #, fuzzy
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr "NFS service kunne ikke genstarte."
 
 #: services/forms.py:118
@@ -1790,7 +1790,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1827,14 +1827,14 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "Servernavn"
@@ -3196,11 +3196,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5357,7 +5357,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5623,7 +5623,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5647,19 +5647,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -9342,7 +9342,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -10022,7 +10022,7 @@ msgstr "Antal servere"
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%s blev opdateret."
 
 #: sharing/models.py:290
@@ -13044,7 +13044,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/de/LC_MESSAGES/django.po
+++ b/gui/locale/de/LC_MESSAGES/django.po
@@ -1385,8 +1385,8 @@ msgid "This field is required for \"Home directories\"."
 msgstr "Diese Feld wird für \"Heimatverzeichnisse\" benötigt."
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
-msgstr "Der CIFS Dienst konnte nicht wieder geladen werden."
+msgid "The SMB service failed to reload."
+msgstr "Der SMB Dienst konnte nicht wieder geladen werden."
 
 #: services/forms.py:118
 msgid "The AFP service failed to reload."
@@ -1848,11 +1848,11 @@ msgstr "Unix Extensions"
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 "Diese Erweiterungen erlauben symbolische Links, Hardlinks etc in Samba, "
-"damit eine bessere Integration von UNIX CIFS Clients."
+"damit eine bessere Integration von UNIX SMB Clients."
 
 #: services/models.py:171
 msgid "Enable AIO"
@@ -1892,17 +1892,17 @@ msgstr "Zeroconf Freigaben Suche"
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 "Zeroconf mittels Avahi erlaubt Clients (speziell dem (Mac) OS X Finder) ein "
-"Anzeigen der CIFS Freigaben dieses Systems ohne weitere Konfiguration, "
+"Anzeigen der SMB Freigaben dieses Systems ohne weitere Konfiguration, "
 "vergleichbar der Netzwerk und Freigabe-Anzeige in Windows. "
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "Servername"
@@ -3434,12 +3434,12 @@ msgstr ""
 "hinzugefügt."
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
-msgstr "Windows (CIFS) Freigabe"
+msgid "Windows (SMB) Share"
+msgstr "Windows (SMB) Freigabe"
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
-msgstr "Windows (CIFS) Freigaben"
+msgid "Windows (SMB) Shares"
+msgstr "Windows (SMB) Freigaben"
 
 #: sharing/models.py:114
 msgid ""
@@ -5648,8 +5648,8 @@ msgstr "AFP Einstellungen"
 #~ msgstr "Active Directory Einstellungen"
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
-msgstr "CIFS Einstellungen"
+msgid "SMB Settings"
+msgstr "SMB Einstellungen"
 
 #: templates/services/core.html:45
 msgid "Dynamic DNS Settings"
@@ -5871,8 +5871,8 @@ msgid "UNIX (NFS)"
 msgstr "UNIX Freigabe (NFS)"
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
-msgstr "Windows Freigabe (CIFS)"
+msgid "Windows (SMB)"
+msgstr "Windows Freigabe (SMB)"
 
 #~ msgid "There are no active UNIX (NFS) shares."
 #~ msgstr "Es gibt keine aktiven UNIX (NFS) Freigaben."
@@ -5889,17 +5889,17 @@ msgstr "Windows Freigabe (CIFS)"
 #~ msgid "Add UNIX (NFS) Share"
 #~ msgstr "UNIX (NFS) Freigabe hinzufügen"
 
-#~ msgid "There are no active Windows (CIFS) shares."
-#~ msgstr "Es gibt keine aktiven Windows (CIFS) Freigaben."
+#~ msgid "There are no active Windows (SMB) shares."
+#~ msgstr "Es gibt keine aktiven Windows (SMB) Freigaben."
 
-#~ msgid "Edit Windows (CIFS) Share"
-#~ msgstr "Windows (CIFS) Freigabe bearbeiten"
+#~ msgid "Edit Windows (SMB) Share"
+#~ msgstr "Windows (SMB) Freigabe bearbeiten"
 
-#~ msgid "Delete Windows (CIFS) Share"
-#~ msgstr "Windows (CIFS) Freigabe löschen"
+#~ msgid "Delete Windows (SMB) Share"
+#~ msgstr "Windows (SMB) Freigabe löschen"
 
-#~ msgid "Add Windows (CIFS) Share"
-#~ msgstr "Windows (CIFS) Freigabe hinzufügen"
+#~ msgid "Add Windows (SMB) Share"
+#~ msgstr "Windows (SMB) Freigabe hinzufügen"
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
 msgid "Clone Snapshot"
@@ -6574,8 +6574,8 @@ msgstr "Kritische Alarme"
 #~ msgid "Plugins path"
 #~ msgstr "Plugin Verzeichnis"
 
-#~ msgid "Add Apple (CIFS) Share"
-#~ msgstr "Apple Freigabe (CIFS) hinzufügen"
+#~ msgid "Add Apple (SMB) Share"
+#~ msgstr "Apple Freigabe (SMB) hinzufügen"
 
 #~ msgid "Apply Service Pack"
 #~ msgstr "Service Pack anwenden"
@@ -6692,11 +6692,11 @@ msgstr "Kritische Alarme"
 #~ "Gast-Dienst verbinden. Dieser Benutzer muss zwar in der Passwortdatei "
 #~ "existieren, benötigt aber keine gültige Anmeldung."
 
-#~ msgid "CIFS Share"
-#~ msgstr "CIFS Freigabe"
+#~ msgid "SMB Share"
+#~ msgstr "SMB Freigabe"
 
-#~ msgid "CIFS Shares"
-#~ msgstr "CIFS Freigaben"
+#~ msgid "SMB Shares"
+#~ msgstr "SMB Freigaben"
 
 #~ msgid "NFS Share"
 #~ msgstr "NFS Freigabe"
@@ -10088,10 +10088,10 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 "Passwörter mit Fragezeichen (?) sind nicht erlaubt auf Grund eines Problems "
-"mit CIFS.                "
+"mit SMB.                "
 
 #: directoryservice/forms.py:104
 msgid "NT4 failed to reload."
@@ -10779,7 +10779,7 @@ msgstr "Kerberos Keytab Datei"
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%s erfolgreich aktualisiert."
 
 #: sharing/models.py:290
@@ -13939,7 +13939,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/el/LC_MESSAGES/django.po
+++ b/gui/locale/el/LC_MESSAGES/django.po
@@ -1352,8 +1352,8 @@ msgid "This field is required for \"Home directories\"."
 msgstr "Αυτό το πεδίο απαιτείται για τους \"Αρχικούς καταλόγους\"."
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
-msgstr "Η επαναφόρτωση της υπηρεσίας CIFS απέτυχε."
+msgid "The SMB service failed to reload."
+msgstr "Η επαναφόρτωση της υπηρεσίας SMB απέτυχε."
 
 #: services/forms.py:118
 msgid "The AFP service failed to reload."
@@ -1822,7 +1822,7 @@ msgstr "Προεκτάσεις Unix"
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1863,14 +1863,14 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "Όνομα Διακομιστή"
@@ -3354,12 +3354,12 @@ msgstr "Οι παράμετροι αυτοί προστίθενται στο [Sh
 
 #: sharing/models.py:94
 #, fuzzy
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr "Windows Share"
 
 #: sharing/models.py:95
 #, fuzzy
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr "Windows Shares"
 
 #: sharing/models.py:114
@@ -5515,8 +5515,8 @@ msgstr "Ρυθμίσεις AFP"
 #~ msgstr "Ρυθμίσεις Active Directory"
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
-msgstr "Ρυθμίσεις CIFS"
+msgid "SMB Settings"
+msgstr "Ρυθμίσεις SMB"
 
 #: templates/services/core.html:45
 msgid "Dynamic DNS Settings"
@@ -5752,8 +5752,8 @@ msgid "UNIX (NFS)"
 msgstr "κοινόχρηστα UNIX (NFS)"
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
-msgstr "κοινόχρηστα Windows (CIFS)"
+msgid "Windows (SMB)"
+msgstr "κοινόχρηστα Windows (SMB)"
 
 #~ msgid "There are no active UNIX (NFS) shares."
 #~ msgstr "Δεν υπάρχουν ενεργά κοινόχρηστα UNIX (NFS)."
@@ -5770,17 +5770,17 @@ msgstr "κοινόχρηστα Windows (CIFS)"
 #~ msgid "Add UNIX (NFS) Share"
 #~ msgstr "Προσθήκη κοινόχρηστου UNIX (NFS)"
 
-#~ msgid "There are no active Windows (CIFS) shares."
-#~ msgstr "Δεν υπάρχουν ενεργά κοινόχρηστα Windows (CIFS)."
+#~ msgid "There are no active Windows (SMB) shares."
+#~ msgstr "Δεν υπάρχουν ενεργά κοινόχρηστα Windows (SMB)."
 
-#~ msgid "Edit Windows (CIFS) Share"
-#~ msgstr "Επεξεργασία κοινόχρηστου Windows (CIFS)"
+#~ msgid "Edit Windows (SMB) Share"
+#~ msgstr "Επεξεργασία κοινόχρηστου Windows (SMB)"
 
-#~ msgid "Delete Windows (CIFS) Share"
-#~ msgstr "Διαγραφή κοινόχρηστου Windows (CIFS)"
+#~ msgid "Delete Windows (SMB) Share"
+#~ msgstr "Διαγραφή κοινόχρηστου Windows (SMB)"
 
-#~ msgid "Add Windows (CIFS) Share"
-#~ msgstr "Προσθήκη κοινόχρηστου Windows (CIFS)"
+#~ msgid "Add Windows (SMB) Share"
+#~ msgstr "Προσθήκη κοινόχρηστου Windows (SMB)"
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
 msgid "Clone Snapshot"
@@ -6440,8 +6440,8 @@ msgstr "Domain name"
 #~ msgid "Plugins path"
 #~ msgstr "Διαδρομή επεκτάσεων"
 
-#~ msgid "Add Apple (CIFS) Share"
-#~ msgstr "Προσθήκη κοινόχρηστου Apple (CIFS)"
+#~ msgid "Add Apple (SMB) Share"
+#~ msgstr "Προσθήκη κοινόχρηστου Apple (SMB)"
 
 #~ msgid "Apply Service Pack"
 #~ msgstr "Εφαρμογή Service Pack"
@@ -6549,11 +6549,11 @@ msgstr "Domain name"
 #~ "αλλά δεν απαιτεί μια έγκυρη σύνδεση."
 
 #, fuzzy
-msgid "CIFS Share"
+msgid "SMB Share"
 msgstr "UNIX Share"
 
 #, fuzzy
-msgid "CIFS Shares"
+msgid "SMB Shares"
 msgstr "UNIX Shares"
 
 #, fuzzy
@@ -9937,10 +9937,10 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 "Ο κωδικός πρόσβασης περιέχει ένα ερωτηματικό (?) προς το παρόν αυτό δεν "
-"επιτρέπεται λόγω δημιουργίας προβλημάτων στο CIFS. "
+"επιτρέπεται λόγω δημιουργίας προβλημάτων στο SMB. "
 
 #: directoryservice/forms.py:104
 #, fuzzy
@@ -10632,7 +10632,7 @@ msgstr "Kerberos Αρχείο Keytab"
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%s ενημερώθηκε(αν) με επιτυχία."
 
 #: sharing/models.py:290
@@ -13761,7 +13761,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/en_GB/LC_MESSAGES/django.po
+++ b/gui/locale/en_GB/LC_MESSAGES/django.po
@@ -1313,8 +1313,8 @@ msgid "This field is required for \"Home directories\"."
 msgstr "This field is required for \"Home directories\"."
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
-msgstr "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
+msgstr "The SMB service failed to reload."
 
 #: services/forms.py:118
 msgid "The AFP service failed to reload."
@@ -1758,10 +1758,10 @@ msgstr "Unix Extensions"
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 
 #: services/models.py:171
@@ -1799,17 +1799,17 @@ msgstr "Zeroconf share discovery"
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "Server Name"
@@ -3239,11 +3239,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr "These parameters are added to [Share] section of smb.conf"
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5408,7 +5408,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5664,7 +5664,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5688,19 +5688,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -9318,7 +9318,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -10002,7 +10002,7 @@ msgstr "Number of servers"
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%s successfully updated."
 
 #: sharing/models.py:290
@@ -13041,7 +13041,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/en_ZA/LC_MESSAGES/django.po
+++ b/gui/locale/en_ZA/LC_MESSAGES/django.po
@@ -1342,7 +1342,7 @@ msgid "This field is required for \"Home directories\"."
 msgstr ""
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr ""
 
 #: services/forms.py:118
@@ -1775,7 +1775,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1812,13 +1812,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:203
@@ -3168,11 +3168,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5286,7 +5286,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5546,7 +5546,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5570,19 +5570,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -8939,7 +8939,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -9575,7 +9575,7 @@ msgid "Kerberos Realm"
 msgstr ""
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr ""
 
 #: sharing/models.py:290
@@ -12351,7 +12351,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/es/LC_MESSAGES/django.po
+++ b/gui/locale/es/LC_MESSAGES/django.po
@@ -1340,8 +1340,8 @@ msgid "This field is required for \"Home directories\"."
 msgstr "Este campo es obligatorio para \"Directorios home\""
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
-msgstr "El servicio CIFS ha fallado en la recarga."
+msgid "The SMB service failed to reload."
+msgstr "El servicio SMB ha fallado en la recarga."
 
 #: services/forms.py:118
 msgid "The AFP service failed to reload."
@@ -1812,7 +1812,7 @@ msgstr "Extensiones Unix"
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 "Esta extension permite a SAMBA servir mejor a clientes UNIX que soporten "
@@ -1855,17 +1855,17 @@ msgstr "Descubrir automaticamente compartidos con Zeroconf"
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 "El soporte Zeroconf via Avahi permite el descubrimiento automatico de "
-"compartidos windows (CIFS) de forma parecida a como lo hace Windows con "
+"compartidos windows (SMB) de forma parecida a como lo hace Windows con "
 "\"Explorar la red\" "
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "Nombre del Servidor"
@@ -3281,12 +3281,12 @@ msgstr ""
 "Estos parametros son añadidos a la seccion [Share] del fichero smb.conf"
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
-msgstr "Compartidos de Windows (CIFS) SAMBA"
+msgid "Windows (SMB) Share"
+msgstr "Compartidos de Windows (SMB) SAMBA"
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
-msgstr "Compartidos de Windows (CIFS) SAMBA"
+msgid "Windows (SMB) Shares"
+msgstr "Compartidos de Windows (SMB) SAMBA"
 
 #: sharing/models.py:114
 msgid ""
@@ -3426,7 +3426,7 @@ msgstr ""
 #~ msgstr ""
 #~ "Si se selecciona AFPD, se usa la ID almacenada en las cabeceras AppleDouble "
 #~ "V2 para reducir la carga de la BBDD. No usar esta opción si el volumen es "
-#~ "modificado por clientes que no sean AFP Ej: NFS/SMB/CIFS/Local)"
+#~ "modificado por clientes que no sean AFP Ej: NFS/SMB/SMB/Local)"
 
 #~ msgid "Translate CR/LF"
 #~ msgstr "Convertir los CR/LF"
@@ -5409,8 +5409,8 @@ msgstr "Configuración AFP"
 #~ msgstr "Configuración AD"
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
-msgstr "Configuración CIFS"
+msgid "SMB Settings"
+msgstr "Configuración SMB"
 
 #: templates/services/core.html:45
 msgid "Dynamic DNS Settings"
@@ -5630,8 +5630,8 @@ msgid "UNIX (NFS)"
 msgstr "NFS (Unix)"
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
-msgstr "SAMBA (CIFS)"
+msgid "Windows (SMB)"
+msgstr "SAMBA (SMB)"
 
 #~ msgid "There are no active UNIX (NFS) shares."
 #~ msgstr "No hay compartidos NFS (Unix)"
@@ -5648,16 +5648,16 @@ msgstr "SAMBA (CIFS)"
 #~ msgid "Add UNIX (NFS) Share"
 #~ msgstr "Añadir Compartidos NFS (Unix)"
 
-#~ msgid "There are no active Windows (CIFS) shares."
+#~ msgid "There are no active Windows (SMB) shares."
 #~ msgstr "No hay compartidos SAMBA activos"
 
-#~ msgid "Edit Windows (CIFS) Share"
+#~ msgid "Edit Windows (SMB) Share"
 #~ msgstr "Editar Compartidos SAMBA"
 
-#~ msgid "Delete Windows (CIFS) Share"
+#~ msgid "Delete Windows (SMB) Share"
 #~ msgstr "Borrar Compartidos SAMBA"
 
-#~ msgid "Add Windows (CIFS) Share"
+#~ msgid "Add Windows (SMB) Share"
 #~ msgstr "Añadir Compartidos SAMBA"
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -6320,8 +6320,8 @@ msgstr "Alertas críticas"
 #~ msgid "Plugins path"
 #~ msgstr "Ruta de los Plugins"
 
-#~ msgid "Add Apple (CIFS) Share"
-#~ msgstr "Añadir Compartido CIFS (Apple)"
+#~ msgid "Add Apple (SMB) Share"
+#~ msgstr "Añadir Compartido SMB (Apple)"
 
 #~ msgid "Apply Service Pack"
 #~ msgstr "Aplicar Service Pack"
@@ -6431,11 +6431,11 @@ msgstr "Alertas críticas"
 #~ "Este usuario debe existir en el archivo de contraseña, pero no requiere "
 #~ "un inicio de sesión válido."
 
-#~ msgid "CIFS Share"
-#~ msgstr "Compartido CIFS"
+#~ msgid "SMB Share"
+#~ msgstr "Compartido SMB"
 
-#~ msgid "CIFS Shares"
-#~ msgstr "Compartidos CIFS"
+#~ msgid "SMB Shares"
+#~ msgstr "Compartidos SMB"
 
 #~ msgid "NFS Share"
 #~ msgstr "Editar Compartidos NFS (Unix)"
@@ -9723,10 +9723,10 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 "Las contraseñas que contienen un signo de interrogación (?) Actualmente no "
-"se permiten debido a problemas con CIFS.                "
+"se permiten debido a problemas con SMB.                "
 
 #: directoryservice/forms.py:104
 msgid "NT4 failed to reload."
@@ -10445,7 +10445,7 @@ msgstr "Reino Kerberos"
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%s ha sido actualizado correctamente."
 
 #: sharing/models.py:290
@@ -13570,7 +13570,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/et/LC_MESSAGES/django.po
+++ b/gui/locale/et/LC_MESSAGES/django.po
@@ -1342,7 +1342,7 @@ msgid "This field is required for \"Home directories\"."
 msgstr ""
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr ""
 
 #: services/forms.py:118
@@ -1775,7 +1775,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1812,13 +1812,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:203
@@ -3168,11 +3168,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5286,7 +5286,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5546,7 +5546,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5570,19 +5570,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -8939,7 +8939,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -9575,7 +9575,7 @@ msgid "Kerberos Realm"
 msgstr ""
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr ""
 
 #: sharing/models.py:290
@@ -12351,7 +12351,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/eu/LC_MESSAGES/django.po
+++ b/gui/locale/eu/LC_MESSAGES/django.po
@@ -1342,7 +1342,7 @@ msgid "This field is required for \"Home directories\"."
 msgstr ""
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr ""
 
 #: services/forms.py:118
@@ -1775,7 +1775,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1812,13 +1812,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:203
@@ -3168,11 +3168,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5286,7 +5286,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5546,7 +5546,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5570,19 +5570,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -8939,7 +8939,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -9575,7 +9575,7 @@ msgid "Kerberos Realm"
 msgstr ""
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr ""
 
 #: sharing/models.py:290
@@ -12351,7 +12351,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/fa/LC_MESSAGES/django.po
+++ b/gui/locale/fa/LC_MESSAGES/django.po
@@ -1351,7 +1351,7 @@ msgid "This field is required for \"Home directories\"."
 msgstr ""
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr ""
 
 #: services/forms.py:118
@@ -1785,7 +1785,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1822,13 +1822,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:203
@@ -3178,11 +3178,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5303,7 +5303,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5564,7 +5564,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5588,19 +5588,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -9135,7 +9135,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -9809,7 +9809,7 @@ msgstr ""
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%s تکمیل عملیات بروز رسانی"
 
 #: sharing/models.py:290
@@ -12792,7 +12792,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/fi/LC_MESSAGES/django.po
+++ b/gui/locale/fi/LC_MESSAGES/django.po
@@ -1341,7 +1341,7 @@ msgid "This field is required for \"Home directories\"."
 msgstr ""
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr ""
 
 #: services/forms.py:118
@@ -1775,7 +1775,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1812,13 +1812,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:203
@@ -3170,11 +3170,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5296,7 +5296,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5561,7 +5561,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5585,19 +5585,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -9012,7 +9012,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -9657,7 +9657,7 @@ msgid "Kerberos Realm"
 msgstr ""
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr ""
 
 #: sharing/models.py:290
@@ -12522,7 +12522,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/fr/LC_MESSAGES/django.po
+++ b/gui/locale/fr/LC_MESSAGES/django.po
@@ -1349,8 +1349,8 @@ msgid "This field is required for \"Home directories\"."
 msgstr "Ce champ est nécessaire pour \"Dossiers personnels\"."
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
-msgstr "Le rechargement du service CIFS a échoué."
+msgid "The SMB service failed to reload."
+msgstr "Le rechargement du service SMB a échoué."
 
 #: services/forms.py:118
 msgid "The AFP service failed to reload."
@@ -1810,10 +1810,10 @@ msgstr "Extensions Unix"
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
-"Ces extensions permettent à Samba de mieux servir les clients CIFS UNIX en "
+"Ces extensions permettent à Samba de mieux servir les clients SMB UNIX en "
 "supportant des fonctionnalités telles que les liens symboliques, liens "
 "physiques, etc ..."
 
@@ -1854,17 +1854,17 @@ msgstr "Découverte zeroconf du partage"
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 "Le support zeroconf via Avahi permet aux clients (le finder MAC OSX en "
-"particulier) de découvrir automatique des partages CIFS du système de façon "
+"particulier) de découvrir automatique des partages SMB du système de façon "
 "similaire au service \"Explorateur d'ordinateurs\" de Windows."
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "Nom du serveur"
@@ -3335,12 +3335,12 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr "Ces paramètres sont ajoutés à la section [Share] de smb.conf"
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
-msgstr "Partage Windows (CIFS)"
+msgid "Windows (SMB) Share"
+msgstr "Partage Windows (SMB)"
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
-msgstr "Partages Windows (CIFS)"
+msgid "Windows (SMB) Shares"
+msgstr "Partages Windows (SMB)"
 
 # Les termes sont à vérifier avec ceux réellement utilisés sur Macintosh
 #: sharing/models.py:114
@@ -3483,7 +3483,7 @@ msgstr ""
 #~ msgstr ""
 #~ "Si activé, afpd utilise l'ID stocké dans les entêtes des fichiers "
 #~ "AppleDouble V2 pour réduire la charge de la base de données. Ne pas activer "
-#~ "cette option si le volume est modifié par des clients non AFP (NFS/CIFS/"
+#~ "cette option si le volume est modifié par des clients non AFP (NFS/SMB/"
 #~ "Local)."
 
 #~ msgid "Translate CR/LF"
@@ -5482,8 +5482,8 @@ msgstr "Paramètres AFP"
 #~ msgstr "Paramètres Active Directory"
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
-msgstr "Paramètres CIFS"
+msgid "SMB Settings"
+msgstr "Paramètres SMB"
 
 #: templates/services/core.html:45
 msgid "Dynamic DNS Settings"
@@ -5705,8 +5705,8 @@ msgid "UNIX (NFS)"
 msgstr "UNIX (NFS)"
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
-msgstr "Windows (CIFS)"
+msgid "Windows (SMB)"
+msgstr "Windows (SMB)"
 
 #~ msgid "There are no active UNIX (NFS) shares."
 #~ msgstr "Aucun partage UNIX (NFS) n'est actif."
@@ -5723,17 +5723,17 @@ msgstr "Windows (CIFS)"
 #~ msgid "Add UNIX (NFS) Share"
 #~ msgstr "Ajouter un partage UNIX (NFS)"
 
-#~ msgid "There are no active Windows (CIFS) shares."
-#~ msgstr "Aucun partage Windows (CIFS) n'est actif."
+#~ msgid "There are no active Windows (SMB) shares."
+#~ msgstr "Aucun partage Windows (SMB) n'est actif."
 
-#~ msgid "Edit Windows (CIFS) Share"
-#~ msgstr "Modifier le partage Windows (CIFS)"
+#~ msgid "Edit Windows (SMB) Share"
+#~ msgstr "Modifier le partage Windows (SMB)"
 
-#~ msgid "Delete Windows (CIFS) Share"
-#~ msgstr "Supprimer le partage Windows (CIFS)"
+#~ msgid "Delete Windows (SMB) Share"
+#~ msgstr "Supprimer le partage Windows (SMB)"
 
-#~ msgid "Add Windows (CIFS) Share"
-#~ msgstr "Ajouter un partage Windows (CIFS)"
+#~ msgid "Add Windows (SMB) Share"
+#~ msgstr "Ajouter un partage Windows (SMB)"
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
 msgid "Clone Snapshot"
@@ -6396,8 +6396,8 @@ msgstr "Alertes critiques"
 #~ msgid "Plugins path"
 #~ msgstr "Chemin des modules"
 
-#~ msgid "Add Apple (CIFS) Share"
-#~ msgstr "Ajouter un partage Apple (CIFS)"
+#~ msgid "Add Apple (SMB) Share"
+#~ msgstr "Ajouter un partage Apple (SMB)"
 
 #~ msgid "Apply Service Pack"
 #~ msgstr "Appliquer le Service Pack"
@@ -6514,11 +6514,11 @@ msgstr "Alertes critiques"
 #~ "exister dans le fichier de mot de passe, mais ne nécessite pas une "
 #~ "connexion valide."
 
-#~ msgid "CIFS Share"
-#~ msgstr "Partage CIFS"
+#~ msgid "SMB Share"
+#~ msgstr "Partage SMB"
 
-#~ msgid "CIFS Shares"
-#~ msgstr "Partages CIFS"
+#~ msgid "SMB Shares"
+#~ msgstr "Partages SMB"
 
 #~ msgid "NFS Share"
 #~ msgstr "Partage NFS"
@@ -9871,10 +9871,10 @@ msgstr "Activer la cible expérimentale"
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 "Les mots de passe contenant un point d'interrogation (?) ne sont "
-"actuellement pas autorisés à cause de problèmes avec CIFS."
+"actuellement pas autorisés à cause de problèmes avec SMB."
 
 #: directoryservice/forms.py:104
 msgid "NT4 failed to reload."
@@ -10588,8 +10588,8 @@ msgid "Kerberos Realm"
 msgstr "Fichier Keytab pour Kerberos"
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
-msgstr "CIFS a été mis à jour avec succès."
+msgid "SMB successfully updated."
+msgstr "SMB a été mis à jour avec succès."
 
 #: sharing/models.py:290
 msgid "Security"
@@ -13721,7 +13721,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/fur/LC_MESSAGES/django.po
+++ b/gui/locale/fur/LC_MESSAGES/django.po
@@ -1342,7 +1342,7 @@ msgid "This field is required for \"Home directories\"."
 msgstr ""
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr ""
 
 #: services/forms.py:118
@@ -1775,7 +1775,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1812,13 +1812,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:203
@@ -3168,11 +3168,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5286,7 +5286,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5546,7 +5546,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5570,19 +5570,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -8939,7 +8939,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -9575,7 +9575,7 @@ msgid "Kerberos Realm"
 msgstr ""
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr ""
 
 #: sharing/models.py:290
@@ -12351,7 +12351,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/gl/LC_MESSAGES/django.po
+++ b/gui/locale/gl/LC_MESSAGES/django.po
@@ -1351,7 +1351,7 @@ msgid "This field is required for \"Home directories\"."
 msgstr ""
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr ""
 
 #: services/forms.py:118
@@ -1785,7 +1785,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1822,13 +1822,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:203
@@ -3179,11 +3179,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5304,7 +5304,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5565,7 +5565,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5589,19 +5589,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -9002,7 +9002,7 @@ msgstr "Cargador"
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -9656,7 +9656,7 @@ msgid "Kerberos Realm"
 msgstr ""
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr ""
 
 #: sharing/models.py:290
@@ -12476,7 +12476,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/he/LC_MESSAGES/django.po
+++ b/gui/locale/he/LC_MESSAGES/django.po
@@ -1361,7 +1361,7 @@ msgstr "השדה נדרש ל\"תיקיות הבית\"."
 
 #: services/forms.py:106
 #, fuzzy
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr "שירות הNFS נכשל להיטען מחדש"
 
 #: services/forms.py:118
@@ -1808,7 +1808,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1851,14 +1851,14 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "שם השרת"
@@ -3283,12 +3283,12 @@ msgstr "המאפיינים האלו מוספים ל(שיתוף) חלק של smb.
 
 #: sharing/models.py:94
 #, fuzzy
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr "שיתוף חלונות "
 
 #: sharing/models.py:95
 #, fuzzy
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr "שיתופי חלונות (ווינדוס)"
 
 #: sharing/models.py:114
@@ -5453,8 +5453,8 @@ msgstr "הגדרות AFP"
 #~ msgstr "הגדרות תיקייה פעילה"
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
-msgstr "הגדרות CIFS"
+msgid "SMB Settings"
+msgstr "הגדרות SMB"
 
 #: templates/services/core.html:45
 msgid "Dynamic DNS Settings"
@@ -5711,8 +5711,8 @@ msgstr "הוסף שיתוף UNIX (NFS)"
 
 #: templates/sharing/index.html:12
 #, fuzzy
-msgid "Windows (CIFS)"
-msgstr "הוסף שיתוף חלונות (CIFS)"
+msgid "Windows (SMB)"
+msgstr "הוסף שיתוף חלונות (SMB)"
 
 #: templates/sharing/unix.html:7
 #, fuzzy
@@ -5739,22 +5739,22 @@ msgstr "הוסף שיתוף UNIX"
 
 #: templates/sharing/windows.html:7
 #, fuzzy
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr "אין שום שיתופי חלונות פעילים."
 
 #: templates/sharing/windows.html:33
 #, fuzzy
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr "ערוך שיתוף חלונות"
 
 #: templates/sharing/windows.html:39
 #, fuzzy
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr "מחק שיתוף חלונות"
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
 #, fuzzy
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr "הוסף שיתוף חלונות"
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -6436,7 +6436,7 @@ msgstr "ראה את כל המשתמשים"
 #~ msgstr "סגור"
 
 #, fuzzy
-msgid "Add Apple (CIFS) Share"
+msgid "Add Apple (SMB) Share"
 msgstr "הוסף שיתוף אפל"
 
 #~ msgid "Apply Service Pack"
@@ -6542,11 +6542,11 @@ msgstr "הוסף שיתוף אפל"
 #~ "מצליח כניסה חוקית."
 
 #, fuzzy
-msgid "CIFS Share"
+msgid "SMB Share"
 msgstr "שיתוף UNIX"
 
 #, fuzzy
-msgid "CIFS Shares"
+msgid "SMB Shares"
 msgstr "שיתופי UNIX"
 
 #, fuzzy
@@ -9873,7 +9873,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -10564,7 +10564,7 @@ msgstr "קובץ Kerberos Keytab"
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%S עודכן בהצלחה."
 
 #: sharing/models.py:290
@@ -13653,7 +13653,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/hi/LC_MESSAGES/django.po
+++ b/gui/locale/hi/LC_MESSAGES/django.po
@@ -1342,7 +1342,7 @@ msgid "This field is required for \"Home directories\"."
 msgstr ""
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr ""
 
 #: services/forms.py:118
@@ -1775,7 +1775,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1812,13 +1812,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:203
@@ -3168,11 +3168,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5286,7 +5286,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5546,7 +5546,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5570,19 +5570,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -8939,7 +8939,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -9575,7 +9575,7 @@ msgid "Kerberos Realm"
 msgstr ""
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr ""
 
 #: sharing/models.py:290
@@ -12351,7 +12351,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/hr/LC_MESSAGES/django.po
+++ b/gui/locale/hr/LC_MESSAGES/django.po
@@ -1346,8 +1346,8 @@ msgid "This field is required for \"Home directories\"."
 msgstr "Ovo polje je obavezno za \"Korisničke mape\"."
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
-msgstr "CIFS servis se nije uspio učitati."
+msgid "The SMB service failed to reload."
+msgstr "SMB servis se nije uspio učitati."
 
 #: services/forms.py:118
 msgid "The AFP service failed to reload."
@@ -1802,7 +1802,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1845,14 +1845,14 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "Naziv poslužitelja"
@@ -3217,11 +3217,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5360,7 +5360,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5630,7 +5630,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5654,19 +5654,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -9408,7 +9408,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -10088,7 +10088,7 @@ msgstr "Broj poslužitelja"
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%s je uspješno promijenjen."
 
 #: sharing/models.py:290
@@ -13121,7 +13121,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/hu/LC_MESSAGES/django.po
+++ b/gui/locale/hu/LC_MESSAGES/django.po
@@ -1361,8 +1361,8 @@ msgid "This field is required for \"Home directories\"."
 msgstr "Kötelező mező a \"Saját könyvtárak\" eléréséhez"
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
-msgstr "Az CIFS szolgáltatás újraindítása nem sikerült."
+msgid "The SMB service failed to reload."
+msgstr "Az SMB szolgáltatás újraindítása nem sikerült."
 
 #: services/forms.py:118
 msgid "The AFP service failed to reload."
@@ -1817,7 +1817,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1858,14 +1858,14 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "Szerver neve"
@@ -3271,12 +3271,12 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr "Ezek a paraméterek az smb.conf fájl [Share] részéhez adódnak."
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
-msgstr "Windows (CIFS) megosztás"
+msgid "Windows (SMB) Share"
+msgstr "Windows (SMB) megosztás"
 
 #: sharing/models.py:95
 #, fuzzy
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr "Windows megosztások"
 
 #: sharing/models.py:114
@@ -5439,7 +5439,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5704,7 +5704,7 @@ msgstr ""
 
 #: templates/sharing/index.html:12
 #, fuzzy
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr "Windows megosztás"
 
 #~ msgid "There are no active UNIX (NFS) shares."
@@ -5727,22 +5727,22 @@ msgstr "UNIX megosztás"
 msgid "Add UNIX (NFS) Share"
 msgstr "UNIX megosztás"
 
-#~ msgid "There are no active Windows (CIFS) shares."
-#~ msgstr "Nincs aktív Windows(CIFS) megosztás"
+#~ msgid "There are no active Windows (SMB) shares."
+#~ msgstr "Nincs aktív Windows(SMB) megosztás"
 
 #: templates/sharing/windows.html:33
 #, fuzzy
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr "Windows megosztás"
 
 #: templates/sharing/windows.html:39
 #, fuzzy
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr "Windows megosztás"
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
 #, fuzzy
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr "Windows megosztás"
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -6366,7 +6366,7 @@ msgid "View Tunables"
 msgstr "Minden felhasználó mutatása"
 
 #, fuzzy
-msgid "Add Apple (CIFS) Share"
+msgid "Add Apple (SMB) Share"
 msgstr "UNIX megosztás"
 
 #~ msgid "Hourly"
@@ -6438,7 +6438,7 @@ msgstr "UNIX megosztás"
 #~ "bejelentkezési engedély."
 
 #, fuzzy
-msgid "CIFS Shares"
+msgid "SMB Shares"
 msgstr "UNIX karakterkészlet"
 
 #~ msgid "NTP server 2"
@@ -9489,9 +9489,9 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
-"A CIFS korlátozásai miatt a kérdőjelet(?) tartalmazó jelszavak tiltottak."
+"A SMB korlátozásai miatt a kérdőjelet(?) tartalmazó jelszavak tiltottak."
 
 #: directoryservice/forms.py:104
 #, fuzzy
@@ -10179,7 +10179,7 @@ msgstr "Kiszolgálók száma"
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%s sikeresen frissítve."
 
 #: sharing/models.py:290
@@ -13271,7 +13271,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/id/LC_MESSAGES/django.po
+++ b/gui/locale/id/LC_MESSAGES/django.po
@@ -1362,7 +1362,7 @@ msgstr "Kolom ini diperlukan untuk \"Direktori home\"."
 
 #: services/forms.py:106
 #, fuzzy
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr "Servis NFS gagal untuk memuat ulang."
 
 #: services/forms.py:118
@@ -1819,7 +1819,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1862,14 +1862,14 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "Nama Server"
@@ -3345,12 +3345,12 @@ msgstr "Parameter tersebut ditambahkan ke bagian [Share] pada smb.conf"
 
 #: sharing/models.py:94
 #, fuzzy
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr "Berbagi Windows"
 
 #: sharing/models.py:95
 #, fuzzy
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr "Berbagi Windows"
 
 #: sharing/models.py:114
@@ -5559,8 +5559,8 @@ msgstr "Pengaturan AFP"
 #~ msgstr "Pengaturan Direktori Aktif"
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
-msgstr "Pengaturan CIFS"
+msgid "SMB Settings"
+msgstr "Pengaturan SMB"
 
 #: templates/services/core.html:45
 msgid "Dynamic DNS Settings"
@@ -5817,8 +5817,8 @@ msgstr "Tambahkan Berbagi UNIX (NFS)"
 
 #: templates/sharing/index.html:12
 #, fuzzy
-msgid "Windows (CIFS)"
-msgstr "Tambahkan Berbagi Windows (CIFS)"
+msgid "Windows (SMB)"
+msgstr "Tambahkan Berbagi Windows (SMB)"
 
 #: templates/sharing/unix.html:7
 #, fuzzy
@@ -5845,22 +5845,22 @@ msgstr "Tambahkan Berbagi UNIX"
 
 #: templates/sharing/windows.html:7
 #, fuzzy
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr "Tidak ada Berbagi Windows yang aktif disini."
 
 #: templates/sharing/windows.html:33
 #, fuzzy
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr "Sunting Berbagi Windows"
 
 #: templates/sharing/windows.html:39
 #, fuzzy
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr "Hapus Berbagi Windows"
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
 #, fuzzy
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr "Tambahkan Berbagi Windows"
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -6552,7 +6552,7 @@ msgstr "Lihat Semua Pengguna"
 #~ msgstr "Tutup"
 
 #, fuzzy
-msgid "Add Apple (CIFS) Share"
+msgid "Add Apple (SMB) Share"
 msgstr "Tambahkan Berbagi Apple"
 
 #~ msgid "Apply Service Pack"
@@ -6664,11 +6664,11 @@ msgstr "Tambahkan Berbagi Apple"
 #~ "login yang valid."
 
 #, fuzzy
-msgid "CIFS Share"
+msgid "SMB Share"
 msgstr "Berbagi UNIX"
 
 #, fuzzy
-msgid "CIFS Shares"
+msgid "SMB Shares"
 msgstr "Berbagi UNIX"
 
 #, fuzzy
@@ -9880,7 +9880,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -10571,7 +10571,7 @@ msgstr "Jumlah server"
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%s berhasil diperbaharui."
 
 #: sharing/models.py:290
@@ -13672,7 +13672,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/is/LC_MESSAGES/django.po
+++ b/gui/locale/is/LC_MESSAGES/django.po
@@ -1376,7 +1376,7 @@ msgstr "Þessi reitur er skilyrði fyrir \"Heima möppur\"."
 
 #: services/forms.py:106
 #, fuzzy
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr "Ekki tókst að endurhlaða iSCSI þjónustu."
 
 #: services/forms.py:118
@@ -1819,7 +1819,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1856,13 +1856,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:203
@@ -3233,11 +3233,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5396,7 +5396,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5666,7 +5666,7 @@ msgstr ""
 
 #: templates/sharing/index.html:12
 #, fuzzy
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr "Windows"
 
 #: templates/sharing/unix.html:7
@@ -5695,19 +5695,19 @@ msgstr "Bæta við Deilingum"
 
 #: templates/sharing/windows.html:7
 #, fuzzy
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr "Það eru engar virkar UNIX Deilingar"
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -6347,7 +6347,7 @@ msgid "View Tunables"
 msgstr "Skoða alla notendur"
 
 #, fuzzy
-msgid "Add Apple (CIFS) Share"
+msgid "Add Apple (SMB) Share"
 msgstr "Bæta við Apple Deilingu"
 
 #~ msgid "DVD"
@@ -9354,7 +9354,7 @@ msgstr "Bæta við Gátt"
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -10033,7 +10033,7 @@ msgstr "Fjöldi þjóna"
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%s hefur verið uppfært."
 
 #: sharing/models.py:290
@@ -13000,7 +13000,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/it/LC_MESSAGES/django.po
+++ b/gui/locale/it/LC_MESSAGES/django.po
@@ -1353,8 +1353,8 @@ msgid "This field is required for \"Home directories\"."
 msgstr "Questo campo è obbligatorio per \"directory base\"."
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
-msgstr "Riavvio del servizio CIFS fallito."
+msgid "The SMB service failed to reload."
+msgstr "Riavvio del servizio SMB fallito."
 
 #: services/forms.py:118
 msgid "The AFP service failed to reload."
@@ -1821,10 +1821,10 @@ msgstr "Estensioni Unix"
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
-"Queste estensioni consentono a Samba di servire meglio i client UNIX CIFS "
+"Queste estensioni consentono a Samba di servire meglio i client UNIX SMB "
 "supportando caratteristiche come link simbolici, hard link, ecc..."
 
 #: services/models.py:171
@@ -1864,17 +1864,17 @@ msgstr "Discovery di condivisioni Zeroconf"
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 "Il supporto Zeroconf tramite Avahi consente ai client (Mac OSX finder in "
-"particolare) di scoprire le condivisioni CIFS sul sistema in modo simile al "
+"particolare) di scoprire le condivisioni SMB sul sistema in modo simile al "
 "servizio Esplora Risorse di Windows"
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "Nome server"
@@ -3351,12 +3351,12 @@ msgstr ""
 "Questi parametri saranno aggiunti alla sezione [Share] del file smb.conf"
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
-msgstr "Elemento condiviso di Windows (CIFS)"
+msgid "Windows (SMB) Share"
+msgstr "Elemento condiviso di Windows (SMB)"
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
-msgstr "Elementi condivisi di Windows (CIFS)"
+msgid "Windows (SMB) Shares"
+msgstr "Elementi condivisi di Windows (SMB)"
 
 #: sharing/models.py:114
 msgid ""
@@ -5521,8 +5521,8 @@ msgstr "Impostazioni AFP"
 #~ msgstr "Impostazioni Active Directory"
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
-msgstr "Impostazioni CIFS"
+msgid "SMB Settings"
+msgstr "Impostazioni SMB"
 
 #: templates/services/core.html:45
 msgid "Dynamic DNS Settings"
@@ -5778,8 +5778,8 @@ msgstr "Aggiungi condivisione UNIX (NFS)"
 
 #: templates/sharing/index.html:12
 #, fuzzy
-msgid "Windows (CIFS)"
-msgstr "Aggiungi condivisione Windows (CIFS)"
+msgid "Windows (SMB)"
+msgstr "Aggiungi condivisione Windows (SMB)"
 
 #: templates/sharing/unix.html:7
 #, fuzzy
@@ -5806,22 +5806,22 @@ msgstr "Aggiungi condivisione UNIX"
 
 #: templates/sharing/windows.html:7
 #, fuzzy
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr "Non ci sono condivisioni WIndows attive."
 
 #: templates/sharing/windows.html:33
 #, fuzzy
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr "Modifica condivisione Windows"
 
 #: templates/sharing/windows.html:39
 #, fuzzy
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr "Elimina condivisione WIndows"
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
 #, fuzzy
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr "Aggiungi condivisione Windows"
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -6499,7 +6499,7 @@ msgstr "Mostra Chiave Pubblica"
 #~ msgstr "Chiudi"
 
 #, fuzzy
-msgid "Add Apple (CIFS) Share"
+msgid "Add Apple (SMB) Share"
 msgstr "Aggiungi Condivisione Apple"
 
 #~ msgid "Apply Service Pack"
@@ -6612,11 +6612,11 @@ msgstr "Aggiungi Condivisione Apple"
 #~ "client connesso al servizio come guest. Questo utente deve esistere nel "
 #~ "file delle password, ma non richiede un account valido."
 
-#~ msgid "CIFS Share"
-#~ msgstr "Condivisione CIFS"
+#~ msgid "SMB Share"
+#~ msgstr "Condivisione SMB"
 
-#~ msgid "CIFS Shares"
-#~ msgstr "Condivisioni CIFS"
+#~ msgid "SMB Shares"
+#~ msgstr "Condivisioni SMB"
 
 #~ msgid "NFS Share"
 #~ msgstr "Condivisione NFS"
@@ -9969,10 +9969,10 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 "Le password che contengono un punto interrogativo (?) non sono attualmente "
-"permesse a causa di problemi con CIFS.                "
+"permesse a causa di problemi con SMB.                "
 
 #: directoryservice/forms.py:104
 msgid "NT4 failed to reload."
@@ -10674,7 +10674,7 @@ msgstr "Kerberos keytab file"
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%s aggiornato con successo."
 
 #: sharing/models.py:290
@@ -13797,7 +13797,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/ja/LC_MESSAGES/django.po
+++ b/gui/locale/ja/LC_MESSAGES/django.po
@@ -1369,7 +1369,7 @@ msgid "This field is required for \"Home directories\"."
 msgstr "この項目は、\"ホームディレクトリ\" のために必須です。"
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr "NFS サービスを再開できませんでした。"
 
 #: services/forms.py:118
@@ -1837,9 +1837,9 @@ msgstr "UNIX形式"
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
-msgstr "この拡張はSambaをUNIX CIFSクライアントにシンボリックリンクやハードリンクリンクなどを提供するために有効になっています"
+msgstr "この拡張はSambaをUNIX SMBクライアントにシンボリックリンクやハードリンクリンクなどを提供するために有効になっています"
 
 #: services/models.py:171
 msgid "Enable AIO"
@@ -1881,16 +1881,16 @@ msgstr "Zeroconf 共有探索"
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 "Zeroconf は Avahi 経由でのクライアント（主にMac "
-"OSXのファインダーなど）に、自動的にCIFS共有フォルダをWindows上と同様に発見できるようにします。"
+"OSXのファインダーなど）に、自動的にSMB共有フォルダをWindows上と同様に発見できるようにします。"
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "サーバ名"
@@ -3399,12 +3399,12 @@ msgstr ""
 
 #: sharing/models.py:94
 #, fuzzy
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr "Windowsファイル共有"
 
 #: sharing/models.py:95
 #, fuzzy
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr "Windowsファイル共有"
 
 # 流暢な日本語にできなかった。しばらくこのまま晒して何か提案がなければ確定します。
@@ -5669,8 +5669,8 @@ msgstr "AFP の設定"
 #~ msgstr "Active Directory の設定"
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
-msgstr "CIFS の設定"
+msgid "SMB Settings"
+msgstr "SMB の設定"
 
 #: templates/services/core.html:45
 msgid "Dynamic DNS Settings"
@@ -5908,8 +5908,8 @@ msgid "UNIX (NFS)"
 msgstr "UNIX(NFS)"
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
-msgstr "Windows共有(CIFS)"
+msgid "Windows (SMB)"
+msgstr "Windows共有(SMB)"
 
 #~ msgid "There are no active UNIX (NFS) shares."
 #~ msgstr "有効な Unix ファイル共有（ＮＦＳ）はありません。"
@@ -5926,17 +5926,17 @@ msgstr "Windows共有(CIFS)"
 #~ msgid "Add UNIX (NFS) Share"
 #~ msgstr "UNIX共有を追加"
 
-#~ msgid "There are no active Windows (CIFS) shares."
+#~ msgid "There are no active Windows (SMB) shares."
 #~ msgstr "有効なWindows ファイル共有はありません。"
 
-#~ msgid "Edit Windows (CIFS) Share"
+#~ msgid "Edit Windows (SMB) Share"
 #~ msgstr "Windows共有を編集"
 
-#~ msgid "Delete Windows (CIFS) Share"
-#~ msgstr "Windows共有(CIFS)を削除"
+#~ msgid "Delete Windows (SMB) Share"
+#~ msgstr "Windows共有(SMB)を削除"
 
-#~ msgid "Add Windows (CIFS) Share"
-#~ msgstr "Windows共有(CIFS)を追加"
+#~ msgid "Add Windows (SMB) Share"
+#~ msgstr "Windows共有(SMB)を追加"
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
 msgid "Clone Snapshot"
@@ -6604,7 +6604,7 @@ msgstr "閉じる"
 #~ msgid "Plugins path"
 #~ msgstr "プラグインのパス"
 
-#~ msgid "Add Apple (CIFS) Share"
+#~ msgid "Add Apple (SMB) Share"
 #~ msgstr "Apple（ＣＩＦＳ）共有を追加"
 
 #~ msgid "Apply Service Pack"
@@ -6712,11 +6712,11 @@ msgstr "閉じる"
 #~ "ユーザはパスワードファイル内に必ず記述して下さい。なお、ログイン可能である"
 #~ "必要はありません。"
 
-#~ msgid "CIFS Share"
+#~ msgid "SMB Share"
 #~ msgstr "ＣＩＦＳ共有"
 
-#~ msgid "CIFS Shares"
-#~ msgstr "CIFS共有"
+#~ msgid "SMB Shares"
+#~ msgstr "SMB共有"
 
 #, fuzzy
 msgid "NFS Share"
@@ -10089,7 +10089,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -10788,7 +10788,7 @@ msgstr "ケルベロス認証のキータブファイル"
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%s を正しく更新しました。"
 
 #: sharing/models.py:290
@@ -13909,7 +13909,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/ka/LC_MESSAGES/django.po
+++ b/gui/locale/ka/LC_MESSAGES/django.po
@@ -1352,7 +1352,7 @@ msgid "This field is required for \"Home directories\"."
 msgstr ""
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr ""
 
 #: services/forms.py:118
@@ -1784,7 +1784,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1821,13 +1821,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:203
@@ -3177,11 +3177,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5296,7 +5296,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5556,7 +5556,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5580,19 +5580,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -8953,7 +8953,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -9589,7 +9589,7 @@ msgid "Kerberos Realm"
 msgstr ""
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr ""
 
 #: sharing/models.py:290
@@ -12370,7 +12370,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/ko/LC_MESSAGES/django.po
+++ b/gui/locale/ko/LC_MESSAGES/django.po
@@ -1314,8 +1314,8 @@ msgid "This field is required for \"Home directories\"."
 msgstr "\"홈 디렉토리\"를 위해 필요한 입력란입니다. "
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
-msgstr "CIFS 서비스를 다시 시작하는데 실패하였습니다."
+msgid "The SMB service failed to reload."
+msgstr "SMB 서비스를 다시 시작하는데 실패하였습니다."
 
 #: services/forms.py:118
 msgid "The AFP service failed to reload."
@@ -1742,10 +1742,10 @@ msgstr "유닉스 확장자들"
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
-"이 확장들은 삼바가 UNIX CIFS 클라이언트들에게 심볼릭 링크나 하드 링크등의 기능을 지원함으로써 더 낳은 서비스를 가능하게 합니다."
+"이 확장들은 삼바가 UNIX SMB 클라이언트들에게 심볼릭 링크나 하드 링크등의 기능을 지원함으로써 더 낳은 서비스를 가능하게 합니다."
 
 #: services/models.py:171
 msgid "Enable AIO"
@@ -1780,14 +1780,14 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "서버 이름"
@@ -3162,12 +3162,12 @@ msgstr ""
 
 #: sharing/models.py:94
 #, fuzzy
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr "윈도우 공유 추가"
 
 #: sharing/models.py:95
 #, fuzzy
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr "윈도우 공유 추가"
 
 #: sharing/models.py:114
@@ -5320,7 +5320,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5553,8 +5553,8 @@ msgid "UNIX (NFS)"
 msgstr "유닉스 (NFS)"
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
-msgstr "윈도우 (CIFS)"
+msgid "Windows (SMB)"
+msgstr "윈도우 (SMB)"
 
 #~ msgid "There are no active UNIX (NFS) shares."
 #~ msgstr "현재 활성중인 UNIX 공유(NFS)가 없습니다."
@@ -5571,17 +5571,17 @@ msgstr "윈도우 (CIFS)"
 #~ msgid "Add UNIX (NFS) Share"
 #~ msgstr "UNIX 공유 (NFS) 추가하기"
 
-#~ msgid "There are no active Windows (CIFS) shares."
-#~ msgstr "활성화된 윈도우 공유 (CIFS) 가 없습니다. "
+#~ msgid "There are no active Windows (SMB) shares."
+#~ msgstr "활성화된 윈도우 공유 (SMB) 가 없습니다. "
 
-#~ msgid "Edit Windows (CIFS) Share"
-#~ msgstr "윈도우 공유 (CIFS) 수정하기"
+#~ msgid "Edit Windows (SMB) Share"
+#~ msgstr "윈도우 공유 (SMB) 수정하기"
 
-#~ msgid "Delete Windows (CIFS) Share"
-#~ msgstr "윈도우 공유 (CIFS) 삭제하기"
+#~ msgid "Delete Windows (SMB) Share"
+#~ msgstr "윈도우 공유 (SMB) 삭제하기"
 
-#~ msgid "Add Windows (CIFS) Share"
-#~ msgstr "윈도우 공유(CIFS) 추가하기"
+#~ msgid "Add Windows (SMB) Share"
+#~ msgstr "윈도우 공유(SMB) 추가하기"
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
 msgid "Clone Snapshot"
@@ -6150,8 +6150,8 @@ msgstr "디스크 보기"
 #~ msgid "View Tunables"
 #~ msgstr "Tunables 보기"
 
-#~ msgid "Add Apple (CIFS) Share"
-#~ msgstr "애플 공유 (CIFS) 추가하기"
+#~ msgid "Add Apple (SMB) Share"
+#~ msgstr "애플 공유 (SMB) 추가하기"
 
 #~ msgid "Apply Service Pack"
 #~ msgstr "서비스팩 적용"
@@ -6218,11 +6218,11 @@ msgstr "디스크 보기"
 #~ msgstr "게스트 계정"
 
 #, fuzzy
-msgid "CIFS Share"
+msgid "SMB Share"
 msgstr "NFS 공유 수정"
 
 #, fuzzy
-msgid "CIFS Shares"
+msgid "SMB Shares"
 msgstr "UNIX 공유 추가"
 
 #, fuzzy
@@ -9364,8 +9364,8 @@ msgstr "로더"
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
-msgstr "패스워드에 ? 마크를 포함하고 있어 현재 CIFS 문제를 해결할 수 없습니다."
+"problems with SMB."
+msgstr "패스워드에 ? 마크를 포함하고 있어 현재 SMB 문제를 해결할 수 없습니다."
 
 #: directoryservice/forms.py:104
 #, fuzzy
@@ -10048,7 +10048,7 @@ msgstr "서버 갯수"
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%s을(를) 성공적으로 갱신하였습니다."
 
 #: sharing/models.py:290
@@ -13109,7 +13109,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/lt/LC_MESSAGES/django.po
+++ b/gui/locale/lt/LC_MESSAGES/django.po
@@ -1321,8 +1321,8 @@ msgid "This field is required for \"Home directories\"."
 msgstr "Šis laukas yra būtinas \"Namų katalogui\""
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
-msgstr "Nepavyko perleisti CIFS serviso."
+msgid "The SMB service failed to reload."
+msgstr "Nepavyko perleisti SMB serviso."
 
 #: services/forms.py:118
 msgid "The AFP service failed to reload."
@@ -1759,7 +1759,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1796,14 +1796,14 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "Serverio pavadinimas"
@@ -3165,11 +3165,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5298,7 +5298,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5558,7 +5558,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5582,19 +5582,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -9159,7 +9159,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -9833,7 +9833,7 @@ msgstr "Serverių kiekis"
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%s sėkmingai atnaujintas."
 
 #: sharing/models.py:290
@@ -12802,7 +12802,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/lv/LC_MESSAGES/django.po
+++ b/gui/locale/lv/LC_MESSAGES/django.po
@@ -1322,8 +1322,8 @@ msgid "This field is required for \"Home directories\"."
 msgstr "Šis lauks ir nepieciešams priekš \"Mājas direktorijas\"."
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
-msgstr "CIFS servisam neizdevās startēties."
+msgid "The SMB service failed to reload."
+msgstr "SMB servisam neizdevās startēties."
 
 #: services/forms.py:118
 msgid "The AFP service failed to reload."
@@ -1768,10 +1768,10 @@ msgstr "Unix Paplašinājumi"
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
-"Šie papildinājumi ļauj Sambai labāk apkalpot UNIX CIFS klientus, piedāvājot "
+"Šie papildinājumi ļauj Sambai labāk apkalpot UNIX SMB klientus, piedāvājot "
 "iespējas kā simboliskās saites, cietās saites, citus..."
 
 #: services/models.py:171
@@ -1809,17 +1809,17 @@ msgstr "Zeroconf kopīgojuma atrašana"
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 "Zeroconf atbalsts caur Avahi ļauj klientiem (it īpaši Mac OSX finder) "
-"automātiski atrast CIFS kopīgojumus uz sistēmas, kas līdzīga Datoru Pārlūkam "
+"automātiski atrast SMB kopīgojumus uz sistēmas, kas līdzīga Datoru Pārlūkam "
 "uz Windows."
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "Servera nosaukums"
@@ -3254,12 +3254,12 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr "Šie parametri ir pievienoti uz [Share] sekciju iekš smdb.conf"
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
-msgstr "Windows (CIFS) Kopīgojums"
+msgid "Windows (SMB) Share"
+msgstr "Windows (SMB) Kopīgojums"
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
-msgstr "Windows (CIFS) Kopīgojumi"
+msgid "Windows (SMB) Shares"
+msgstr "Windows (SMB) Kopīgojumi"
 
 #: sharing/models.py:114
 msgid ""
@@ -5367,8 +5367,8 @@ msgstr "AFP Uzstādījumi"
 #~ msgstr "Aktīvās Mapes Uzstādījumi"
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
-msgstr "CIFS Uzstādījumi"
+msgid "SMB Settings"
+msgstr "SMB Uzstādījumi"
 
 #: templates/services/core.html:45
 msgid "Dynamic DNS Settings"
@@ -5587,8 +5587,8 @@ msgid "UNIX (NFS)"
 msgstr "UNIX (NFS)"
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
-msgstr "Windows (CIFS)"
+msgid "Windows (SMB)"
+msgstr "Windows (SMB)"
 
 #~ msgid "There are no active UNIX (NFS) shares."
 #~ msgstr "Šeit nav aktīvu UNIX (NFS) Kopīgojumu."
@@ -5605,17 +5605,17 @@ msgstr "Windows (CIFS)"
 #~ msgid "Add UNIX (NFS) Share"
 #~ msgstr "Pievienot UNIX (NFS) Kopīgojumu"
 
-#~ msgid "There are no active Windows (CIFS) shares."
-#~ msgstr "Nav aktīvu Windows (CIFS) Kopīgojumu."
+#~ msgid "There are no active Windows (SMB) shares."
+#~ msgstr "Nav aktīvu Windows (SMB) Kopīgojumu."
 
-#~ msgid "Edit Windows (CIFS) Share"
-#~ msgstr "Labot Windows (CIFS) Kopīgojumu"
+#~ msgid "Edit Windows (SMB) Share"
+#~ msgstr "Labot Windows (SMB) Kopīgojumu"
 
-#~ msgid "Delete Windows (CIFS) Share"
-#~ msgstr "Dzēst Windows (CIFS) Kopīgojumu"
+#~ msgid "Delete Windows (SMB) Share"
+#~ msgstr "Dzēst Windows (SMB) Kopīgojumu"
 
-#~ msgid "Add Windows (CIFS) Share"
-#~ msgstr "Pievienot Windows (CIFS) Kopīgojumu"
+#~ msgid "Add Windows (SMB) Share"
+#~ msgstr "Pievienot Windows (SMB) Kopīgojumu"
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
 msgid "Clone Snapshot"
@@ -6281,8 +6281,8 @@ msgstr "Kritiskas Trauksmes"
 #~ msgid "Plugins path"
 #~ msgstr "Spraudņu ceļš"
 
-#~ msgid "Add Apple (CIFS) Share"
-#~ msgstr "Pievienot Apple (CIFS) Kopīgojumu"
+#~ msgid "Add Apple (SMB) Share"
+#~ msgstr "Pievienot Apple (SMB) Kopīgojumu"
 
 #~ msgid "Apply Service Pack"
 #~ msgstr "Uzstādīt servisa pakotni"
@@ -6393,11 +6393,11 @@ msgstr "Kritiskas Trauksmes"
 #~ "klientam, kurš savienosies ar viesa servisu. Šim lietotājam ir jāeksistē "
 #~ "paroļu datnē, bet nevajag derīgu autorizāciju."
 
-#~ msgid "CIFS Share"
-#~ msgstr "CIFS Kopīgojums"
+#~ msgid "SMB Share"
+#~ msgstr "SMB Kopīgojums"
 
-#~ msgid "CIFS Shares"
-#~ msgstr "CIFS Koplietojumi"
+#~ msgid "SMB Shares"
+#~ msgstr "SMB Koplietojumi"
 
 #~ msgid "NFS Share"
 #~ msgstr "NFS Kopīgojums"
@@ -9662,7 +9662,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -10355,7 +10355,7 @@ msgstr "Serveru skaits"
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%s veiksmīgi atjaunināts."
 
 #: sharing/models.py:290
@@ -13470,7 +13470,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/mk/LC_MESSAGES/django.po
+++ b/gui/locale/mk/LC_MESSAGES/django.po
@@ -1342,7 +1342,7 @@ msgid "This field is required for \"Home directories\"."
 msgstr ""
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr ""
 
 #: services/forms.py:118
@@ -1775,7 +1775,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1812,13 +1812,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:203
@@ -3168,11 +3168,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5286,7 +5286,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5546,7 +5546,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5570,19 +5570,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -8939,7 +8939,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -9575,7 +9575,7 @@ msgid "Kerberos Realm"
 msgstr ""
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr ""
 
 #: sharing/models.py:290
@@ -12351,7 +12351,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/mn/LC_MESSAGES/django.po
+++ b/gui/locale/mn/LC_MESSAGES/django.po
@@ -1347,8 +1347,8 @@ msgid "This field is required for \"Home directories\"."
 msgstr ""
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
-msgstr "дахин ачааллахад CIFS сервист алдаа гарлаа"
+msgid "The SMB service failed to reload."
+msgstr "дахин ачааллахад SMB сервист алдаа гарлаа"
 
 #: services/forms.py:118
 msgid "The AFP service failed to reload."
@@ -1782,7 +1782,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1819,13 +1819,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:203
@@ -3175,11 +3175,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5293,7 +5293,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5553,7 +5553,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5577,19 +5577,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -9057,7 +9057,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -9727,7 +9727,7 @@ msgstr ""
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%s амжилттай шинэчлэгдлээ"
 
 #: sharing/models.py:290
@@ -12678,7 +12678,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/ms/LC_MESSAGES/django.po
+++ b/gui/locale/ms/LC_MESSAGES/django.po
@@ -1341,7 +1341,7 @@ msgid "This field is required for \"Home directories\"."
 msgstr "Ruangan ini diperlukan untuk \"Direktori Utama\"."
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr ""
 
 #: services/forms.py:118
@@ -1780,7 +1780,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1817,13 +1817,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:203
@@ -3178,11 +3178,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5331,7 +5331,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5592,7 +5592,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5616,19 +5616,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -9217,7 +9217,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -9889,7 +9889,7 @@ msgstr ""
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "% berjaya dinaiktaraf"
 
 #: sharing/models.py:290
@@ -12857,7 +12857,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/mt/LC_MESSAGES/django.po
+++ b/gui/locale/mt/LC_MESSAGES/django.po
@@ -967,7 +967,7 @@ msgstr ""
 #: account/forms.py:374
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: account/forms.py:384 account/forms.py:640 directoryservice/forms.py:167
@@ -3238,7 +3238,7 @@ msgid "NetBIOS Alias: %s"
 msgstr ""
 
 #: services/forms.py:306
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr ""
 
 #: services/forms.py:328
@@ -3670,7 +3670,7 @@ msgstr ""
 
 #: services/models.py:183
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -3707,7 +3707,7 @@ msgstr ""
 #: services/models.py:212
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
@@ -3777,7 +3777,7 @@ msgstr ""
 
 #: services/models.py:278 services/models.py:279 services/nav.py:43
 #: storage/forms.py:2483 templates/services/core.html:15
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:298
@@ -5174,7 +5174,7 @@ msgid "The service could not be started."
 msgstr ""
 
 #: services/views.py:287
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr ""
 
 #: services/views.py:296
@@ -5348,11 +5348,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:145
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:146
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:158
@@ -7011,7 +7011,7 @@ msgid "Purpose"
 msgstr ""
 
 #: system/forms.py:1563 templates/sharing/index.html:21
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: system/forms.py:1564 templates/sharing/index.html:3
@@ -8480,7 +8480,7 @@ msgid "AFP Settings"
 msgstr ""
 
 #: templates/services/core.html:21 templates/services/core.html.py:22
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:33
@@ -9675,7 +9675,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/nb/LC_MESSAGES/django.po
+++ b/gui/locale/nb/LC_MESSAGES/django.po
@@ -1354,7 +1354,7 @@ msgstr "Dette feltet er påkrevd for \"Hjemmemapper\"."
 
 #: services/forms.py:106
 #, fuzzy
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr "NFS-tjenesten klarte ikke å restarte."
 
 #: services/forms.py:118
@@ -1816,7 +1816,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1859,14 +1859,14 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "Servernavn"
@@ -3291,12 +3291,12 @@ msgstr ""
 
 #: sharing/models.py:94
 #, fuzzy
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr "Windows Deling"
 
 #: sharing/models.py:95
 #, fuzzy
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr "Windowsversjon"
 
 #: sharing/models.py:114
@@ -5481,7 +5481,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5765,7 +5765,7 @@ msgstr ""
 
 #: templates/sharing/index.html:12
 #, fuzzy
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr "Windows Deling"
 
 #: templates/sharing/unix.html:7
@@ -5793,22 +5793,22 @@ msgstr "UNIX tegnsett"
 
 #: templates/sharing/windows.html:7
 #, fuzzy
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr "Det er ingen aktive UNIX Delinger"
 
 #: templates/sharing/windows.html:33
 #, fuzzy
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr "Windows Deling"
 
 #: templates/sharing/windows.html:39
 #, fuzzy
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr "Windows Deling"
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
 #, fuzzy
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr "Windows Deling"
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -6474,7 +6474,7 @@ msgid "View Tunables"
 msgstr "Vis alle brukere"
 
 #, fuzzy
-msgid "Add Apple (CIFS) Share"
+msgid "Add Apple (SMB) Share"
 msgstr "Legg til Apple deling"
 
 #~ msgid "Apply Service Pack"
@@ -6579,11 +6579,11 @@ msgstr "Legg til Apple deling"
 #~ "trenger ikke en gyldig pålogging."
 
 #, fuzzy
-msgid "CIFS Share"
+msgid "SMB Share"
 msgstr "UNIX tegnsett"
 
 #, fuzzy
-msgid "CIFS Shares"
+msgid "SMB Shares"
 msgstr "UNIX tegnsett"
 
 #~ msgid "When in a day should we start making snapshots, e.g. 8:00"
@@ -9761,10 +9761,10 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 "Passord som inneholder spørsmålstegn (?) er ikke støttet grunnet problemer "
-"med CIFS"
+"med SMB"
 
 #: directoryservice/forms.py:104
 #, fuzzy
@@ -10454,7 +10454,7 @@ msgstr "Antall servere"
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "% er korrekt oppdatert."
 
 #: sharing/models.py:290
@@ -13521,7 +13521,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/ne/LC_MESSAGES/django.po
+++ b/gui/locale/ne/LC_MESSAGES/django.po
@@ -1342,7 +1342,7 @@ msgid "This field is required for \"Home directories\"."
 msgstr ""
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr ""
 
 #: services/forms.py:118
@@ -1775,7 +1775,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1812,13 +1812,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:203
@@ -3168,11 +3168,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5286,7 +5286,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5546,7 +5546,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5570,19 +5570,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -8939,7 +8939,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -9575,7 +9575,7 @@ msgid "Kerberos Realm"
 msgstr ""
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr ""
 
 #: sharing/models.py:290
@@ -12351,7 +12351,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/nl/LC_MESSAGES/django.po
+++ b/gui/locale/nl/LC_MESSAGES/django.po
@@ -1321,8 +1321,8 @@ msgid "This field is required for \"Home directories\"."
 msgstr "Dit veld is vereist voor 'Basismappen'."
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
-msgstr "Opnieuw laden van de CIFS-service is mislukt."
+msgid "The SMB service failed to reload."
+msgstr "Opnieuw laden van de SMB-service is mislukt."
 
 #: services/forms.py:118
 msgid "The AFP service failed to reload."
@@ -1774,10 +1774,10 @@ msgstr "Unix-extensies"
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
-"Via deze extensies kan Samba UNIX CIFS-clients beter bedienen door functies "
+"Via deze extensies kan Samba UNIX SMB-clients beter bedienen door functies "
 "als symbolische koppelingen, harde koppelingen etc. te ondersteunen."
 
 #: services/models.py:171
@@ -1816,17 +1816,17 @@ msgstr "Zeroconf-share-detectie"
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 "Door ondersteuning van Zeroconf via Avahi kunnen clients (met name de Finder "
-"in Mac OSX) automatisch de CIFS-shares op het systeem detecteren, "
+"in Mac OSX) automatisch de SMB-shares op het systeem detecteren, "
 "vergelijkbaar met de service Computer Browser in Windows."
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "Server Naam"
@@ -3272,12 +3272,12 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr "Deze parameters worden aan de sectie [share] van smb.conf toegevoegd"
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
-msgstr "Windows (CIFS)-share"
+msgid "Windows (SMB) Share"
+msgstr "Windows (SMB)-share"
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
-msgstr "Windows (CIFS)-shares"
+msgid "Windows (SMB) Shares"
+msgstr "Windows (SMB)-shares"
 
 #: sharing/models.py:114
 msgid ""
@@ -5411,8 +5411,8 @@ msgstr "AFP-instellingen"
 #~ msgstr "Active Directory Instellingen"
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
-msgstr "CIFS-instellingen"
+msgid "SMB Settings"
+msgstr "SMB-instellingen"
 
 #: templates/services/core.html:45
 msgid "Dynamic DNS Settings"
@@ -5648,8 +5648,8 @@ msgid "UNIX (NFS)"
 msgstr "UNIX (NFS)"
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
-msgstr "Windows (CIFS)"
+msgid "Windows (SMB)"
+msgstr "Windows (SMB)"
 
 #: templates/sharing/unix.html:7
 msgid "There are no active UNIX (NFS) shares."
@@ -5671,19 +5671,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr "UNIX (NFS)-share toevoegen"
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
-msgstr "Er zijn geen actieve Windows (CIFS)-shares."
+msgid "There are no active Windows (SMB) shares."
+msgstr "Er zijn geen actieve Windows (SMB)-shares."
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
-msgstr "Windows (CIFS)-share bewerken"
+msgid "Edit Windows (SMB) Share"
+msgstr "Windows (SMB)-share bewerken"
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
-msgstr "Windows (CIFS)-share verwijderen"
+msgid "Delete Windows (SMB) Share"
+msgstr "Windows (SMB)-share verwijderen"
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr "Replicatiestroomcompressie"
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -6332,8 +6332,8 @@ msgstr "Afstembare parameters weergeven"
 #~ msgid "Close"
 #~ msgstr "Sluiten"
 
-msgid "Add Apple (CIFS) Share"
-msgstr "Apple (CIFS)-share toevoegen"
+msgid "Add Apple (SMB) Share"
+msgstr "Apple (SMB)-share toevoegen"
 
 #~ msgid "Apply Service Pack"
 #~ msgstr "Service Pack toepassen"
@@ -6440,11 +6440,11 @@ msgstr "Apple (CIFS)-share toevoegen"
 #~ "bestaan in het wachtwoord bestand, maar er is geen geldige aanmelding "
 #~ "vereist."
 
-#~ msgid "CIFS Share"
-#~ msgstr "CIFS Share"
+#~ msgid "SMB Share"
+#~ msgstr "SMB Share"
 
-#~ msgid "CIFS Shares"
-#~ msgstr "CIFS Shares"
+#~ msgid "SMB Shares"
+#~ msgstr "SMB Shares"
 
 #~ msgid "NFS Share"
 #~ msgstr "NFS Share"
@@ -9664,10 +9664,10 @@ msgstr "Experimental target inschakelen"
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 "Wachtwoorden die een vraagteken (?) bevatten zijn momenteel niet toegestaan "
-"vanwege problemen met CIFS."
+"vanwege problemen met SMB."
 
 #: directoryservice/forms.py:104
 msgid "NT4 failed to reload."
@@ -10372,8 +10372,8 @@ msgid "Kerberos Realm"
 msgstr "Kerberos-realm"
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
-msgstr "CIFS met succes bijgewerkt."
+msgid "SMB successfully updated."
+msgstr "SMB met succes bijgewerkt."
 
 #: sharing/models.py:290
 msgid "Security"
@@ -13502,8 +13502,8 @@ msgstr ""
 "streepjes."
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
-msgstr "Kan CIFS niet uitschakelen terwijl ActiveDirectory in gebruik is."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
+msgstr "Kan SMB niet uitschakelen terwijl ActiveDirectory in gebruik is."
 
 #: services/models.py:1295
 msgid "Shutdown Command"

--- a/gui/locale/pa/LC_MESSAGES/django.po
+++ b/gui/locale/pa/LC_MESSAGES/django.po
@@ -1342,7 +1342,7 @@ msgid "This field is required for \"Home directories\"."
 msgstr ""
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr ""
 
 #: services/forms.py:118
@@ -1775,7 +1775,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1812,13 +1812,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:203
@@ -3168,11 +3168,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5286,7 +5286,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5546,7 +5546,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5570,19 +5570,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -8939,7 +8939,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -9575,7 +9575,7 @@ msgid "Kerberos Realm"
 msgstr ""
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr ""
 
 #: sharing/models.py:290
@@ -12351,7 +12351,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/pl/LC_MESSAGES/django.po
+++ b/gui/locale/pl/LC_MESSAGES/django.po
@@ -1341,8 +1341,8 @@ msgid "This field is required for \"Home directories\"."
 msgstr "To pole jest wymagane dla opcji \"Katalogi domowe\"."
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
-msgstr "Nieudane przeładowanie usługi CIFS."
+msgid "The SMB service failed to reload."
+msgstr "Nieudane przeładowanie usługi SMB."
 
 #: services/forms.py:118
 msgid "The AFP service failed to reload."
@@ -1800,7 +1800,7 @@ msgstr "Rozszerzenia Unix"
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1843,14 +1843,14 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "Nazwa serwera"
@@ -3328,12 +3328,12 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr "Te parametry zostaną dodane w sekcji [Share] pliku smb.conf"
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
-msgstr "Udział Windows (CIFS)"
+msgid "Windows (SMB) Share"
+msgstr "Udział Windows (SMB)"
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
-msgstr "Udziały Windows (CIFS)"
+msgid "Windows (SMB) Shares"
+msgstr "Udziały Windows (SMB)"
 
 #: sharing/models.py:114
 msgid ""
@@ -5461,8 +5461,8 @@ msgstr "Ustawienia AFP"
 #~ msgstr "Ustawienia Active Directory"
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
-msgstr "Ustawienia CIFS"
+msgid "SMB Settings"
+msgstr "Ustawienia SMB"
 
 #: templates/services/core.html:45
 msgid "Dynamic DNS Settings"
@@ -5708,8 +5708,8 @@ msgid "UNIX (NFS)"
 msgstr "UNIX (NFS)"
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
-msgstr "Windows (CIFS)"
+msgid "Windows (SMB)"
+msgstr "Windows (SMB)"
 
 #: templates/sharing/unix.html:7
 #, fuzzy
@@ -5728,17 +5728,17 @@ msgstr "Brak aktywnych udziałów UNIX."
 #~ msgid "Add UNIX (NFS) Share"
 #~ msgstr "Dodaj udział UNIX (NFS)"
 
-#~ msgid "There are no active Windows (CIFS) shares."
-#~ msgstr "Brak aktywnych udziałów Windows (CIFS)."
+#~ msgid "There are no active Windows (SMB) shares."
+#~ msgstr "Brak aktywnych udziałów Windows (SMB)."
 
-#~ msgid "Edit Windows (CIFS) Share"
-#~ msgstr "Edytuj udział Windows (CIFS)"
+#~ msgid "Edit Windows (SMB) Share"
+#~ msgstr "Edytuj udział Windows (SMB)"
 
-#~ msgid "Delete Windows (CIFS) Share"
-#~ msgstr "Usuń udział Windows (CIFS)"
+#~ msgid "Delete Windows (SMB) Share"
+#~ msgstr "Usuń udział Windows (SMB)"
 
-#~ msgid "Add Windows (CIFS) Share"
-#~ msgstr "Dodaj udział Windows (CIFS)"
+#~ msgid "Add Windows (SMB) Share"
+#~ msgstr "Dodaj udział Windows (SMB)"
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
 msgid "Clone Snapshot"
@@ -6378,7 +6378,7 @@ msgid "View Tunables"
 msgstr "Pokaż wszystkich użytkowników"
 
 #, fuzzy
-msgid "Add Apple (CIFS) Share"
+msgid "Add Apple (SMB) Share"
 msgstr "Dodaj udział Apple"
 
 #~ msgid "Apply Service Pack"
@@ -6487,11 +6487,11 @@ msgstr "na godzinę"
 #~ "hasłami, nie jest jednak wymagany prawidłowy login."
 
 #, fuzzy
-msgid "CIFS Share"
+msgid "SMB Share"
 msgstr "Udział UNIX"
 
-#~ msgid "CIFS Shares"
-#~ msgstr "Udziały CIFS"
+#~ msgid "SMB Shares"
+#~ msgstr "Udziały SMB"
 
 #~ msgid "NFS Share"
 #~ msgstr "Udział NFS"
@@ -9760,10 +9760,10 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 "Hasła zawierające znak zapytania (?) obecnie nie są dozwolone ze względu na "
-"problemy z CIFS."
+"problemy z SMB."
 
 #: directoryservice/forms.py:104
 msgid "NT4 failed to reload."
@@ -10442,7 +10442,7 @@ msgstr "Liczba serwerów"
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%s zaktualizowany pomyślnie."
 
 #: sharing/models.py:290
@@ -13544,7 +13544,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/pt/LC_MESSAGES/django.po
+++ b/gui/locale/pt/LC_MESSAGES/django.po
@@ -1334,8 +1334,8 @@ msgid "This field is required for \"Home directories\"."
 msgstr "Este campo é necessário para \"Directórios da raiz\"."
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
-msgstr "O serviço CIFS falhou no reinicio."
+msgid "The SMB service failed to reload."
+msgstr "O serviço SMB falhou no reinicio."
 
 #: services/forms.py:118
 msgid "The AFP service failed to reload."
@@ -1794,10 +1794,10 @@ msgstr "Extensões Unix"
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
-"Estas extensões permitem Samba para melhor servir os clientes UNIX CIFS "
+"Estas extensões permitem Samba para melhor servir os clientes UNIX SMB "
 "apoiando recursos, como links simbólicos, links rígidos, etc..."
 
 #: services/models.py:171
@@ -1836,17 +1836,17 @@ msgstr "Descobrir partilha Zeroconf"
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 "Apoio zeroconf via Avahi permite aos clientes (o Mac OSX finder em "
-"particular) para detectar automaticamente as partilhas CIFS no sistema "
+"particular) para detectar automaticamente as partilhas SMB no sistema "
 "similar ao serviço Navegador do Computador no Windows."
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "Nome do servidor"
@@ -3303,12 +3303,12 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr "Estes parâmetros foram adicionados á [Share] secção do smb.conf"
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
-msgstr "Partilha (CIFS) Windows"
+msgid "Windows (SMB) Share"
+msgstr "Partilha (SMB) Windows"
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
-msgstr "Partilhas (CIFS) Windows"
+msgid "Windows (SMB) Shares"
+msgstr "Partilhas (SMB) Windows"
 
 #: sharing/models.py:114
 msgid ""
@@ -5450,8 +5450,8 @@ msgstr "Definições de AFP"
 #~ msgstr "Definições da Active Directory"
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
-msgstr "Definições do CIFS"
+msgid "SMB Settings"
+msgstr "Definições do SMB"
 
 #: templates/services/core.html:45
 msgid "Dynamic DNS Settings"
@@ -5704,8 +5704,8 @@ msgstr "Adicionar partilha UNIX (NFS)"
 
 #: templates/sharing/index.html:12
 #, fuzzy
-msgid "Windows (CIFS)"
-msgstr "Adicionar partilha Windows (CIFS)"
+msgid "Windows (SMB)"
+msgstr "Adicionar partilha Windows (SMB)"
 
 #: templates/sharing/unix.html:7
 #, fuzzy
@@ -5732,22 +5732,22 @@ msgstr "Adicionar partilha UNIX"
 
 #: templates/sharing/windows.html:7
 #, fuzzy
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr "Não existem partilhas Windows activas."
 
 #: templates/sharing/windows.html:33
 #, fuzzy
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr "Editar partilha Windows"
 
 #: templates/sharing/windows.html:39
 #, fuzzy
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr "Apagar partilha Windows"
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
 #, fuzzy
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr "Adicionar partilha Windows"
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -6378,7 +6378,7 @@ msgstr "Ver chave-pública"
 #~ msgstr "Fechar"
 
 #, fuzzy
-msgid "Add Apple (CIFS) Share"
+msgid "Add Apple (SMB) Share"
 msgstr "Adicionar partilha Apple"
 
 #~ msgid "Apply Service Pack"
@@ -6485,11 +6485,11 @@ msgstr "Adicionar partilha Apple"
 #~ "para qualquer cliente se conectar ao serviço cliente. Este utilizador "
 #~ "deve existir no arquivo de senha, mas não exige um login válido."
 
-#~ msgid "CIFS Share"
-#~ msgstr "Partilha CIFS"
+#~ msgid "SMB Share"
+#~ msgstr "Partilha SMB"
 
-#~ msgid "CIFS Shares"
-#~ msgstr "CIFS Partilhas"
+#~ msgid "SMB Shares"
+#~ msgstr "SMB Partilhas"
 
 #~ msgid "NFS Share"
 #~ msgstr "Partilha NFS"
@@ -9762,7 +9762,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -10454,7 +10454,7 @@ msgstr "Número de servidores"
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%s actualizado com sucesso."
 
 #: sharing/models.py:290
@@ -13563,7 +13563,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/pt_BR/LC_MESSAGES/django.po
+++ b/gui/locale/pt_BR/LC_MESSAGES/django.po
@@ -1336,8 +1336,8 @@ msgid "This field is required for \"Home directories\"."
 msgstr "Este campo é obrigatório para \"Diretórios home\"."
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
-msgstr "O serviço CIFS falhou em recarregar."
+msgid "The SMB service failed to reload."
+msgstr "O serviço SMB falhou em recarregar."
 
 #: services/forms.py:118
 msgid "The AFP service failed to reload."
@@ -1785,10 +1785,10 @@ msgstr "Extensões Unix"
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
-"Estas extensões permitem que o Samba sirva melhor os clientes UNIX CIFS, "
+"Estas extensões permitem que o Samba sirva melhor os clientes UNIX SMB, "
 "suportando funcionalidades como links simbólicos, hard links, etc..."
 
 #: services/models.py:171
@@ -1828,17 +1828,17 @@ msgstr "Descoberta de compartilhamentos Zeroconf"
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 "Suporte Zeroconf via Avahi permite clientes (O finder do Mac OSX em "
-"particular) para descobrir automaticamente compartilhamentos CIFS no "
+"particular) para descobrir automaticamente compartilhamentos SMB no "
 "sistema, similitar ao serviço Browser de Computador do Windows."
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "Nome do Servidor"
@@ -3297,12 +3297,12 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr "Esses parâmetros são adicionados à seção [Share] de smb.conf"
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
-msgstr "Compartilhamento Windows (CIFS)"
+msgid "Windows (SMB) Share"
+msgstr "Compartilhamento Windows (SMB)"
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
-msgstr "Compartilhamentos Windows (CIFS)"
+msgid "Windows (SMB) Shares"
+msgstr "Compartilhamentos Windows (SMB)"
 
 #: sharing/models.py:114
 msgid ""
@@ -5437,8 +5437,8 @@ msgstr "Configurações do AFP"
 #~ msgstr "Configurações do Active Directory"
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
-msgstr "Configurações do CIFS"
+msgid "SMB Settings"
+msgstr "Configurações do SMB"
 
 #: templates/services/core.html:45
 msgid "Dynamic DNS Settings"
@@ -5668,8 +5668,8 @@ msgid "UNIX (NFS)"
 msgstr "UNIX (NFS)"
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
-msgstr "Windows (CIFS)"
+msgid "Windows (SMB)"
+msgstr "Windows (SMB)"
 
 #~ msgid "There are no active UNIX (NFS) shares."
 #~ msgstr "Não existe nenhum compartilhamento UNIX (NFS) ativo."
@@ -5686,17 +5686,17 @@ msgstr "Windows (CIFS)"
 #~ msgid "Add UNIX (NFS) Share"
 #~ msgstr "Adicionar compartilhamento UNIX (NFS)"
 
-#~ msgid "There are no active Windows (CIFS) shares."
-#~ msgstr "Não existe nenhum compartilhamento Windows (CIFS) ativo."
+#~ msgid "There are no active Windows (SMB) shares."
+#~ msgstr "Não existe nenhum compartilhamento Windows (SMB) ativo."
 
-#~ msgid "Edit Windows (CIFS) Share"
-#~ msgstr "Editar compartilhamento Windows (CIFS)"
+#~ msgid "Edit Windows (SMB) Share"
+#~ msgstr "Editar compartilhamento Windows (SMB)"
 
-#~ msgid "Delete Windows (CIFS) Share"
-#~ msgstr "Excluir compartilhamento Windows (CIFS)"
+#~ msgid "Delete Windows (SMB) Share"
+#~ msgstr "Excluir compartilhamento Windows (SMB)"
 
-#~ msgid "Add Windows (CIFS) Share"
-#~ msgstr "Adicionar compartilhamento Windows (CIFS)"
+#~ msgid "Add Windows (SMB) Share"
+#~ msgstr "Adicionar compartilhamento Windows (SMB)"
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
 msgid "Clone Snapshot"
@@ -6364,8 +6364,8 @@ msgstr "Visualizar Discos"
 #~ msgid "Plugins path"
 #~ msgstr "Caminho dos plugins"
 
-#~ msgid "Add Apple (CIFS) Share"
-#~ msgstr "Adicionar Compartilhamento Apple (CIFS)"
+#~ msgid "Add Apple (SMB) Share"
+#~ msgstr "Adicionar Compartilhamento Apple (SMB)"
 
 #~ msgid "Apply Service Pack"
 #~ msgstr "Aplicar Service Pack"
@@ -6472,11 +6472,11 @@ msgstr "Visualizar Discos"
 #~ "a conexão no serviço de convidados. O usuário precisa possuir uma senha, "
 #~ "mas não é necessário um login válido."
 
-#~ msgid "CIFS Share"
-#~ msgstr "Compartilhamento CIFS (Sistema de Arquivos Comum da Internet)"
+#~ msgid "SMB Share"
+#~ msgstr "Compartilhamento SMB (Sistema de Arquivos Comum da Internet)"
 
-#~ msgid "CIFS Shares"
-#~ msgstr "Compartilhamento CIFS (Sistemas de Arquivos Comum da Internet)"
+#~ msgid "SMB Shares"
+#~ msgstr "Compartilhamento SMB (Sistemas de Arquivos Comum da Internet)"
 
 #~ msgid "NFS Share"
 #~ msgstr "Compartilhamento NFS"
@@ -9731,10 +9731,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 "As senhas que contenham um ponto de interrogação (?) Atualmente não é "
-"permitido devido a problemas com CIFS."
+"permitido devido a problemas com SMB."
 
 #: directoryservice/forms.py:104
 #, fuzzy
@@ -10459,8 +10459,8 @@ msgid "Kerberos Realm"
 msgstr "Arquivo Kerberos Keytab"
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
-msgstr "CIFS atualizado com sucesso."
+msgid "SMB successfully updated."
+msgstr "SMB atualizado com sucesso."
 
 #: sharing/models.py:290
 msgid "Security"
@@ -13616,7 +13616,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/ro/LC_MESSAGES/django.po
+++ b/gui/locale/ro/LC_MESSAGES/django.po
@@ -1332,8 +1332,8 @@ msgid "This field is required for \"Home directories\"."
 msgstr "Acest câmp este obligatoriu pentru \"Directoare Home\"."
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
-msgstr "Serviciul CIFS a eșuat să repornească."
+msgid "The SMB service failed to reload."
+msgstr "Serviciul SMB a eșuat să repornească."
 
 #: services/forms.py:118
 msgid "The AFP service failed to reload."
@@ -1792,10 +1792,10 @@ msgstr "Extensii Unix"
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
-"Aceste extensii permit Samba să servească mai bine clienții UNIX CIFS prin "
+"Aceste extensii permit Samba să servească mai bine clienții UNIX SMB prin "
 "caracteristici de sprijin cum ar fi legături simbolice, legături hard, etc . "
 ". . ."
 
@@ -1836,17 +1836,17 @@ msgstr "Descoperire partajare Zeroconf"
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 "Suportul Zeroconf via Avahi permite clienţilor (în special clienţilor Mac "
-"OSX) să descopere partajările CIFS din sistem similar serviciului Computer "
+"OSX) să descopere partajările SMB din sistem similar serviciului Computer "
 "Browser din Windows."
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "Nume server"
@@ -3301,12 +3301,12 @@ msgstr ""
 "Aceşti parametri sunt adaugaţi la secţiunea [Share] a fişierului smb.conf"
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
-msgstr "Partajări Windows (CIFS)"
+msgid "Windows (SMB) Share"
+msgstr "Partajări Windows (SMB)"
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
-msgstr "Partajări Windows (CIFS)"
+msgid "Windows (SMB) Shares"
+msgstr "Partajări Windows (SMB)"
 
 #: sharing/models.py:114
 msgid ""
@@ -5429,8 +5429,8 @@ msgstr "Setări AFP"
 #~ msgstr "Setări Active Directory"
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
-msgstr "Setări CIFS"
+msgid "SMB Settings"
+msgstr "Setări SMB"
 
 #: templates/services/core.html:45
 msgid "Dynamic DNS Settings"
@@ -5650,8 +5650,8 @@ msgid "UNIX (NFS)"
 msgstr "UNIX (NFS)"
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
-msgstr "Windows (CIFS)"
+msgid "Windows (SMB)"
+msgstr "Windows (SMB)"
 
 #~ msgid "There are no active UNIX (NFS) shares."
 #~ msgstr "Nu există partajări UNIX (NFS) active"
@@ -5668,17 +5668,17 @@ msgstr "Windows (CIFS)"
 #~ msgid "Add UNIX (NFS) Share"
 #~ msgstr "Adăugare partajare UNIX (NFS)"
 
-#~ msgid "There are no active Windows (CIFS) shares."
-#~ msgstr "Nu există partajări Windows (CIFS) active."
+#~ msgid "There are no active Windows (SMB) shares."
+#~ msgstr "Nu există partajări Windows (SMB) active."
 
-#~ msgid "Edit Windows (CIFS) Share"
-#~ msgstr "Editare partajare Windows (CIFS)"
+#~ msgid "Edit Windows (SMB) Share"
+#~ msgstr "Editare partajare Windows (SMB)"
 
-#~ msgid "Delete Windows (CIFS) Share"
-#~ msgstr "Modificare partajare Windows (CIFS)"
+#~ msgid "Delete Windows (SMB) Share"
+#~ msgstr "Modificare partajare Windows (SMB)"
 
-#~ msgid "Add Windows (CIFS) Share"
-#~ msgstr "Adăugare partajare Windows (CIFS)"
+#~ msgid "Add Windows (SMB) Share"
+#~ msgstr "Adăugare partajare Windows (SMB)"
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
 msgid "Clone Snapshot"
@@ -6288,8 +6288,8 @@ msgstr "Alerte critice"
 #~ msgid "View Tunables"
 #~ msgstr "Vizualizare setări reglabile"
 
-#~ msgid "Add Apple (CIFS) Share"
-#~ msgstr "Adăugare partajare Apple (CIFS)"
+#~ msgid "Add Apple (SMB) Share"
+#~ msgstr "Adăugare partajare Apple (SMB)"
 
 #~ msgid "Apply Service Pack"
 #~ msgstr "Aplicare service pack"
@@ -6395,11 +6395,11 @@ msgstr "Alerte critice"
 #~ "oricărei conexiuni la serviciul vizitator. Acest utilizator trebuie să "
 #~ "existe in fișierul de parole, dar nu necesită o autentificare validă."
 
-#~ msgid "CIFS Share"
-#~ msgstr "Partajare CIFS"
+#~ msgid "SMB Share"
+#~ msgstr "Partajare SMB"
 
-#~ msgid "CIFS Shares"
-#~ msgstr "Partajări CIFS"
+#~ msgid "SMB Shares"
+#~ msgstr "Partajări SMB"
 
 #~ msgid "NFS Share"
 #~ msgstr "Partajare NFS"
@@ -9600,10 +9600,10 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 "Parolele care conțin caracterul (?) nu pot fi utilizate în acest moment din "
-"cauza problemelor cu CIFS"
+"cauza problemelor cu SMB"
 
 #: directoryservice/forms.py:104
 msgid "NT4 failed to reload."
@@ -10299,7 +10299,7 @@ msgstr "Kerberos Realm"
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%s actualizat cu succes."
 
 #: sharing/models.py:290
@@ -13441,7 +13441,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/ru/LC_MESSAGES/django.po
+++ b/gui/locale/ru/LC_MESSAGES/django.po
@@ -1341,8 +1341,8 @@ msgid "This field is required for \"Home directories\"."
 msgstr "Это поле является обязательным для \"Домашние каталоги\"."
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
-msgstr "Не удалось перезагрузить службу CIFS."
+msgid "The SMB service failed to reload."
+msgstr "Не удалось перезагрузить службу SMB."
 
 #: services/forms.py:118
 msgid "The AFP service failed to reload."
@@ -1796,10 +1796,10 @@ msgstr "Расшиения Unix"
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
-"Эти расширения позволяют Samba лучше обслуживать UNIX CIFS клиентов "
+"Эти расширения позволяют Samba лучше обслуживать UNIX SMB клиентов "
 "благодаря поддержке символических ссылок, жёстких ссылок итд..."
 
 #: services/models.py:171
@@ -1837,17 +1837,17 @@ msgstr "Zeroconf обнаружение ресурса"
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 "Поддержка Zeroconf через Avahi позволяет клиентам (в частности Mac OSX "
-"finder) автоматически находить общие ресурсы CIFS аналогично Computer "
+"finder) автоматически находить общие ресурсы SMB аналогично Computer "
 "Browser service в Windows."
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "Имя сервера"
@@ -3312,12 +3312,12 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr "Эти параметры добавляются в раздел [Share] smb.conf"
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
-msgstr "Общий ресурс Windows (CIFS)"
+msgid "Windows (SMB) Share"
+msgstr "Общий ресурс Windows (SMB)"
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
-msgstr "Общие ресурсы Windows (CIFS)"
+msgid "Windows (SMB) Shares"
+msgstr "Общие ресурсы Windows (SMB)"
 
 #: sharing/models.py:114
 msgid ""
@@ -5434,8 +5434,8 @@ msgstr "Настройки AFP"
 #~ msgstr "Настройки Active Directory"
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
-msgstr "Настройки CIFS"
+msgid "SMB Settings"
+msgstr "Настройки SMB"
 
 #: templates/services/core.html:45
 msgid "Dynamic DNS Settings"
@@ -5656,8 +5656,8 @@ msgid "UNIX (NFS)"
 msgstr "UNIX (NFS)"
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
-msgstr "Windows (CIFS)"
+msgid "Windows (SMB)"
+msgstr "Windows (SMB)"
 
 #~ msgid "There are no active UNIX (NFS) shares."
 #~ msgstr "Нет активных общих ресурсов UNIX (NFS)."
@@ -5674,17 +5674,17 @@ msgstr "Windows (CIFS)"
 #~ msgid "Add UNIX (NFS) Share"
 #~ msgstr "Добавить общий ресурс UNIX (NFS)"
 
-#~ msgid "There are no active Windows (CIFS) shares."
-#~ msgstr "Нет активных общих ресурсов Windows (CIFS)."
+#~ msgid "There are no active Windows (SMB) shares."
+#~ msgstr "Нет активных общих ресурсов Windows (SMB)."
 
-#~ msgid "Edit Windows (CIFS) Share"
-#~ msgstr "Изменить общий ресурс Windows (CIFS)"
+#~ msgid "Edit Windows (SMB) Share"
+#~ msgstr "Изменить общий ресурс Windows (SMB)"
 
-#~ msgid "Delete Windows (CIFS) Share"
-#~ msgstr "Удалить общий ресурс Windows (CIFS)"
+#~ msgid "Delete Windows (SMB) Share"
+#~ msgstr "Удалить общий ресурс Windows (SMB)"
 
-#~ msgid "Add Windows (CIFS) Share"
-#~ msgstr "Добавить общий ресурс Windows (CIFS)"
+#~ msgid "Add Windows (SMB) Share"
+#~ msgstr "Добавить общий ресурс Windows (SMB)"
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
 msgid "Clone Snapshot"
@@ -6345,8 +6345,8 @@ msgstr "Критические оповещения"
 #~ msgid "Plugins path"
 #~ msgstr "Путь плагинов"
 
-#~ msgid "Add Apple (CIFS) Share"
-#~ msgstr "Добавить общий ресурс Apple (CIFS)"
+#~ msgid "Add Apple (SMB) Share"
+#~ msgstr "Добавить общий ресурс Apple (SMB)"
 
 #~ msgid "Apply Service Pack"
 #~ msgstr "Принять обновление"
@@ -6460,11 +6460,11 @@ msgstr "Критические оповещения"
 #~ "клиента, подключающегося к гостевой службе. Этот пользователь должен "
 #~ "существовать в файле паролей, но не требует корректного логина."
 
-#~ msgid "CIFS Share"
-#~ msgstr "Общий ресурс CIFS"
+#~ msgid "SMB Share"
+#~ msgstr "Общий ресурс SMB"
 
-#~ msgid "CIFS Shares"
-#~ msgstr "Общие ресурсы CIFS"
+#~ msgid "SMB Shares"
+#~ msgstr "Общие ресурсы SMB"
 
 #~ msgid "NFS Share"
 #~ msgstr "Общий ресурс NFS"
@@ -9673,8 +9673,8 @@ msgstr "Включить экспериментальную цель"
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
-msgstr "Пароли содержащие знак вопроса (?) запрещены из-за проблем с CIFS."
+"problems with SMB."
+msgstr "Пароли содержащие знак вопроса (?) запрещены из-за проблем с SMB."
 
 #: directoryservice/forms.py:104
 msgid "NT4 failed to reload."
@@ -10370,8 +10370,8 @@ msgid "Kerberos Realm"
 msgstr "Область Kerberos"
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
-msgstr "CIFS успешно обновлен."
+msgid "SMB successfully updated."
+msgstr "SMB успешно обновлен."
 
 #: sharing/models.py:290
 msgid "Security"
@@ -13388,8 +13388,8 @@ msgstr ""
 "подчеркивания."
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
-msgstr "Невозможно отключить CIFS в то время как Active Directory используется."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
+msgstr "Невозможно отключить SMB в то время как Active Directory используется."
 
 #: services/models.py:1295
 msgid "Shutdown Command"

--- a/gui/locale/sk/LC_MESSAGES/django.po
+++ b/gui/locale/sk/LC_MESSAGES/django.po
@@ -1352,8 +1352,8 @@ msgid "This field is required for \"Home directories\"."
 msgstr "Toto pole je vyžadované pre \"Domovské adresáre\"."
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
-msgstr "Službu CIFS sa nepodarilo načítať."
+msgid "The SMB service failed to reload."
+msgstr "Službu SMB sa nepodarilo načítať."
 
 #: services/forms.py:118
 msgid "The AFP service failed to reload."
@@ -1821,7 +1821,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1864,14 +1864,14 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "Názov servera"
@@ -3347,12 +3347,12 @@ msgstr "Tieto parametre sú pridané do [Share] sekcie v smb.conf"
 
 #: sharing/models.py:94
 #, fuzzy
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr "Windows zdieľaný adresár"
 
 #: sharing/models.py:95
 #, fuzzy
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr "Windows zdielané adresáre"
 
 #: sharing/models.py:114
@@ -5537,8 +5537,8 @@ msgstr "AFP Nastavenia"
 #~ msgstr "Active Directory Nastavenia"
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
-msgstr "CIFS Nastavenia"
+msgid "SMB Settings"
+msgstr "SMB Nastavenia"
 
 #: templates/services/core.html:45
 msgid "Dynamic DNS Settings"
@@ -5795,8 +5795,8 @@ msgstr "Pridať UNIX Zdieľaný Adresár (NFS)"
 
 #: templates/sharing/index.html:12
 #, fuzzy
-msgid "Windows (CIFS)"
-msgstr "Pridať Windows Zdieľaný Adresár (CIFS)"
+msgid "Windows (SMB)"
+msgstr "Pridať Windows Zdieľaný Adresár (SMB)"
 
 #: templates/sharing/unix.html:7
 #, fuzzy
@@ -5823,22 +5823,22 @@ msgstr "Pridať UNIX Zdieľaný Adresár"
 
 #: templates/sharing/windows.html:7
 #, fuzzy
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr "Neexistujú žiadne aktívne Windows Zdieľané Adresáre."
 
 #: templates/sharing/windows.html:33
 #, fuzzy
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr "Upraviť Windows Zdieľaný Adresár"
 
 #: templates/sharing/windows.html:39
 #, fuzzy
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr "Zmazať Windows Zdieľaný Adresár"
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
 #, fuzzy
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr "Pridať Windows Zdieľaný Adresár"
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -6520,7 +6520,7 @@ msgstr "Zobraziť všetkých používateľov"
 #~ msgstr "Zatvoriť"
 
 #, fuzzy
-msgid "Add Apple (CIFS) Share"
+msgid "Add Apple (SMB) Share"
 msgstr "Pridať Apple Zideľaný Adresár"
 
 #~ msgid "Apply Service Pack"
@@ -6629,11 +6629,11 @@ msgstr "Pridať Apple Zideľaný Adresár"
 #~ "heslami, ale nevyžaduje platný login."
 
 #, fuzzy
-msgid "CIFS Share"
+msgid "SMB Share"
 msgstr "UNIX Share"
 
 #, fuzzy
-msgid "CIFS Shares"
+msgid "SMB Shares"
 msgstr "UNIX Zdieľané Adresáre"
 
 #, fuzzy
@@ -9827,7 +9827,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -10519,7 +10519,7 @@ msgstr "Počet serverov"
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%s úspešne aktualizovaný."
 
 #: sharing/models.py:290
@@ -13607,7 +13607,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/sl/LC_MESSAGES/django.po
+++ b/gui/locale/sl/LC_MESSAGES/django.po
@@ -1329,8 +1329,8 @@ msgid "This field is required for \"Home directories\"."
 msgstr "To polje je potrebno za \"Domač-e direktorij-e\"."
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
-msgstr "CIFS servis se ni ponovno zagnal."
+msgid "The SMB service failed to reload."
+msgstr "SMB servis se ni ponovno zagnal."
 
 #: services/forms.py:118
 msgid "The AFP service failed to reload."
@@ -1780,10 +1780,10 @@ msgstr "UNIX Končnica"
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
-"Te razširitve omogočajo, da Samba bolje služil UNIX CIFS strankam s podporo "
+"Te razširitve omogočajo, da Samba bolje služil UNIX SMB strankam s podporo "
 "funkcij, kot so simbolne povezave (symbolic links), trdih povezav (hard "
 "links), itd ..."
 
@@ -1826,17 +1826,17 @@ msgstr "Odkrivanje deljenja Zeroconf"
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 "Zeroconf podpora preko Avahi-a omogoča strankam (Mac OSX finder) za "
-"samodejno odkrivanje CIFS deljenje prostora na sistemu, podobno kot Computer "
+"samodejno odkrivanje SMB deljenje prostora na sistemu, podobno kot Computer "
 "Browse storitev v windows sistemih."
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "Ime strežnika"
@@ -3246,11 +3246,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr "Ti parametri so dodani [Share] sekciji v smb.conf"
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5396,7 +5396,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5659,7 +5659,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5683,19 +5683,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -9353,7 +9353,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -10032,7 +10032,7 @@ msgstr "Število strežnikov"
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "% uspešno posodobljen."
 
 #: sharing/models.py:290
@@ -13038,7 +13038,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/sr/LC_MESSAGES/django.po
+++ b/gui/locale/sr/LC_MESSAGES/django.po
@@ -1335,8 +1335,8 @@ msgid "This field is required for \"Home directories\"."
 msgstr "Ovo polje je obavezno za \"Matične direktorijume\"."
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
-msgstr "CIFS servis nije uspeo da se ponovo učita."
+msgid "The SMB service failed to reload."
+msgstr "SMB servis nije uspeo da se ponovo učita."
 
 #: services/forms.py:118
 msgid "The AFP service failed to reload."
@@ -1801,10 +1801,10 @@ msgstr "Unix ekstenzije"
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
-"Ovi dodaci omogućavaju da Samba bolje služiti UNIX CIFS klijentima "
+"Ovi dodaci omogućavaju da Samba bolje služiti UNIX SMB klijentima "
 "podržavajući funkcije kao što su simboličke veze, čvrste vezama, itd..."
 
 #: services/models.py:171
@@ -1842,17 +1842,17 @@ msgstr "Zeroconf deljeno otkrivanje"
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 "Zeroconf podrška preko Avahi omogućava klijentima (Mac OSX Finder posebno) "
-"da automatski otkrije CIFS deljene resurse na sistemu sličnih Computer "
+"da automatski otkrije SMB deljene resurse na sistemu sličnih Computer "
 "Browser servisa u Windows sistemu."
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "Ime Servera"
@@ -3309,12 +3309,12 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr "Ovi parametri su dodati na [Share] sekciju smb.conf"
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
-msgstr "Windows (CIFS) deljeni resurs"
+msgid "Windows (SMB) Share"
+msgstr "Windows (SMB) deljeni resurs"
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
-msgstr "Windows (CIFS) deljeni resurs"
+msgid "Windows (SMB) Shares"
+msgstr "Windows (SMB) deljeni resurs"
 
 #: sharing/models.py:114
 msgid ""
@@ -5444,8 +5444,8 @@ msgstr "AFP podešavanja"
 #~ msgstr "Podešavanja za Aktivni Direktorijum"
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
-msgstr "CIFS podešavanja"
+msgid "SMB Settings"
+msgstr "SMB podešavanja"
 
 #: templates/services/core.html:45
 msgid "Dynamic DNS Settings"
@@ -5666,8 +5666,8 @@ msgid "UNIX (NFS)"
 msgstr "UNIX (NFS)"
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
-msgstr "Windows (CIFS)"
+msgid "Windows (SMB)"
+msgstr "Windows (SMB)"
 
 #~ msgid "There are no active UNIX (NFS) shares."
 #~ msgstr "Nema aktivnih UNIX (NFS) deljenih resursa."
@@ -5684,17 +5684,17 @@ msgstr "Windows (CIFS)"
 #~ msgid "Add UNIX (NFS) Share"
 #~ msgstr "Dodati UNIX (NFS) deljeni resurs"
 
-#~ msgid "There are no active Windows (CIFS) shares."
-#~ msgstr "Nema aktivnih Windows (CIFS) deljenih resursa."
+#~ msgid "There are no active Windows (SMB) shares."
+#~ msgstr "Nema aktivnih Windows (SMB) deljenih resursa."
 
-#~ msgid "Edit Windows (CIFS) Share"
-#~ msgstr "Urediti Windows (CIFS) deljenje"
+#~ msgid "Edit Windows (SMB) Share"
+#~ msgstr "Urediti Windows (SMB) deljenje"
 
-#~ msgid "Delete Windows (CIFS) Share"
-#~ msgstr "Obrisati Windows (CIFS) deljenje"
+#~ msgid "Delete Windows (SMB) Share"
+#~ msgstr "Obrisati Windows (SMB) deljenje"
 
-#~ msgid "Add Windows (CIFS) Share"
-#~ msgstr "Dodati Windows (CIFS) deljenje"
+#~ msgid "Add Windows (SMB) Share"
+#~ msgstr "Dodati Windows (SMB) deljenje"
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
 msgid "Clone Snapshot"
@@ -9452,7 +9452,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -10145,7 +10145,7 @@ msgstr "Broj servera"
 # ako % predstavlja user  kao users 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%s uspešno ažurirani."
 
 #: sharing/models.py:290
@@ -13288,7 +13288,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/sv/LC_MESSAGES/django.po
+++ b/gui/locale/sv/LC_MESSAGES/django.po
@@ -1322,8 +1322,8 @@ msgid "This field is required for \"Home directories\"."
 msgstr "Detta fält krävs för \"hemkataloger\"."
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
-msgstr "CIFS tjänsten kunde inte starta om."
+msgid "The SMB service failed to reload."
+msgstr "SMB tjänsten kunde inte starta om."
 
 #: services/forms.py:118
 msgid "The AFP service failed to reload."
@@ -1772,10 +1772,10 @@ msgstr "UNIX anknytningar"
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
-"Dessa anknytningar aktiverar Samba för att bättre betjäna UNIX CIFS-klienter "
+"Dessa anknytningar aktiverar Samba för att bättre betjäna UNIX SMB-klienter "
 "genom att stödja funktioner som symboliska länkar, hårda länkar, etc. .."
 
 #: services/models.py:171
@@ -1813,17 +1813,17 @@ msgstr "Noll-konfigurerings utdelning upptäckt"
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 "Noll-konfigurerings support via Avahi tillåter klienter (Mac OSX Finder i "
-"synnerhet) för att automatiskt upptäcka CIFS utdelningarna i systemet "
+"synnerhet) för att automatiskt upptäcka SMB utdelningarna i systemet "
 "liknande utforskaren tjänsten i Windows."
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "Server namn"
@@ -3261,12 +3261,12 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr "Dessa parametrar läggs till [Share] i smb.conf"
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
-msgstr "Windows (CIFS) utdelning"
+msgid "Windows (SMB) Share"
+msgstr "Windows (SMB) utdelning"
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
-msgstr "Windows (CIFS) utdelning"
+msgid "Windows (SMB) Shares"
+msgstr "Windows (SMB) utdelning"
 
 #: sharing/models.py:114
 #, fuzzy
@@ -5386,8 +5386,8 @@ msgstr "AFP Inställningar"
 #~ msgstr "Active DirectoryInställningar"
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
-msgstr "CIFS Inställningar"
+msgid "SMB Settings"
+msgstr "SMB Inställningar"
 
 #: templates/services/core.html:45
 msgid "Dynamic DNS Settings"
@@ -5607,8 +5607,8 @@ msgid "UNIX (NFS)"
 msgstr "UNIX (NFS)"
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
-msgstr "Windows (CIFS)"
+msgid "Windows (SMB)"
+msgstr "Windows (SMB)"
 
 #~ msgid "There are no active UNIX (NFS) shares."
 #~ msgstr "Det finns inga aktiva UNIX (NFS) utdelningar."
@@ -5625,17 +5625,17 @@ msgstr "Windows (CIFS)"
 #~ msgid "Add UNIX (NFS) Share"
 #~ msgstr "Lägg till UNIX (NFS) utdelningar"
 
-#~ msgid "There are no active Windows (CIFS) shares."
-#~ msgstr "Det finns inga aktiva Windows (CIFS) utdelningar."
+#~ msgid "There are no active Windows (SMB) shares."
+#~ msgstr "Det finns inga aktiva Windows (SMB) utdelningar."
 
-#~ msgid "Edit Windows (CIFS) Share"
-#~ msgstr "Redigera Windows (CIFS) utdelningar"
+#~ msgid "Edit Windows (SMB) Share"
+#~ msgstr "Redigera Windows (SMB) utdelningar"
 
-#~ msgid "Delete Windows (CIFS) Share"
-#~ msgstr "Ta bort Windows (CIFS) utdelningar"
+#~ msgid "Delete Windows (SMB) Share"
+#~ msgstr "Ta bort Windows (SMB) utdelningar"
 
-#~ msgid "Add Windows (CIFS) Share"
-#~ msgstr "Lägg till Windows (CIFS) utdelning"
+#~ msgid "Add Windows (SMB) Share"
+#~ msgstr "Lägg till Windows (SMB) utdelning"
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
 msgid "Clone Snapshot"
@@ -6215,8 +6215,8 @@ msgstr "Kritiska Alarm"
 #~ msgid "Close"
 #~ msgstr "Stäng"
 
-#~ msgid "Add Apple (CIFS) Share"
-#~ msgstr "Lägg till Apple (CIFS) utdelningar"
+#~ msgid "Add Apple (SMB) Share"
+#~ msgstr "Lägg till Apple (SMB) utdelningar"
 
 #~ msgid "Hourly"
 #~ msgstr "Varje timme"
@@ -9383,7 +9383,7 @@ msgstr "Lägg till laddare"
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -10063,7 +10063,7 @@ msgstr "Antal servrar"
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%s uppdateringen lyckades."
 
 #: sharing/models.py:290
@@ -13163,7 +13163,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/sw/LC_MESSAGES/django.po
+++ b/gui/locale/sw/LC_MESSAGES/django.po
@@ -1341,7 +1341,7 @@ msgid "This field is required for \"Home directories\"."
 msgstr ""
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr ""
 
 #: services/forms.py:118
@@ -1773,7 +1773,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1810,13 +1810,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:203
@@ -3166,11 +3166,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5284,7 +5284,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5544,7 +5544,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5568,19 +5568,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -8936,7 +8936,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -9572,7 +9572,7 @@ msgid "Kerberos Realm"
 msgstr ""
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr ""
 
 #: sharing/models.py:290
@@ -12348,7 +12348,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/ta/LC_MESSAGES/django.po
+++ b/gui/locale/ta/LC_MESSAGES/django.po
@@ -1359,7 +1359,7 @@ msgid "This field is required for \"Home directories\"."
 msgstr ""
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr ""
 
 #: services/forms.py:118
@@ -1792,7 +1792,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1829,13 +1829,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:203
@@ -3185,11 +3185,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5303,7 +5303,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5563,7 +5563,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5587,19 +5587,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -8992,7 +8992,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -9636,7 +9636,7 @@ msgid "Kerberos Realm"
 msgstr ""
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr ""
 
 #: sharing/models.py:290
@@ -12458,7 +12458,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/tg/LC_MESSAGES/django.po
+++ b/gui/locale/tg/LC_MESSAGES/django.po
@@ -1341,7 +1341,7 @@ msgid "This field is required for \"Home directories\"."
 msgstr ""
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr ""
 
 #: services/forms.py:118
@@ -1773,7 +1773,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1810,13 +1810,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:203
@@ -3166,11 +3166,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5284,7 +5284,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5544,7 +5544,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5568,19 +5568,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -8936,7 +8936,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -9572,7 +9572,7 @@ msgid "Kerberos Realm"
 msgstr ""
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr ""
 
 #: sharing/models.py:290
@@ -12348,7 +12348,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/th/LC_MESSAGES/django.po
+++ b/gui/locale/th/LC_MESSAGES/django.po
@@ -1398,7 +1398,7 @@ msgid "This field is required for \"Home directories\"."
 msgstr ""
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr ""
 
 #: services/forms.py:118
@@ -1832,7 +1832,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1869,13 +1869,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:203
@@ -3226,11 +3226,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5351,7 +5351,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5611,7 +5611,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5635,19 +5635,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -9084,7 +9084,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -9739,7 +9739,7 @@ msgid "Kerberos Realm"
 msgstr ""
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr ""
 
 #: sharing/models.py:290
@@ -12619,7 +12619,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/tr/LC_MESSAGES/django.po
+++ b/gui/locale/tr/LC_MESSAGES/django.po
@@ -1349,8 +1349,8 @@ msgid "This field is required for \"Home directories\"."
 msgstr "\"Ana dizinler\" için bu alan gereklidir."
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
-msgstr "CIFS hizmetini yeniden yükleme başarısız oldu."
+msgid "The SMB service failed to reload."
+msgstr "SMB hizmetini yeniden yükleme başarısız oldu."
 
 #: services/forms.py:118
 msgid "The AFP service failed to reload."
@@ -1809,11 +1809,11 @@ msgstr "Unix Uzantıları"
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 "Bu uzantılar, simgesel bağlantılar, sabit bağlatılar, vb. gibi özellikleri "
-"destekleyerek UNIX CIFS istemcilerinin daha iyi hizmet etmesi için Samba'yı "
+"destekleyerek UNIX SMB istemcilerinin daha iyi hizmet etmesi için Samba'yı "
 "etkinleştirir."
 
 #: services/models.py:171
@@ -1849,17 +1849,17 @@ msgstr "Sıfır yapılandırma paylaşım keşfi"
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 "Avahi aracılığıyla sıfır yapılandırma desteği, Windows'taki Bilgisayar "
-"Tarayıcısı hizmetine benzer, sistem üzerinde CIFS paylaşımlarını otomatik "
+"Tarayıcısı hizmetine benzer, sistem üzerinde SMB paylaşımlarını otomatik "
 "olarak keşfetmek için istemcilere (özellikle Mac OSX buluculara) izin verir."
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "Sunucu adı"
@@ -3317,12 +3317,12 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr "Bu parametreler smb.conf dosyasının [Share] bölümüne eklenir"
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
-msgstr "Windows (CIFS) Paylaşımı"
+msgid "Windows (SMB) Share"
+msgstr "Windows (SMB) Paylaşımı"
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
-msgstr "Windows (CIFS) Paylaşımları"
+msgid "Windows (SMB) Shares"
+msgstr "Windows (SMB) Paylaşımları"
 
 #: sharing/models.py:114
 msgid ""
@@ -5463,8 +5463,8 @@ msgid "Active Directory Settings"
 msgstr "Active Directory Ayarları"
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
-msgstr "CIFS Ayarları"
+msgid "SMB Settings"
+msgstr "SMB Ayarları"
 
 #: templates/services/core.html:45
 msgid "Dynamic DNS Settings"
@@ -5687,8 +5687,8 @@ msgid "UNIX (NFS)"
 msgstr "UNIX (NFS)"
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
-msgstr "Windows (CIFS)"
+msgid "Windows (SMB)"
+msgstr "Windows (SMB)"
 
 #~ msgid "There are no active UNIX (NFS) shares."
 #~ msgstr "Hiç aktif UNIX (NFS) paylaşımı yok."
@@ -5705,17 +5705,17 @@ msgstr "Windows (CIFS)"
 #~ msgid "Add UNIX (NFS) Share"
 #~ msgstr "UNIX (NFS) Paylaşımı Ekle"
 
-#~ msgid "There are no active Windows (CIFS) shares."
-#~ msgstr "Hiç aktif Windows (CIFS) paylaşımı yok."
+#~ msgid "There are no active Windows (SMB) shares."
+#~ msgstr "Hiç aktif Windows (SMB) paylaşımı yok."
 
-#~ msgid "Edit Windows (CIFS) Share"
-#~ msgstr "Windows (CIFS) Paylaşımını Düzenle"
+#~ msgid "Edit Windows (SMB) Share"
+#~ msgstr "Windows (SMB) Paylaşımını Düzenle"
 
-#~ msgid "Delete Windows (CIFS) Share"
-#~ msgstr "Windows (CIFS) Paylaşımını Sil"
+#~ msgid "Delete Windows (SMB) Share"
+#~ msgstr "Windows (SMB) Paylaşımını Sil"
 
-#~ msgid "Add Windows (CIFS) Share"
-#~ msgstr "Windows (CIFS) Paylaşımı Ekle"
+#~ msgid "Add Windows (SMB) Share"
+#~ msgstr "Windows (SMB) Paylaşımı Ekle"
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
 msgid "Clone Snapshot"
@@ -6378,8 +6378,8 @@ msgstr "Kafes IP"
 #~ msgid "Plugins path"
 #~ msgstr "Eklenti yolu"
 
-#~ msgid "Add Apple (CIFS) Share"
-#~ msgstr "Apple (CIFS) Paylaşımı Ekle"
+#~ msgid "Add Apple (SMB) Share"
+#~ msgstr "Apple (SMB) Paylaşımı Ekle"
 
 #~ msgid "Apply Service Pack"
 #~ msgstr "Hizmet Paketi Yükle"
@@ -6492,11 +6492,11 @@ msgstr "Parolayı etkisizleştir"
 #~ "istemciye sunulacak olan ayrıcalıklar. Bu kullanıcının giriş yapabilmesi "
 #~ "için parola dosyasında olmalıdır yoksa girişi geçersizdir."
 
-#~ msgid "CIFS Share"
-#~ msgstr "CIFS Paylaşımı"
+#~ msgid "SMB Share"
+#~ msgstr "SMB Paylaşımı"
 
-#~ msgid "CIFS Shares"
-#~ msgstr "CIFS Paylaşımları"
+#~ msgid "SMB Shares"
+#~ msgstr "SMB Paylaşımları"
 
 #~ msgid "NFS Share"
 #~ msgstr "NFS Paylaşımı"
@@ -9593,9 +9593,9 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
-"Soru işareti (?) içeren parolalara, şimdilik CIFS ile olan sorunlardan "
+"Soru işareti (?) içeren parolalara, şimdilik SMB ile olan sorunlardan "
 "dolayı izin verilmiyor."
 
 #: directoryservice/forms.py:104
@@ -10299,8 +10299,8 @@ msgid "Kerberos Realm"
 msgstr "Kerberos Erişim Alanı"
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
-msgstr "CIFS başarılı olarak güncellendi."
+msgid "SMB successfully updated."
+msgstr "SMB başarılı olarak güncellendi."
 
 #: sharing/models.py:290
 msgid "Security"
@@ -13331,8 +13331,8 @@ msgstr ""
 "çizgilerdir."
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
-msgstr "Active Directory kullanımdayken CIFS etkisizleştirilemez."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
+msgstr "Active Directory kullanımdayken SMB etkisizleştirilemez."
 
 #: services/models.py:1295
 msgid "Shutdown Command"

--- a/gui/locale/uk/LC_MESSAGES/django.po
+++ b/gui/locale/uk/LC_MESSAGES/django.po
@@ -1347,8 +1347,8 @@ msgid "This field is required for \"Home directories\"."
 msgstr "Це поле є обов'язковим для \"Домашні каталоги\"."
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
-msgstr "Службу CIFS не вдалося перезавантажити."
+msgid "The SMB service failed to reload."
+msgstr "Службу SMB не вдалося перезавантажити."
 
 #: services/forms.py:118
 msgid "The AFP service failed to reload."
@@ -1793,10 +1793,10 @@ msgstr "Розширення Unix"
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
-"Ці розширення дозволяють Samba краще обслуговувати UNIX CIFS клієнтів "
+"Ці розширення дозволяють Samba краще обслуговувати UNIX SMB клієнтів "
 "завдяки підтримці символічних посилань, жорстких посилань і тд ..."
 
 #: services/models.py:171
@@ -1835,17 +1835,17 @@ msgstr "Використання Zeroconf share"
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 "Підтримка Zeroconf через Avahi дозволяє клієнтам (зокрема, пошуку Mac OSX) "
-"автоматично знаходити спільні ресурси CIFS аналогічно службі Computer "
+"автоматично знаходити спільні ресурси SMB аналогічно службі Computer "
 "Browser в Windows."
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "Ім'я сервера"
@@ -3297,12 +3297,12 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr "Ці параметри додаються до розділу [Share] smb.conf"
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
-msgstr "Спільний ресурс Windows (CIFS)"
+msgid "Windows (SMB) Share"
+msgstr "Спільний ресурс Windows (SMB)"
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
-msgstr "Спільні ресурси Windows (CIFS)"
+msgid "Windows (SMB) Shares"
+msgstr "Спільні ресурси Windows (SMB)"
 
 #: sharing/models.py:114
 msgid ""
@@ -5430,8 +5430,8 @@ msgid "Active Directory Settings"
 msgstr "Налаштування Active Directory"
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
-msgstr "Налаштування CIFS"
+msgid "SMB Settings"
+msgstr "Налаштування SMB"
 
 #: templates/services/core.html:45
 msgid "Dynamic DNS Settings"
@@ -5652,8 +5652,8 @@ msgid "UNIX (NFS)"
 msgstr "UNIX (NFS)"
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
-msgstr "Windows (CIFS)"
+msgid "Windows (SMB)"
+msgstr "Windows (SMB)"
 
 #~ msgid "There are no active UNIX (NFS) shares."
 #~ msgstr "Немає активних спільних ресурсів UNIX (NFS)."
@@ -5670,17 +5670,17 @@ msgstr "Windows (CIFS)"
 #~ msgid "Add UNIX (NFS) Share"
 #~ msgstr "Додати спільний ресурс UNIX (NFS)"
 
-#~ msgid "There are no active Windows (CIFS) shares."
-#~ msgstr "Немає активних спільних ресурсів Windows (CIFS)."
+#~ msgid "There are no active Windows (SMB) shares."
+#~ msgstr "Немає активних спільних ресурсів Windows (SMB)."
 
-#~ msgid "Edit Windows (CIFS) Share"
-#~ msgstr "Змінити спільний ресурс Windows (CIFS)"
+#~ msgid "Edit Windows (SMB) Share"
+#~ msgstr "Змінити спільний ресурс Windows (SMB)"
 
-#~ msgid "Delete Windows (CIFS) Share"
-#~ msgstr "Видалити спільний ресурс Windows (CIFS)"
+#~ msgid "Delete Windows (SMB) Share"
+#~ msgstr "Видалити спільний ресурс Windows (SMB)"
 
-#~ msgid "Add Windows (CIFS) Share"
-#~ msgstr "Додати спільний ресурс Windows (CIFS)"
+#~ msgid "Add Windows (SMB) Share"
+#~ msgstr "Додати спільний ресурс Windows (SMB)"
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
 msgid "Clone Snapshot"
@@ -6345,8 +6345,8 @@ msgstr "Jail IP"
 #~ msgid "Plugins path"
 #~ msgstr "Шлях плагінів"
 
-#~ msgid "Add Apple (CIFS) Share"
-#~ msgstr "Додати спільний ресурс Apple (CIFS)"
+#~ msgid "Add Apple (SMB) Share"
+#~ msgstr "Додати спільний ресурс Apple (SMB)"
 
 #~ msgid "Apply Service Pack"
 #~ msgstr "Прийняти оновлення"
@@ -6452,11 +6452,11 @@ msgstr "Відключити пароль"
 #~ "гостьової служби. Цей користувач повинен існувати у файлі паролів, але не "
 #~ "вимагає коректного імені користувача."
 
-#~ msgid "CIFS Share"
-#~ msgstr "Загальний ресурс CIFS"
+#~ msgid "SMB Share"
+#~ msgstr "Загальний ресурс SMB"
 
-#~ msgid "CIFS Shares"
-#~ msgstr "Загальні ресурси CIFS"
+#~ msgid "SMB Shares"
+#~ msgstr "Загальні ресурси SMB"
 
 #~ msgid "NFS Share"
 #~ msgstr "Спільний ресурс NFS"
@@ -9522,8 +9522,8 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
-msgstr "Паролі що містять знак питання (?) заборонені через проблеми з CIFS."
+"problems with SMB."
+msgstr "Паролі що містять знак питання (?) заборонені через проблеми з SMB."
 
 #: directoryservice/forms.py:104
 msgid "NT4 failed to reload."
@@ -10217,8 +10217,8 @@ msgid "Kerberos Realm"
 msgstr "Область Kerberos"
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
-msgstr "CIFS успішно оновлено."
+msgid "SMB successfully updated."
+msgstr "SMB успішно оновлено."
 
 #: sharing/models.py:290
 msgid "Security"
@@ -13215,9 +13215,9 @@ msgid ""
 msgstr "Символи для імен jail є букви, цифри, тире або знак підкреслення."
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
-"Неможливо відключити CIFS в той час як Active Directory використовується."
+"Неможливо відключити SMB в той час як Active Directory використовується."
 
 #: services/models.py:1295
 msgid "Shutdown Command"

--- a/gui/locale/uz/LC_MESSAGES/django.po
+++ b/gui/locale/uz/LC_MESSAGES/django.po
@@ -1342,7 +1342,7 @@ msgid "This field is required for \"Home directories\"."
 msgstr ""
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr ""
 
 #: services/forms.py:118
@@ -1774,7 +1774,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1811,13 +1811,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:203
@@ -3167,11 +3167,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5285,7 +5285,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5545,7 +5545,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5569,19 +5569,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -8937,7 +8937,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -9573,7 +9573,7 @@ msgid "Kerberos Realm"
 msgstr ""
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr ""
 
 #: sharing/models.py:290
@@ -12349,7 +12349,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/vi/LC_MESSAGES/django.po
+++ b/gui/locale/vi/LC_MESSAGES/django.po
@@ -1359,7 +1359,7 @@ msgstr "Mục này bắt buộc cho \"Thư mục chính\""
 
 #: services/forms.py:106
 #, fuzzy
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr "Khởi động lại dịch vụ đã không thành công."
 
 #: services/forms.py:118
@@ -1796,7 +1796,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1833,13 +1833,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:203
@@ -3198,13 +3198,13 @@ msgstr ""
 
 #: sharing/models.py:94
 #, fuzzy
-msgid "Windows (CIFS) Share"
-msgstr "Thiết lập CIFS"
+msgid "Windows (SMB) Share"
+msgstr "Thiết lập SMB"
 
 #: sharing/models.py:95
 #, fuzzy
-msgid "Windows (CIFS) Shares"
-msgstr "Thiết lập CIFS"
+msgid "Windows (SMB) Shares"
+msgstr "Thiết lập SMB"
 
 #: sharing/models.py:114
 msgid ""
@@ -5344,8 +5344,8 @@ msgid "Active Directory Settings"
 msgstr "Thiết lập Active Directory"
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
-msgstr "Thiết lập CIFS"
+msgid "SMB Settings"
+msgstr "Thiết lập SMB"
 
 #: templates/services/core.html:45
 msgid "Dynamic DNS Settings"
@@ -5611,7 +5611,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5633,22 +5633,22 @@ msgstr ""
 #: templates/sharing/unix.html:49 templates/sharing/unix.html.py:51
 #, fuzzy
 msgid "Add UNIX (NFS) Share"
-msgstr "Thiết lập CIFS"
+msgstr "Thiết lập SMB"
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -6268,8 +6268,8 @@ msgid "View Tunables"
 msgstr "Xem tất cả tài khoản"
 
 #, fuzzy
-msgid "Add Apple (CIFS) Share"
-msgstr "Thiết lập CIFS"
+msgid "Add Apple (SMB) Share"
+msgstr "Thiết lập SMB"
 
 #~ msgid "DVD"
 #~ msgstr "DVD"
@@ -9237,7 +9237,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -9908,7 +9908,7 @@ msgstr ""
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%s đã cập nhật thành công."
 
 #: sharing/models.py:290
@@ -12862,7 +12862,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/zh_CN/LC_MESSAGES/django.po
+++ b/gui/locale/zh_CN/LC_MESSAGES/django.po
@@ -1325,8 +1325,8 @@ msgid "This field is required for \"Home directories\"."
 msgstr "要使用 \"主目录\" 则此项必填。"
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
-msgstr "CIFS 服务重载失败。"
+msgid "The SMB service failed to reload."
+msgstr "SMB 服务重载失败。"
 
 #: services/forms.py:118
 msgid "The AFP service failed to reload."
@@ -1756,9 +1756,9 @@ msgstr "Unix 扩展"
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
-msgstr "这些扩展使 Samba 能更好地支持 UNIX CIFS 客户端，实现如符号链接，硬件链接等功能..."
+msgstr "这些扩展使 Samba 能更好地支持 UNIX SMB 客户端，实现如符号链接，硬件链接等功能..."
 
 #: services/models.py:171
 msgid "Enable AIO"
@@ -1793,14 +1793,14 @@ msgstr "Zeroconf 共享发现"
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
-msgstr "Zeroconf 通过 Avahi 允许客户端(特别是Mac OSX Finder)自动发现 CIFS 共享。"
+msgstr "Zeroconf 通过 Avahi 允许客户端(特别是Mac OSX Finder)自动发现 SMB 共享。"
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "服务器名"
@@ -3157,12 +3157,12 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr "这些参数将追加到 smb.conf 配置文件的 [Share] 小节"
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
-msgstr "Windows (CIFS) 共享"
+msgid "Windows (SMB) Share"
+msgstr "Windows (SMB) 共享"
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
-msgstr "Windows (CIFS) 共享列表"
+msgid "Windows (SMB) Shares"
+msgstr "Windows (SMB) 共享列表"
 
 #: sharing/models.py:114
 msgid ""
@@ -5211,8 +5211,8 @@ msgid "Active Directory Settings"
 msgstr "活动目录设置"
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
-msgstr "CIFS设置"
+msgid "SMB Settings"
+msgstr "SMB设置"
 
 #: templates/services/core.html:45
 msgid "Dynamic DNS Settings"
@@ -5434,8 +5434,8 @@ msgid "UNIX (NFS)"
 msgstr "UNIX（NFS）"
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
-msgstr "Windows(CIFS)"
+msgid "Windows (SMB)"
+msgstr "Windows(SMB)"
 
 #~ msgid "There are no active UNIX (NFS) shares."
 #~ msgstr "无活动 UNIX(NFS) 共享"
@@ -5452,17 +5452,17 @@ msgstr "Windows(CIFS)"
 #~ msgid "Add UNIX (NFS) Share"
 #~ msgstr "添加 UNIX(NFS) 共享"
 
-#~ msgid "There are no active Windows (CIFS) shares."
-#~ msgstr "无活动的 Windows(CIFS) 共享"
+#~ msgid "There are no active Windows (SMB) shares."
+#~ msgstr "无活动的 Windows(SMB) 共享"
 
-#~ msgid "Edit Windows (CIFS) Share"
-#~ msgstr "编辑 Windows(CIFS) 共享"
+#~ msgid "Edit Windows (SMB) Share"
+#~ msgstr "编辑 Windows(SMB) 共享"
 
-#~ msgid "Delete Windows (CIFS) Share"
-#~ msgstr "删除 Windows(CIFS) 共享"
+#~ msgid "Delete Windows (SMB) Share"
+#~ msgstr "删除 Windows(SMB) 共享"
 
-#~ msgid "Add Windows (CIFS) Share"
-#~ msgstr "添加 Windows(CIFS) 共享"
+#~ msgid "Add Windows (SMB) Share"
+#~ msgstr "添加 Windows(SMB) 共享"
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
 msgid "Clone Snapshot"
@@ -6082,7 +6082,7 @@ msgstr "无效的前缀"
 #~ msgid "Close"
 #~ msgstr "关闭"
 
-#~ msgid "Add Apple (CIFS) Share"
+#~ msgid "Add Apple (SMB) Share"
 #~ msgstr "增加 Apple (AFP) 共享"
 
 #~ msgid "Apply Service Pack"
@@ -6185,11 +6185,11 @@ msgstr "禁用密码"
 #~ "这个用户的权限将决定所有以访客身份连接服务的客户的权限。这个用户在密码文件"
 #~ "中必须存在，但不必拥有登录权限。"
 
-#~ msgid "CIFS Share"
-#~ msgstr "CIFS 共享"
+#~ msgid "SMB Share"
+#~ msgstr "SMB 共享"
 
-#~ msgid "CIFS Shares"
-#~ msgstr "CIFS 共享列表"
+#~ msgid "SMB Shares"
+#~ msgstr "SMB 共享列表"
 
 #~ msgid "NFS Share"
 #~ msgstr "NFS共享"
@@ -9111,8 +9111,8 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
-msgstr "由于CIFS服务问题，当前不允许在密码中使用 (?) 符号。"
+"problems with SMB."
+msgstr "由于SMB服务问题，当前不允许在密码中使用 (?) 符号。"
 
 #: directoryservice/forms.py:104
 msgid "NT4 failed to reload."
@@ -9764,8 +9764,8 @@ msgid "Kerberos Realm"
 msgstr "Kerberos Realm"
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
-msgstr "CIFS 已更新。"
+msgid "SMB successfully updated."
+msgstr "SMB 已更新。"
 
 #: sharing/models.py:290
 msgid "Security"
@@ -12681,7 +12681,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/zh_HK/LC_MESSAGES/django.po
+++ b/gui/locale/zh_HK/LC_MESSAGES/django.po
@@ -1353,7 +1353,7 @@ msgid "This field is required for \"Home directories\"."
 msgstr "欲使用 \"家目錄\" 的功能須填此欄位。"
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr ""
 
 #: services/forms.py:118
@@ -1796,7 +1796,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1833,13 +1833,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #~ msgid "Server Name"
@@ -3212,12 +3212,12 @@ msgstr ""
 
 #: sharing/models.py:94
 #, fuzzy
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr "Windows 版本"
 
 #: sharing/models.py:95
 #, fuzzy
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr "Windows 版本"
 
 #: sharing/models.py:114
@@ -5393,7 +5393,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5667,7 +5667,7 @@ msgstr ""
 
 #: templates/sharing/index.html:12
 #, fuzzy
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr "Windows 版本"
 
 #: templates/sharing/unix.html:7
@@ -5693,22 +5693,22 @@ msgid "Add UNIX (NFS) Share"
 msgstr "UNIX 字符集"
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
 #, fuzzy
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr "Windows 版本"
 
 #: templates/sharing/windows.html:39
 #, fuzzy
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr "Windows 版本"
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
 #, fuzzy
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr "Windows 版本"
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -6346,7 +6346,7 @@ msgid "View Tunables"
 msgstr "查看所有用戶"
 
 #, fuzzy
-msgid "Add Apple (CIFS) Share"
+msgid "Add Apple (SMB) Share"
 msgstr "UNIX 字符集"
 
 #~ msgid "Apply Service Pack"
@@ -6406,7 +6406,7 @@ msgstr "停用密碼"
 #~ msgstr "訪客帳戶"
 
 #, fuzzy
-msgid "CIFS Shares"
+msgid "SMB Shares"
 msgstr "UNIX 字符集"
 
 #, fuzzy
@@ -9416,7 +9416,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -10096,7 +10096,7 @@ msgstr "伺服器數量"
 
 #: services/views.py:269
 #, fuzzy
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr "%s 已成功更新."
 
 #: sharing/models.py:290
@@ -13093,7 +13093,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/zh_TW/LC_MESSAGES/django.po
+++ b/gui/locale/zh_TW/LC_MESSAGES/django.po
@@ -1365,8 +1365,8 @@ msgid "This field is required for \"Home directories\"."
 msgstr "欲使用 \"家目錄\" 的功能須填此欄位。"
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
-msgstr "CIFS 服務重新載入時發生失敗"
+msgid "The SMB service failed to reload."
+msgstr "SMB 服務重新載入時發生失敗"
 
 #: services/forms.py:118
 msgid "The AFP service failed to reload."
@@ -1803,7 +1803,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1842,14 +1842,14 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
-msgstr "CIFS"
+msgid "SMB"
+msgstr "SMB"
 
 #~ msgid "Server Name"
 #~ msgstr "主機名稱"
@@ -3240,12 +3240,12 @@ msgstr "這些參數被新增到 smb.conf 的 [Share] 段落"
 
 #: sharing/models.py:94
 #, fuzzy
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr "Windows 檔案共享"
 
 #: sharing/models.py:95
 #, fuzzy
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr "Windows 檔案共享"
 
 #: sharing/models.py:114
@@ -5358,8 +5358,8 @@ msgstr "AFP 設定"
 #~ msgstr "Active Directory 設定"
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
-msgstr "CIFS 設定"
+msgid "SMB Settings"
+msgstr "SMB 設定"
 
 #: templates/services/core.html:45
 msgid "Dynamic DNS Settings"
@@ -5615,8 +5615,8 @@ msgstr "新增UNIX共享(NFS)"
 
 #: templates/sharing/index.html:12
 #, fuzzy
-msgid "Windows (CIFS)"
-msgstr "新增Windows共享(CIFS)"
+msgid "Windows (SMB)"
+msgstr "新增Windows共享(SMB)"
 
 #: templates/sharing/unix.html:7
 #, fuzzy
@@ -5643,22 +5643,22 @@ msgstr "新增UNIX共享"
 
 #: templates/sharing/windows.html:7
 #, fuzzy
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr "沒有設定Windows共享"
 
 #: templates/sharing/windows.html:33
 #, fuzzy
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr "設定Windows共享"
 
 #: templates/sharing/windows.html:39
 #, fuzzy
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr "刪除Windows共享"
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
 #, fuzzy
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr "新增Windows共享"
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -6303,7 +6303,7 @@ msgstr "檢視公開金鑰"
 #~ msgstr "關閉"
 
 #, fuzzy
-msgid "Add Apple (CIFS) Share"
+msgid "Add Apple (SMB) Share"
 msgstr "新增 Apple Share"
 
 #~ msgid "Apply Service Pack"
@@ -6410,11 +6410,11 @@ msgstr "停用密碼"
 #~ "所有權限都將套用至每個連至訪客服務的用戶端。此帳號必須存在於 password 檔"
 #~ "裡，但不必是個有效的登入帳號。"
 
-#~ msgid "CIFS Share"
-#~ msgstr "CIFS 共享"
+#~ msgid "SMB Share"
+#~ msgstr "SMB 共享"
 
-#~ msgid "CIFS Shares"
-#~ msgstr "CIFS 共享"
+#~ msgid "SMB Shares"
+#~ msgstr "SMB 共享"
 
 #~ msgid "NFS Share"
 #~ msgstr "NFS 共享"
@@ -9703,8 +9703,8 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
-msgstr "由於 CIFS 的問題，目前不允許密碼中包含問號 (?)"
+"problems with SMB."
+msgstr "由於 SMB 的問題，目前不允許密碼中包含問號 (?)"
 
 #: directoryservice/forms.py:104
 #, fuzzy
@@ -10394,8 +10394,8 @@ msgid "Kerberos Realm"
 msgstr "Kerberos Keytab 檔"
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
-msgstr "CIFS 更新成功"
+msgid "SMB successfully updated."
+msgstr "SMB 更新成功"
 
 #: sharing/models.py:290
 msgid "Security"
@@ -13473,7 +13473,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/locale/zu/LC_MESSAGES/django.po
+++ b/gui/locale/zu/LC_MESSAGES/django.po
@@ -1341,7 +1341,7 @@ msgid "This field is required for \"Home directories\"."
 msgstr ""
 
 #: services/forms.py:106
-msgid "The CIFS service failed to reload."
+msgid "The SMB service failed to reload."
 msgstr ""
 
 #: services/forms.py:118
@@ -1773,7 +1773,7 @@ msgstr ""
 
 #: services/models.py:167
 msgid ""
-"These extensions enable Samba to better serve UNIX CIFS clients by "
+"These extensions enable Samba to better serve UNIX SMB clients by "
 "supporting features such as symbolic links, hard links, etc..."
 msgstr ""
 
@@ -1810,13 +1810,13 @@ msgstr ""
 #: services/models.py:189
 msgid ""
 "Zeroconf support via Avahi allows clients (the Mac OSX finder in particular) "
-"to automatically discover the CIFS shares on the system similar to the "
+"to automatically discover the SMB shares on the system similar to the "
 "Computer Browser service in Windows."
 msgstr ""
 
 #: services/models.py:193 services/models.py:194
 #: templates/services/core.html:26
-msgid "CIFS"
+msgid "SMB"
 msgstr ""
 
 #: services/models.py:203
@@ -3166,11 +3166,11 @@ msgid "These parameters are added to [Share] section of smb.conf"
 msgstr ""
 
 #: sharing/models.py:94
-msgid "Windows (CIFS) Share"
+msgid "Windows (SMB) Share"
 msgstr ""
 
 #: sharing/models.py:95
-msgid "Windows (CIFS) Shares"
+msgid "Windows (SMB) Shares"
 msgstr ""
 
 #: sharing/models.py:114
@@ -5284,7 +5284,7 @@ msgid "Active Directory Settings"
 msgstr ""
 
 #: templates/services/core.html:32
-msgid "CIFS Settings"
+msgid "SMB Settings"
 msgstr ""
 
 #: templates/services/core.html:45
@@ -5544,7 +5544,7 @@ msgid "UNIX (NFS)"
 msgstr ""
 
 #: templates/sharing/index.html:12
-msgid "Windows (CIFS)"
+msgid "Windows (SMB)"
 msgstr ""
 
 #: templates/sharing/unix.html:7
@@ -5568,19 +5568,19 @@ msgid "Add UNIX (NFS) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:7
-msgid "There are no active Windows (CIFS) shares."
+msgid "There are no active Windows (SMB) shares."
 msgstr ""
 
 #: templates/sharing/windows.html:33
-msgid "Edit Windows (CIFS) Share"
+msgid "Edit Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:39
-msgid "Delete Windows (CIFS) Share"
+msgid "Delete Windows (SMB) Share"
 msgstr ""
 
 #: templates/sharing/windows.html:53 templates/sharing/windows.html.py:55
-msgid "Add Windows (CIFS) Share"
+msgid "Add Windows (SMB) Share"
 msgstr ""
 
 #: templates/storage/clonesnap.html:2 templates/storage/snapshots.html:16
@@ -8936,7 +8936,7 @@ msgstr ""
 #: account/forms.py:500
 msgid ""
 "Passwords containing a question mark (?) are currently not allowed due to "
-"problems with CIFS."
+"problems with SMB."
 msgstr ""
 
 #: directoryservice/forms.py:104
@@ -9572,7 +9572,7 @@ msgid "Kerberos Realm"
 msgstr ""
 
 #: services/views.py:269
-msgid "CIFS successfully updated."
+msgid "SMB successfully updated."
 msgstr ""
 
 #: sharing/models.py:290
@@ -12348,7 +12348,7 @@ msgid ""
 msgstr ""
 
 #: services/forms.py:95
-msgid "Cannot disable CIFS while ActiveDirectory is in use."
+msgid "Cannot disable SMB while ActiveDirectory is in use."
 msgstr ""
 
 #: services/models.py:1295

--- a/gui/services/forms.py
+++ b/gui/services/forms.py
@@ -91,7 +91,7 @@ class servicesForm(ModelForm):
         if obj.srv_enable is False and activedirectory_enabled():
             obj.srv_enable= True
             obj.save()
-            return _("Cannot disable CIFS while ActiveDirectory is in use.")
+            return _("Cannot disable SMB while ActiveDirectory is in use.")
         return False
 
     def save(self, *args, **kwargs):
@@ -322,7 +322,7 @@ class CIFSForm(ModelForm):
             models.services.objects.get(srv_service='cifs').srv_enable
         ):
             raise ServiceFailed(
-                "cifs", _("The CIFS service failed to reload.")
+                "cifs", _("The SMB service failed to reload.")
             )
 
 

--- a/gui/services/models.py
+++ b/gui/services/models.py
@@ -181,7 +181,7 @@ class CIFS(Model):
         verbose_name=_("Unix Extensions"),
         default=True,
         help_text=_("These extensions enable Samba to better serve UNIX "
-                    "CIFS clients by supporting features such as symbolic "
+                    "SMB clients by supporting features such as symbolic "
                     "links, hard links, etc..."),
     )
     cifs_srv_aio_enable = models.BooleanField(
@@ -211,7 +211,7 @@ class CIFS(Model):
         default=True,
         help_text=_("Zeroconf support via Avahi allows clients (the Mac "
                     "OSX finder in particular) to automatically discover the "
-                    "CIFS shares on the system similar to the Computer "
+                    "SMB shares on the system similar to the Computer "
                     "Browser service in Windows."),
     )
     cifs_srv_hostlookup = models.BooleanField(

--- a/gui/services/views.py
+++ b/gui/services/views.py
@@ -284,7 +284,7 @@ def services_cifs(request):
             idmap_form.save()
             return JsonResp(
                 request,
-                message=_("CIFS successfully updated.")
+                message=_("SMB successfully updated.")
             )
         else:
             return JsonResp(request, form=idmap_form)

--- a/gui/sharing/models.py
+++ b/gui/sharing/models.py
@@ -142,8 +142,8 @@ class CIFS_Share(Model):
         notifier().reload("cifs")
 
     class Meta:
-        verbose_name = _("Windows (CIFS) Share")
-        verbose_name_plural = _("Windows (CIFS) Shares")
+        verbose_name = _("Windows (SMB) Share")
+        verbose_name_plural = _("Windows (SMB) Shares")
         ordering = ["cifs_name"]
 
 

--- a/gui/system/forms.py
+++ b/gui/system/forms.py
@@ -1607,7 +1607,7 @@ class InitialWizardShareForm(Form):
     share_purpose = forms.ChoiceField(
         label=_('Purpose'),
         choices=(
-            ('cifs', _('Windows (CIFS)')),
+            ('cifs', _('Windows (SMB)')),
             ('afp', _('Apple (AFP)')),
             ('nfs', _('Unix (NFS)')),
             ('iscsitarget', _('Block Storage (iSCSI)')),

--- a/gui/templates/services/core.html
+++ b/gui/templates/services/core.html
@@ -12,14 +12,14 @@
    </tr>
    <tr>
        <td>
-           <strong>{% trans "CIFS" %}</strong>
+           <strong>{% trans "SMB" %}</strong>
        </td>
        <td>
        <img id="cifs_toggle" name="cifs_toggle" src="{{ STATIC_URL }}images/ui/buttons/{% for s  in srv %}{% if s.srv_service == "cifs" %}{% if s.srv_enable %}on{% else %}off{% endif %}{% endif %}{% endfor %}.png" onClick="toggle_service(this)">
        </td>
        <td>
            <!--img id="cifs_settings" src="{{ STATIC_URL }}images/ui/buttons/settings.png" onClick="editObject('{% trans "CIFS Settings"|force_escape|force_escape %}', '{{ cifs.get_edit_url }}');" title="{% trans "CIFS Settings" %}"-->
-           <img id="cifs_settings" src="{{ STATIC_URL }}images/ui/buttons/settings.png" onClick="editObject('{% trans "CIFS Settings"|force_escape|force_escape %}', '{% url "services_cifs" %}');" title="{% trans "CIFS Settings" %}">
+           <img id="cifs_settings" src="{{ STATIC_URL }}images/ui/buttons/settings.png" onClick="editObject('{% trans "SMB Settings"|force_escape|force_escape %}', '{% url "services_cifs" %}');" title="{% trans "SMB Settings" %}">
        </td>
    </tr>
    <tr>

--- a/gui/templates/sharing/index.html
+++ b/gui/templates/sharing/index.html
@@ -18,7 +18,7 @@
   refreshOnShow: true" class="objrefresh data_sharing_WebDAV_Share" tab="sharing.WebDAV_Share.View" id="tab_WebDAV_Share">
   </div>
 
-  <div data-dojo-type="dijit.layout.ContentPane" data-dojo-props="title: '{% trans "Windows (CIFS)"|force_escape|force_escape %}'
+  <div data-dojo-type="dijit.layout.ContentPane" data-dojo-props="title: '{% trans "Windows (SMB)"|force_escape|force_escape %}'
   {% if focus_form == "sharing.CIFS_Share.View" %}, selected: true{% endif %},
   href: '{% url "freeadmin_sharing_cifs_share_datagrid" %}',
   refreshOnShow: true" class="objrefresh data_sharing_CIFS_Share" tab="sharing.CIFS_Share.View" id="tab_CIFS_Share">


### PR DESCRIPTION
In this commit, I have replaced keyword "CIFS" with "SMB" at places
where it is visible to user on UI, example- button, forms, fields
name and help text etc.