### PR TITLE
fix(watchdog): Re-enable hardware watchdog for never firmware versions on AsrockRack C2750D4I

### DIFF
--- a/src/freenas/etc/rc.conf.local
+++ b/src/freenas/etc/rc.conf.local
@@ -743,7 +743,7 @@ _gen_conf()
 			product=`/usr/local/sbin/dmidecode -s baseboard-product-name | /usr/bin/head -n 1`
 			if [ "${product}" = "X9DR3-F" -o "${product}" = "X9DR3-LN4F+" ] ; then
 				echo "watchdogd_enable=\"NO\""
-			elif [ "${product}" = "C2750D4I" -o "${product}" = "C2550D4I" ] ; then
+			elif [ "${product}" = "C2750D4I" -o "${product}" = "C2550D4I" ] && [ "$(/usr/local/bin/ipmitool mc info 2> /dev/null | grep ^Firmware | cut -d . -f 2)" -lt 30 ] ; then
 				echo "watchdogd_flags=\"-t 30 --softtimeout --softtimeout-action log,printf --pretimeout 15 --pretimeout-action log,printf -e 'sleep 1' -w -T 3\""
 				echo "watchdogd_enable=\"YES\""
 			else


### PR DESCRIPTION
This BMC bug have been solved with 00.30.00 BMC Firmware version.

Ticket: #23552