### PR TITLE
Fix: Unable to import NTFS drive

### DIFF
--- a/src/freenas/usr/local/bin/sockscopy
+++ b/src/freenas/usr/local/bin/sockscopy
@@ -226,7 +226,7 @@ if __name__ == '__main__':
                         str(e) + " ")
                 )
 
-        proc_stdout_orig = NamedTemporaryFile(mode="wb", bufsize=0, delete=False)
+        proc_stdout_orig = NamedTemporaryFile(mode="wb", buffering=0, delete=False)
         # Note: Duplicating this in read only mode to properly read from it even
         # whilst it is being written to
         # If you happen to come across this and know of a better solution then fix


### PR DESCRIPTION
Ticket: [#25427](https://bugs.freenas.org/issues/25427) 

Related [forum discussion](https://forums.freenas.org/index.php?threads/cannot-import-ntfs-hdd.56633/#post-398010), including my [first](https://forums.freenas.org/index.php?threads/cannot-import-ntfs-hdd.56633/#post-398010) and [second](https://forums.freenas.org/index.php?threads/cannot-import-ntfs-hdd.56633/#post-398184) replies that explain this fix.