### PR TITLE
fix(netcli): Fix get_lagg_nics

### DIFF
--- a/src/freenas/etc/netcli
+++ b/src/freenas/etc/netcli
@@ -180,10 +180,12 @@ def get_lagg_proto():
 
 
 def get_lagg_nics():
-    group = [ ]
-
     nics = list(NICChoices(nolagg=True))
+    if not nics:
+        print("All interfaces are already allocated to LAGG or VLAN, cannot proceed.")
+        return []
 
+    group = []
     while nics:
         nic = get_nic(nics)
         if not nic:

--- a/src/freenas/etc/netcli
+++ b/src/freenas/etc/netcli
@@ -180,18 +180,17 @@ def get_lagg_proto():
 
 
 def get_lagg_nics():
-
     group = [ ]
 
     nics = list(NICChoices(nolagg=True))
 
-    while True:
+    while nics:
         nic = get_nic(nics)
         if not nic:
             break
-
-        nics.remove(nic)
         group.append(nic)
+
+        nics = [n for n in nics if n[0] != nic]
 
     return group
 


### PR DESCRIPTION
Ticket: #26470

As I understand, this was implemented a long time ago, but never tested. After fixing the next bug, I've had the following dialog:
```
Enter an option from 1-12: 2

1) Create Link Aggregation
2) Delete Link Aggregation
Enter an option from 1-2 (enter q to quit): 1
1) failover
2) lacp
3) loadbalance
4) roundrobin
5) none
Select a lagg protocol (q to quit): 1
1) em0
Select an interface (q to quit): 1
Saving interface configuration: Ok
Saving Link Aggregation configuration: Ok
Saving Link Aggregation member configuration: Ok
Restarting network: Failed
VirtualBox | TrueNAS-11-MASTER-201711210455 | 0
```

I am worried if `Restarting network: Failed` is ok in this situation.

Also, next time I've ran this, I had the following dialog:
```
Enter an option from 1-12: 2

1) Create Link Aggregation
2) Delete Link Aggregation
Enter an option from 1-2 (enter q to quit): 1
1) failover
2) lacp
3) loadbalance
4) roundrobin
5) none
Select a lagg protocol (q to quit): 1
VirtualBox | TrueNAS-11-MASTER-201711210455 | 0
```
and then I got the menu again, is this an accepted behavior?