### PR TITLE
2to3 fix for snmpresponse

### DIFF
--- a/src/freenas/usr/local/bin/freenas-snmp/snmpresponse.py
+++ b/src/freenas/usr/local/bin/freenas-snmp/snmpresponse.py
@@ -32,7 +32,7 @@ def decompose_oid(oid):
 def oid_compare(a, b):
     ad = decompose_oid(a)
     bd = decompose_oid(b)
-    return cmp(ad, bd)
+    return ad > bd
 
 
 def printValue(value, oid):
@@ -54,7 +54,7 @@ def respond_to(operation, req_oid, result):
                 printValue(value, oid)
     elif operation == '-n':
         for oid, value in result:
-            if oid_compare(oid, req_oid) == 1:
+            if oid_compare(oid, req_oid):
                 print(oid)
                 printValue(value, oid)
                 break


### PR DESCRIPTION
Fix use of cmp which is not a function in py3 since there was only one use I simplified instead of defining a replacement cmp.