### PR TITLE
fix(s3): Make the configuration options from UI to be passed to daemon.

### DIFF
--- a/src/freenas/etc/rc.conf.local
+++ b/src/freenas/etc/rc.conf.local
@@ -436,7 +436,7 @@ _s3_config()
 	while read s3_enable s3_bindip s3_bindport s3_access_key \
 		s3_secret_key s3_browser s3_mode s3_disks; do
 		cat <<-__MINIO__
-			minio_enable="${s3_enable}"
+			minio_enable="YES"
 			minio_disks="${s3_disks}"
 			minio_address="${s3_bindip}:${s3_bindport}"
 			minio_env="\\

--- a/src/freenas/etc/rc.conf.local
+++ b/src/freenas/etc/rc.conf.local
@@ -436,8 +436,9 @@ _s3_config()
 	while read s3_enable s3_bindip s3_bindport s3_access_key \
 		s3_secret_key s3_browser s3_mode s3_disks; do
 		cat <<-__MINIO__
-			minio_enable="YES"
+			minio_enable="${s3_enable}"
 			minio_disks="${s3_disks}"
+			minio_address="${s3_bindip}:${s3_bindport}"
 			minio_env="\\
 			MINIO_ACCESS_KEY=${s3_access_key} \\
 			MINIO_SECRET_KEY=${s3_secret_key} \\


### PR DESCRIPTION
Tested checking the bind IP address:
root@freenas:/mnt/ssd # sockstat -4 | grep 9000
minio    minio      9188  5  tcp4   192.168.100.111:9000  *:*

root@freenas:/mnt/ssd # ps ax | grep s3
9188  -  S      0:00.13 /usr/local/bin/minio -C /usr/local/etc/minio server --address=192.168.100.111:9000 --quiet /mnt/ssd/s3

Also checked using the minio UI.

Ticket: #25455
Submitted by: Ben Agricola.