### PR TITLE
Ensure that the update cache directory is readable by nobody, to allow

### DIFF
--- a/gui/middleware/notifier.py
+++ b/gui/middleware/notifier.py
@@ -1934,7 +1934,7 @@ class notifier(metaclass=HookMetaclass):
         try:
             os.chmod(dirpath, 0o755)
         except OSError as e:
-            raise MiddlwareError("Unable to set permissions on update cache directory %s: %s" % (dirpath, str(e)))
+            raise MiddlewareError("Unable to set permissions on update cache directory %s: %s" % (dirpath, str(e)))
         open(INSTALLFILE, 'w').close()
         try:
             subprocess.check_output(

--- a/gui/middleware/notifier.py
+++ b/gui/middleware/notifier.py
@@ -1931,6 +1931,10 @@ class notifier(metaclass=HookMetaclass):
         from freenasUI.system.views import INSTALLFILE
         import freenasOS.Configuration as Configuration
         dirpath = os.path.dirname(path)
+        try:
+            os.chmod(dirpath, 0o755)
+        except OSError as e:
+            raise MiddlwareError("Unable to set permissions on update cache directory %s: %s" % (dirpath, str(e)))
         open(INSTALLFILE, 'w').close()
         try:
             subprocess.check_output(

--- a/gui/tools/autosnap.py
+++ b/gui/tools/autosnap.py
@@ -205,7 +205,7 @@ def doesVMSnapshotByNameExists(vm, snapshotName):
                 break
             tree = tree[0].childSnapshotList
     except:
-        log.debug('Exception in doesVMSnapshotByNameExists')
+        log.debug('Exception in doesVMSnapshotByNameExists', exc_info=True)
     return False
 
 
@@ -280,7 +280,7 @@ if len(mp_to_task_map) > 0:
 
     # Grab all existing snapshot and filter out the expiring ones
     snapshots = {}
-    snapshots_pending_delete = set()
+    snapshots_pending_delete = []
     previous_prefix = '/'
     # Use -s name because its faster. See #18428
     zfsproc = pipeopen("/sbin/zfs list -t snapshot -H -o name -s name", debug, logger=log)
@@ -309,7 +309,7 @@ if len(mp_to_task_map) > 0:
                                     continue
                             else:
                                 previous_prefix = '%s/' % (fs)
-                            snapshots_pending_delete.add(snapshot_name)
+                            snapshots_pending_delete.append(snapshot_name)
                 else:
                     if (fs, snap_ret_policy, True) in mp_to_task_map:
                         if (fs, snap_ret_policy, True) in snapshots:


### PR DESCRIPTION
the update to work.

I tested this with FN 11.0-U1 to 11.0-U2.

Ticket: #25660