### PR TITLE
fix(gui): Don't do double-escaping for safe rsync remote paths

### DIFF
--- a/gui/tasks/models.py
+++ b/gui/tasks/models.py
@@ -25,6 +25,7 @@
 #
 #####################################################################
 import logging
+import pipes
 import subprocess
 
 from django.core.validators import MinValueValidator, MaxValueValidator
@@ -658,16 +659,20 @@ class Rsync(Model):
             ) % (
                 self.rsync_remoteport
             )
+            if pipes.quote(self.rsync_remotepath) == self.rsync_remotepath:
+                rsync_remotepath = self.rsync_remotepath
+            else:
+                rsync_remotepath = '\\""%s"\\"' % self.rsync_remotepath
             if self.rsync_direction == 'push':
-                line += ' "%s" %s:\\""%s"\\"' % (
+                line += ' "%s" %s:%s' % (
                     self.rsync_path,
                     remote,
-                    self.rsync_remotepath,
+                    rsync_remotepath,
                 )
             else:
-                line += ' %s:\\""%s"\\" "%s"' % (
+                line += ' %s:%s "%s"' % (
                     remote,
-                    self.rsync_remotepath,
+                    rsync_remotepath,
                     self.rsync_path,
                 )
         if self.rsync_quiet:


### PR DESCRIPTION
Ticket: #23872