### PR TITLE
Bug #15161: rsync over ssh on host No matching host key fingerprint

### DIFF
--- a/gui/freeadmin/static/lib/js/freeadmin.js
+++ b/gui/freeadmin/static/lib/js/freeadmin.js
@@ -1,4 +1,4 @@
-/*-
+sshkeyscan/*-
  * Copyright (c) 2011 iXsystems, Inc.
  * All rights reserved.
  *
@@ -1609,6 +1609,36 @@ require([
                 });
             }
         });
+    };
+
+    rsync_sshKeyScan = function(url, sendbtn) {
+        sendbtn.set('disabled', true);
+        form = getForm(sendbtn);
+        data = form.get('value');
+        var select = registry.byId("id_rsync_mode");
+        if(select.get('value') == 'ssh') {
+            var rport = registry.byId("id_rsync_remoteport");
+
+            xhr.post(url, {
+                handleAs: 'json',
+                data: {user: data['rsync_user'], host: data['rsync_remotehost'], port: rport},
+                headers: {"X-CSRFToken": CSRFToken}
+            }).then(function(data) {
+                sendbtn.set('disabled', false);
+                if(data.error) {
+                    Tooltip.show(data.errmsg, sendbtn.domNode);
+                    on.once(sendbtn.domNode, mouse.leave, function(){
+                        Tooltip.hide(sendbtn.domNode);
+                    });
+                }
+            });
+        } else {
+            sendbtn.set('disabled', false);
+            Tooltip.show("Select rsync over ssh", sendbtn.domNode);
+            on.once(sendbtn.domNode, mouse.leave, function(){
+                Tooltip.hide(sendbtn.domNode);
+            });
+        }
     };
 
     vmwareDatastores = function(url, button) {

--- a/gui/tasks/urls.py
+++ b/gui/tasks/urls.py
@@ -31,5 +31,6 @@ urlpatterns = patterns(
     'freenasUI.tasks.views',
     url(r'^$', 'home', name="tasks_home"),
     url(r'^cron/(?P<oid>\d+)/run/$', 'cron_run', name="cron_run"),
+    url(r'^rsync/keyscan/$', 'rsync_keyscan', name="tasks_rsync_keyscan"),
     url(r'^rsync/(?P<oid>\d+)/run/$', 'rsync_run', name="rsync_run"),
 )

--- a/gui/tasks/views.py
+++ b/gui/tasks/views.py
@@ -64,3 +64,43 @@ def rsync_run(request, oid):
     return render(request, 'tasks/rsync_run.html', {
         'rsync': rsync,
     })
+
+
+def rsync_keyscan(request):
+    ruser = request.POST.get("user")
+    rhost = request.POST.get("host")
+    rport = request.POST.get("port")
+    if not ruser:
+        data = {'error': True, 'errmsg': _('Please enter a username')}
+        return HttpResponse(json.dumps(data))
+    else:
+        user = bsdUsers.objects.get(bsdusr_username=ruser)
+        ruser_path = user.bsdusr_home
+
+    if not rhost:
+        data = {'error': True, 'errmsg': _('Please enter a hostname')}
+    else:
+        if '@' in rhost:
+            remote = rhost.split("@")
+            remote_host = remote[1]
+        else:
+            remote_host = rhost
+
+        proc = subprocess.Popen([
+            "/usr/bin/ssh-keyscan",
+            "-p", str(rport),
+            "-T", "2",
+            str(remote_host),
+        ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        host_key, errmsg = proc.communicate()
+        if proc.returncode == 0 and host_key:
+            with open(ruser_path + "/.ssh/known_hosts", "a") as myfile:
+                myfile.write(host_key)
+            data = {'error': False}
+        elif not errmsg:
+            errmsg = _("Key could not be retrieved for unknown reason")
+            data = {'error': True, 'errmsg': errmsg}
+        else:
+            data = {'error': True, 'errmsg': errmsg}
+
+    return HttpResponse(json.dumps(data))

--- a/gui/tasks/views.py
+++ b/gui/tasks/views.py
@@ -26,10 +26,14 @@
 #####################################################################
 from django.shortcuts import render
 from django.utils.translation import ugettext as _
+from django.http import HttpResponse
 
 from freenasUI.freeadmin.apppool import appPool
 from freenasUI.freeadmin.views import JsonResp
 from freenasUI.tasks import models
+from freenasUI.account.models import bsdUsers
+import subprocess
+import json
 
 
 def home(request):

--- a/gui/templates/tasks/rsync_add.html
+++ b/gui/templates/tasks/rsync_add.html
@@ -7,3 +7,12 @@ addToStack(function() {
 });
 </script>
 {% endblock %}
+
+{% block buttons_extra %}
+<button id="btn_Rsync_SSHKeyScan" data-dojo-type="dijit.form.Button">
+  {% trans "SSH Key Scan" %}
+  <script type="dojo/event" data-dojo-event="onClick" data-dojo-args="e">
+    rsync_sshKeyScan('{% url "tasks_rsync_keyscan" %}', this);
+  </script>
+</button>
+{% endblock %}

--- a/gui/templates/tasks/rsync_edit.html
+++ b/gui/templates/tasks/rsync_edit.html
@@ -7,3 +7,12 @@ addToStack(function() {
 });
 </script>
 {% endblock %}
+
+{% block buttons_extra %}
+<button id="btn_Rsync_SSHKeyScan" data-dojo-type="dijit.form.Button">
+  {% trans "SSH Key Scan" %}
+  <script type="dojo/event" data-dojo-event="onClick" data-dojo-args="e">
+    rsync_sshKeyScan('{% url "tasks_rsync_keyscan" %}', this);
+  </script>
+</button>
+{% endblock %}


### PR DESCRIPTION
In this commit, I have added a ssh_host_keyscan() method which saves the host key of the remote host into /$(user_home)/.ssh/known_hosts file.
Hence, path validation onto the remote host does not fail even if the destination host has never been accessed from FreeNAS.
