### PR TITLE
Introduce is_dir method for Cloud Sync Providers and make use of it in old GUI

### DIFF
--- a/gui/tasks/forms.py
+++ b/gui/tasks/forms.py
@@ -79,8 +79,8 @@ class CloudSyncForm(ModelForm):
         credential = attributes.get('credential')
         if not credential:
             raise forms.ValidationError(_('This field is required.'))
-        credential_object = CloudCredentials.objects.get(id=credential)
-        if credential_object is None:
+        qs = CloudCredentials.objects.filter(id=credential)
+        if not qs.exists():
             raise forms.ValidationError(_('Invalid credential.'))
 
         if not attributes.get('bucket'):
@@ -90,10 +90,7 @@ class CloudSyncForm(ModelForm):
         folder = attributes.get('folder').strip('/')
         if direction == 'PULL' and folder:
             with client as c:
-                if not c.call('backup.%s.is_dir' % {'AMAZON': 's3',
-                                                    'BACKBLAZE': 'b2',
-                                                    'GCLOUD': 'gcs'}[credential_object.provider],
-                              credential, attributes['bucket'], folder):
+                if not c.call('backup.is_dir', credential, attributes['bucket'], folder):
                     raise forms.ValidationError(_('Folder "%s" does not exist.') % folder)
 
         return attributes

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -830,7 +830,7 @@ class Middleware(object):
         to block the event loop indefinitely.
         """
         loop = asyncio.get_event_loop()
-        task = loop.run_in_executor(self.__threadpool, method, *args, **kwargs)
+        task = loop.run_in_executor(self.__threadpool, functools.partial(method, *args, **kwargs))
         await task
         return task.result()
 

--- a/src/middlewared/middlewared/plugins/backup.py
+++ b/src/middlewared/middlewared/plugins/backup.py
@@ -619,3 +619,13 @@ service_account_file = {keyfile}
                 await asyncio.wait_for(check_task, None)
                 raise ValueError('rclone failed: {}'.format(check_task.result()))
             return True
+
+    @private
+    def is_dir(self, cred_id, bucket, path):
+        client = self.__get_client(cred_id)
+        bucket = storage.Bucket(client, bucket)
+        prefix = f"{path}/"
+        for blob in bucket.list_blobs(prefix=prefix):
+            if blob.name.startswith(prefix):
+                return True
+        return False


### PR DESCRIPTION
Ticket: #26498

https://bugs.freenas.org/issues/26498

This was not implemented at all making it impossible to create a PULL task for any other provider than S3: https://github.com/freenas/freenas/pull/417/files#diff-3531b069fb041d93c202c1142f4f5c40L95

Now we need to
* Also implement `is_dir` for `Google Cloud Storage`
* Think of way to unify this call between providers (I don't like this https://github.com/freenas/freenas/pull/417/files#diff-3531b069fb041d93c202c1142f4f5c40R93)
* Test if PULL tasks are actually working for BACKBLAZE and GCS