### PR TITLE
feat(api): Support setting a quota on dataset

### DIFF
--- a/docs/api/resources/storage.rst
+++ b/docs/api/resources/storage.rst
@@ -162,7 +162,8 @@ Datasets
       Content-Type: application/json
 
       {
-        "name": "foo"
+        "name": "foo",
+        "quota": 0
       }
 
    **Example response**:
@@ -179,7 +180,8 @@ Datasets
         "name": "foo",
         "pool": "tank",
         "refer": 73728,
-        "used": 73728
+        "used": 73728,
+        "quota": 0
       }
 
    :resheader Content-Type: content type of the response
@@ -210,7 +212,8 @@ Datasets
         "name": "foo",
         "pool": "tank",
         "refer": 73728,
-        "used": 73728
+        "used": 73728,
+        "quota": 0
       }]
 
    :resheader Content-Type: content type of the response

--- a/gui/middleware/zfs.py
+++ b/gui/middleware/zfs.py
@@ -484,10 +484,13 @@ class ZFSDataset(object):
     description = None
     parent = None
     children = None
+    quota = None
+
 
     def __init__(self, path=None, used=None, usedsnap=None, usedds=None,
                  usedrefreserv=None, usedchild=None, avail=None, refer=None,
-                 mountpoint=None, compression=None, dedup=None, description=None):
+                 mountpoint=None, compression=None, dedup=None, description=None,
+                 quota=None):
         self.path = path
         if path:
             if '/' in path:
@@ -508,6 +511,7 @@ class ZFSDataset(object):
         self.description = description
         self.parent = None
         self.children = []
+        self.quota = quota
 
     def __repr__(self):
         return "<Dataset: %s>" % self.path
@@ -889,7 +893,7 @@ def zfs_list(path="", recursive=False, hierarchical=False, include_root=False,
         "-p",
         "-H",
         "-s", "name",
-        "-o", "space,refer,mountpoint,type,volsize,compression,dedup,org.freenas:description",
+        "-o", "space,refer,mountpoint,type,volsize,compression,dedup,org.freenas:description,quota",
     ]
     if recursive:
         args.insert(3, "-r")
@@ -934,6 +938,7 @@ def zfs_list(path="", recursive=False, hierarchical=False, include_root=False,
                 compression=data[11],
                 dedup=data[12],
                 description=data[13] if data[13] != '-' else None,
+                quota=int(data[14]) if data[14].isdigit() else None
             )
         elif _type == 'volume':
             item = ZFSVol(


### PR DESCRIPTION
This allows for setting a quota when creating a dataset and return the value
afterwards.

Since datasets have no update (PUT) method yet there is no way to update the
quota through the API right now.

Signed-off-by: Wido den Hollander <wido@widodh.nl>