### PR TITLE
add cores in return

### DIFF
--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -63,6 +63,7 @@ class SystemService(Service):
             'hostname': socket.gethostname(),
             'physmem': sysctl.filter('hw.physmem')[0].value,
             'model': sysctl.filter('hw.model')[0].value,
+            'cores': sysctl.filter('hw.ncpu')[0].value,
             'loadavg': os.getloadavg(),
             'uptime': uptime,
             'system_serial': serial,


### PR DESCRIPTION
Add in ability for middleware to return the number of cores in a system when using the system.info middleware API call is used.