### PR TITLE
removing nasty exec for collectd/ping

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-collectd
+++ b/src/freenas/etc/ix.rc.d/ix-collectd
@@ -194,7 +194,6 @@ LoadPlugin zfs_arc_v2
 
 <Plugin "exec">
     NotificationExec "nobody" "/usr/local/www/freenasUI/tools/collectd_alert.py"
-    Exec "nobody:nobody" "/bin/echo" "PUTVAL localhost/collectd/ping N:1"
 </Plugin>
 
 <Plugin "interface">


### PR DESCRIPTION
This was originally added by @jpaetzel in https://github.com/freenas/freenas/commit/213cf5700c76905da9b391608fdf74e2b15ae4ee based on my blog post: http://cmhramblings.blogspot.com/2015/12/update-on-using-graphite-with-freenas.html

While the graphite server addition is great, the exec line with the collectd/ping was used to create service dependencies in my monitoring system, and has no practical use on a FreeNAS system. As it is, there's a bunch of ways to accomplish the same thing that are far less awful than using an exec and an echo command. As it stands right now, if you send metrics to a graphite server, you'll get a mystery "servers.localhost.collectd.ping" metric coming from the FreeNAS box but showing up outside its metrics folder. (That's how I came to find the code - tracing down that very mystery metric)

This exec line that I'm deleting shouldn't be confused with the collectd ping plugin - the only purpose of this metric was to log a 1 during every reporting interval to prove that collectd was functioning normally. As such, its removal poses no risk.