### PR TITLE
fix(consul/aws-sns): Add credentials and region to compliance with AW…

### DIFF
--- a/gui/choices.py
+++ b/gui/choices.py
@@ -922,7 +922,7 @@ TUNABLE_TYPES = (
 )
 
 CONSULALERTS_TYPES = (
-    ('AWS-SNS', _('AWS-SNS')),
+    ('AWSSNS', _('AWS-SNS')),
     ('HipChat', _('HipChat')),
     ('InfluxDB', _('InfluxDB')),
     ('Mattermost', _('Mattermost')),

--- a/gui/freeadmin/static/lib/js/freeadmin.js
+++ b/gui/freeadmin/static/lib/js/freeadmin.js
@@ -1416,6 +1416,8 @@ require([
         // AWS SNS
         var region = registry.byId("id_region").domNode.parentNode.parentNode;
         var topic_arn = registry.byId("id_topic_arn").domNode.parentNode.parentNode;
+        var aws_access_key_id = registry.byId("id_aws_access_key_id").domNode.parentNode.parentNode;
+        var aws_secret_access_key = registry.byId("id_aws_secret_access_key").domNode.parentNode.parentNode;
 
         // VictorOps
         var routing_key = registry.byId("id_routing_key").domNode.parentNode.parentNode;
@@ -1441,6 +1443,8 @@ require([
         domStyle.set(api_key, "display", "none");
         domStyle.set(region, "display", "none");
         domStyle.set(topic_arn, "display", "none");
+        domStyle.set(aws_access_key_id, "display", "none");
+        domStyle.set(aws_secret_access_key, "display", "none");
         domStyle.set(routing_key, "display", "none");
 
         if(consulalert_type.get('value') == 'InfluxDB') {
@@ -1481,9 +1485,11 @@ require([
             domStyle.set(cluster_name, "display", "table-row");
             domStyle.set(api_key, "display", "table-row");
             domStyle.set(enabled, "display", "table-row");
-        } else if(consulalert_type.get('value') == 'AWS-SNS') {
+        } else if(consulalert_type.get('value') == 'AWSSNS') {
             domStyle.set(region, "display", "table-row");
             domStyle.set(topic_arn, "display", "table-row");
+            domStyle.set(aws_access_key_id, "display", "table-row");
+            domStyle.set(aws_secret_access_key, "display", "table-row");
             domStyle.set(enabled, "display", "table-row");
         } else if(consulalert_type.get('value') == 'VictorOps') {
             domStyle.set(api_key, "display", "table-row");

--- a/gui/system/forms.py
+++ b/gui/system/forms.py
@@ -1569,6 +1569,18 @@ class ConsulAlertsForm(ModelForm):
         help_text=_("Topic ARN to publish to"),
         required=False,
     )
+    aws_access_key_id = forms.CharField(
+        max_length=255,
+        label=_("Key Id"),
+        help_text=_("AWS Access Key Id"),
+        required=False,
+    )
+    aws_secret_access_key = forms.CharField(
+        max_length=255,
+        label=_("Secret Key"),
+        help_text=_("AWS Secret Access Key"),
+        required=False,
+    )
 
     # VictorOps
     routing_key = forms.CharField(
@@ -1628,9 +1640,11 @@ class ConsulAlertsForm(ModelForm):
                 self.fields['cluster_name'].initial = self.instance.attributes.get('cluster_name')
                 self.fields['api_key'].initial = self.instance.attributes.get('api_key')
                 self.fields['enabled'].initial = self.instance.attributes.get('enabled')
-            elif self.instance.consulalert_type == 'AWS-SNS':
+            elif self.instance.consulalert_type == 'AWSSNS':
                 self.fields['region'].initial = self.instance.attributes.get('region')
                 self.fields['topic_arn'].initial = self.instance.attributes.get('topic_arn')
+                self.fields['aws_access_key_id'].initial = self.instance.attributes.get('aws_access_key_id')
+                self.fields['aws_secret_access_key'].initial = self.instance.attributes.get('aws_secret_access_key')
                 self.fields['enabled'].initial = self.instance.attributes.get('enabled')
             elif self.instance.consulalert_type == 'VictorOps':
                 self.fields['api_key'].initial = self.instance.attributes.get('api_key')
@@ -1664,6 +1678,8 @@ class ConsulAlertsForm(ModelForm):
                 "enabled": self.cleaned_data.get('enabled'),
                 "region": self.cleaned_data.get('region'),
                 "topic_arn": self.cleaned_data.get('topic_arn'),
+                "aws_access_key_id": self.cleaned_data.get('aws_access_key_id'),
+                "aws_secret_access_key": self.cleaned_data.get('aws_secret_access_key'),
                 "routing_key": self.cleaned_data.get('routing_key')
             }
             objs.save()

--- a/src/middlewared/middlewared/plugins/consulkv.py
+++ b/src/middlewared/middlewared/plugins/consulkv.py
@@ -34,7 +34,7 @@ class ConsulService(Service):
         """
         c = consul.aio.Consul()
         try:
-            logger.info('CONSUL ===> Add Key: {} Value: {}'.format(str(key), str(value)))
+            logger.info('===> Add Key: {} Value: {}'.format(str(key), str(value)))
             return await c.kv.put(str(key), str(value))
         except Exception as err:
             logger.error('===> Consul set_kv error: %s' % (err))
@@ -154,14 +154,12 @@ class ConsulService(Service):
             with open(config_path, 'w') as config:
                 config.write('[default]\n')
                 config.write('region = {}\n'.format(region))
-                config.close()
 
         if key_id and access_key:
             with open(credentials_path, 'w') as credentials:
                 credentials.write('[default]\n')
                 credentials.write('aws_access_key_id = {}\n'.format(key_id))
                 credentials.write('aws_secret_access_key = {}\n'.format(access_key))
-                credentials.close()
 
     def _convert_keys(self, data):
         """

--- a/src/middlewared/middlewared/plugins/consulkv.py
+++ b/src/middlewared/middlewared/plugins/consulkv.py
@@ -21,7 +21,7 @@ class ConsulService(Service):
     PAGERDUTY_API = ['service-key', 'client-name', 'enabled']
     HIPCHAT_API = ['from', 'cluster-name', 'base-url', 'room-id', 'auth-token', 'enabled']
     OPSGENIE_API = ['cluster-name', 'api-key', 'enabled']
-    AWSSNS_API = ['reigion', 'topic-arn', 'enabled']
+    AWSSNS_API = ['region', 'topic-arn', 'enabled']
     VICTOROPS_API = ['api-key', 'routing-key', 'enabled']
 
     @accepts(Str('key'), Any('value'))
@@ -34,6 +34,7 @@ class ConsulService(Service):
         """
         c = consul.aio.Consul()
         try:
+            logger.info('CONSUL ===> Add Key: {} Value: {}'.format(str(key), str(value)))
             return await c.kv.put(str(key), str(value))
         except Exception as err:
             logger.error('===> Consul set_kv error: %s' % (err))
@@ -69,6 +70,26 @@ class ConsulService(Service):
         except Exception as err:
             logger.error('===> Consul delete_kv error: %s' % (err))
             return False
+
+    @accepts(Str('region'))
+    async def aws_region(self, region):
+        """
+        Create an aws config file with region.
+
+        Returns:
+                    None
+        """
+        return self._aws_config_file(region, None, None)
+
+    @accepts(Str('key_id'), Str('access_key'))
+    async def aws_credentials(self, key_id, access_key):
+        """
+        Create an aws config file with key_id and access_key.
+
+        Returns:
+                    None
+        """
+        return self._aws_config_file(None, key_id, access_key)
 
     @accepts()
     async def reload(self):
@@ -111,6 +132,31 @@ class ConsulService(Service):
                 raise
 
         return await self.reload()
+
+    def _aws_config_file(self, region=None, key_id=None, access_key=None):
+        config_path = '/root/.aws/config'
+        credentials_path = '/root/.aws/credentials'
+        aws_vault = '/root/.aws/'
+
+        if not os.path.exists(aws_vault):
+            try:
+                os.makedirs(aws_vault)
+            except OSError as e:
+                if e.errno != errno.EEXIST:
+                    raise
+
+        if region:
+            with open(config_path, 'w') as config:
+                config.write('[default]\n')
+                config.write('region = {}\n'.format(region))
+                config.close()
+
+        if key_id and access_key:
+            with open(credentials_path, 'w') as credentials:
+                credentials.write('[default]\n')
+                credentials.write('aws_access_key_id = {}\n'.format(key_id))
+                credentials.write('aws_secret_access_key = {}\n'.format(access_key))
+                credentials.close()
 
     def _convert_keys(self, data):
         """
@@ -187,8 +233,12 @@ class ConsulService(Service):
             await self._insert_keys(consul_prefix, cdata, self.HIPCHAT_API)
         elif alert_service == 'OpsGenie':
             await self._insert_keys(consul_prefix, cdata, self.OPSGENIE_API)
-        elif alert_service == 'AWS-SNS':
+        elif alert_service == 'AWSSNS':
             await self._insert_keys(consul_prefix, cdata, self.AWSSNS_API)
+            aws_region = cdata.get('region', None)
+            aws_access_key_id = cdata.get('aws-access-key-id', None)
+            aws_secret_access_key = cdata.get('aws-secret-access-key', None)
+            self._aws_config_file(aws_region, aws_access_key_id, aws_secret_access_key)
         elif alert_service == 'VictorOps':
             await self._insert_keys(consul_prefix, cdata, self.VICTOROPS_API)
 
@@ -211,7 +261,7 @@ class ConsulService(Service):
             await self._delete_keys(consul_prefix, cdata, self.HIPCHAT_API)
         elif alert_service == 'OpsGenie':
             await self._delete_keys(consul_prefix, cdata, self.OPSGENIE_API)
-        elif alert_service == 'AWS-SNS':
+        elif alert_service == 'AWSSNS':
             await self._delete_keys(consul_prefix, cdata, self.AWSSNS_API)
         elif alert_service == 'VictorOps':
             await self._delete_keys(consul_prefix, cdata, self.VICTOROPS_API)

--- a/src/middlewared/middlewared/plugins/consulkv.py
+++ b/src/middlewared/middlewared/plugins/consulkv.py
@@ -102,7 +102,12 @@ class ConsulService(Service):
         consul_error = await (await Popen(['consul', 'reload'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)).wait()
         if consul_error == 0:
             logger.info("===> Reload Consul: {0}".format(consul_error))
-            return True
+            consul_alert_error = await (await Popen(['/usr/local/etc/rc.d/consul-alerts', 'restart'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)).wait()
+            if consul_alert_error == 0:
+                logger.info("===> Reload Consul-Alerts: {0}".format(consul_alert_error))
+                return True
+            else:
+                return False
         else:
             return False
 


### PR DESCRIPTION
…S SDK API requirements. Also fix a typo related with the region name in middlewared. Also the consul notifier expects the AWS entries been into awssns instead of aws-sns.

Tested at region: ap-northeast-1
Test results: Received the alert in two different mailbox as well as via SMS.

Ticket: #25037