### PR TITLE
python print error

### DIFF
--- a/src/afpusers/files/afpusers.py
+++ b/src/afpusers/files/afpusers.py
@@ -44,7 +44,8 @@ def AFPUsers():
 
     for line in p.stdout:
         line = line.rstrip()
-        if AFPD_PROCESS in line:
+        if bytes(AFPD_PROCESS, encoding="ascii") in line:
+            line = line.decode('ascii')
             m = rx.match(line)
             if m is not None:
                 pid = int(m.group(1))
@@ -61,7 +62,8 @@ def AFPUsers():
 
     for line in p.stdout:
         line = line.rstrip()
-        if NETATALK_PROCESS in line:
+        if bytes(NETATALK_PROCESS, encoding="ascii") in line:
+            line = line.decode('ascii')
             m = match_rx.match(line)
             if m is not None:
                 MAIN_PID = int(m.group(2))
@@ -75,7 +77,8 @@ def AFPUsers():
 
     for line in p.stdout:
         line = line.rstrip()
-        if AFPD_PROCESS in line:
+        if bytes(AFPD_PROCESS, encoding="ascii") in line:
+            line = line.decode('ascii')
             m = match_rx.match(line)
             if m is not None:
                 user = m.group(1)
@@ -94,6 +97,6 @@ def AFPUsers():
         p.wait()
 
 if __name__ == "__main__":
-    print "PID      UID      Username         Name                 Logintime Mac"
+    print ("PID      UID      Username         Name                 Logintime Mac")
     for (pid, uid, user, fname, time, mac) in AFPUsers():
-        print "%-8d %-8d %-16s %-20s %-9s %s" % (pid, uid, user, fname, time, mac)
+        print ("{0:8d} {1:8d} {2:16s} {3:20s} {4:9s} {5:s}".format(pid, uid, user, fname, time, mac))

--- a/src/afpusers/files/afpusers.py
+++ b/src/afpusers/files/afpusers.py
@@ -96,6 +96,7 @@ def AFPUsers():
 
         p.wait()
 
+
 if __name__ == "__main__":
     print ("PID      UID      Username         Name                 Logintime Mac")
     for (pid, uid, user, fname, time, mac) in AFPUsers():


### PR DESCRIPTION
The changes fixes the following error on freenas 11 with python 3.6.1
```
  File "/usr/local/bin/afpusers", line 97
    print "PID      UID      Username         Name                 Logintime Mac"
SyntaxError: Missing parentheses in call to 'print'
```
I do not know if it's a good way to copy the objects back ('bytes') and forth ('decode'), but it now works for me again. However, I did not carry out any major tests. So if someone should look at it. 
Thank you.