### PR TITLE
fix(smart): blacklist mrsas as it is not currently supported by FreeBSD smartd

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-smartd
+++ b/src/freenas/etc/ix.rc.d/ix-smartd
@@ -81,6 +81,11 @@ parse_devlist()
 			propdev="/dev/${DRIVER}${CONTROLLER_ID} -d 3ware,${port}"
 			break
 			;;
+		# LSI MegaRAID 6Gb/s and 12Gb/s SAS+SATA RAID controller (not supported)
+		${disk}:mrsas)
+			propdev=
+			break
+			;;
 		# Common device
 		${disk}:* )
 			propdev=/dev/$disk
@@ -89,9 +94,11 @@ parse_devlist()
 		esac
 	done
 
-	local IFS=" "
-	if ! /usr/local/sbin/smartctl -i ${propdev} | egrep -i "^.*SMART.*abled" > /dev/null 2>&1; then
-		propdev=/dev/$disk
+	if [ "$propdev" != "" ]; then
+		local IFS=" "
+		if ! /usr/local/sbin/smartctl -i ${propdev} | egrep -i "^.*SMART.*abled" > /dev/null 2>&1; then
+			propdev=/dev/$disk
+		fi
 	fi
 
 	echo -n $propdev
@@ -134,6 +141,9 @@ EOF
 				;;
 			esac
 			prop_dev=`get_prop_dev ${disk_name} ${TMPFILE}`
+			if [ "$prop_dev" == "" ]; then
+				continue
+			fi
 			/usr/local/sbin/smartctl -i ${prop_dev} > /dev/null 2>&1
 			if [ $? -eq 0 ]; then
 				if ! /usr/local/sbin/smartctl -i ${prop_dev} | egrep -i "^.*SMART.*Enabled" > /dev/null 2>&1; then


### PR DESCRIPTION
TIcket: #26545