### PR TITLE
zfs middlewared plugin typo + enchantments 

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -317,7 +317,8 @@ class ZFSSnapshot(CRUDService):
         Str('dataset'),
         Str('name'),
         Bool('recursive'),
-        Int('vmsnaps_count')
+        Int('vmsnaps_count'),
+        Dict('properties', additional_attrs=True)
     ))
     async def do_create(self, data):
         """
@@ -332,6 +333,7 @@ class ZFSSnapshot(CRUDService):
         name = data.get('name', '')
         recursive = data.get('recursive', False)
         vmsnaps_count = data.get('vmsnaps_count', 0)
+        properties = data.get('properties', None)
 
         if not dataset or not name:
             return False
@@ -343,18 +345,15 @@ class ZFSSnapshot(CRUDService):
             return False
 
         try:
-            if recursive:
-                ds.snapshots('{0}@{1}'.format(dataset, name, recursive=True))
-            else:
-                ds.snapshot('{0}@{1}'.format(dataset, name))
+            ds.snapshot(f'{dataset}@{name}', recursive = recursive, fsopts = properties)
 
             if vmsnaps_count > 0:
                 ds.properties['freenas:vmsynced'] = libzfs.ZFSUserProperty('Y')
 
-            self.logger.info("Snapshot taken: {0}@{1}".format(dataset, name))
+            self.logger.info(f"Snapshot taken: {dataset}@{name}")
             return True
         except libzfs.ZFSException as err:
-                self.logger.error("{0}".format(err))
+                self.logger.error(f"{err}")
                 return False
 
     @accepts(Dict(

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -345,7 +345,7 @@ class ZFSSnapshot(CRUDService):
             return False
 
         try:
-            ds.snapshot(f'{dataset}@{name}', recursive = recursive, fsopts = properties)
+            ds.snapshot(f'{dataset}@{name}', recursive=recursive, fsopts=properties)
 
             if vmsnaps_count > 0:
                 ds.properties['freenas:vmsynced'] = libzfs.ZFSUserProperty('Y')


### PR DESCRIPTION
FIX: I've found a typo: 'snapshots' is a property in py-libzfs, hencethis cant't work.
While I'm here I've fixed some style and added an option to specify additional snapshot properties during the creation time(needed for my autosnap middlewared code).