### PR TITLE
BUG #11585: No check if SSL certificate and private key match

### DIFF
--- a/gui/system/forms.py
+++ b/gui/system/forms.py
@@ -2220,6 +2220,17 @@ class CertificateAuthorityImportForm(ModelForm):
             ))
         return passphrase
 
+    def clean_cert_privatekey(self):
+        cdata = self.cleaned_data
+        certificate = cdata.get('cert_certificate')
+        certificate = CERT_CHAIN_REGEX.findall(certificate)[-1]
+        privatekey = cdata.get('cert_privatekey')
+        if is_valid_privatekey(certificate, privatekey) is False:
+            raise forms.ValidationError(_(
+                "The private key does not match with the certificate."
+            ))
+        return cdata
+
     def save(self):
         self.instance.cert_type = models.CA_TYPE_EXISTING
 

--- a/gui/system/forms.py
+++ b/gui/system/forms.py
@@ -109,7 +109,6 @@ from freenasUI.storage.forms import VolumeAutoImportForm
 from freenasUI.storage.models import Disk, Volume, Scrub
 from freenasUI.system import models
 from freenasUI.tasks.models import SMARTTest
-from common.ssl import CERT_CHAIN_REGEX
 
 log = logging.getLogger('system.forms')
 WIZARD_PROGRESSFILE = '/tmp/.initialwizard_progress'

--- a/gui/system/forms.py
+++ b/gui/system/forms.py
@@ -2227,7 +2227,7 @@ class CertificateAuthorityImportForm(ModelForm):
             raise forms.ValidationError(_(
                 "The private key does not match with the certificate."
             ))
-        return cdata
+        return privatekey
 
     def save(self):
         self.instance.cert_type = models.CA_TYPE_EXISTING
@@ -2687,7 +2687,7 @@ class CertificateImportForm(ModelForm):
             raise forms.ValidationError(_(
                 "The private key does not match with the certificate."
             ))
-        return cdata
+        return privatekey
 
     def save(self):
         self.instance.cert_type = models.CERT_TYPE_EXISTING

--- a/gui/system/forms.py
+++ b/gui/system/forms.py
@@ -2223,7 +2223,6 @@ class CertificateAuthorityImportForm(ModelForm):
     def clean_cert_privatekey(self):
         cdata = self.cleaned_data
         certificate = cdata.get('cert_certificate')
-        certificate = CERT_CHAIN_REGEX.findall(certificate)[-1]
         privatekey = cdata.get('cert_privatekey')
         if is_valid_privatekey(certificate, privatekey) is False:
             raise forms.ValidationError(_(
@@ -2684,7 +2683,6 @@ class CertificateImportForm(ModelForm):
     def clean_cert_privatekey(self):
         cdata = self.cleaned_data
         certificate = cdata.get('cert_certificate')
-        certificate = CERT_CHAIN_REGEX.findall(certificate)[-1]
         privatekey = cdata.get('cert_privatekey')
         if is_valid_privatekey(certificate, privatekey) is False:
             raise forms.ValidationError(_(


### PR DESCRIPTION
In this commit, I have added a clean method to validate the private key against the leaf certificate of the certificate chain in the CertificateImportForm.
