### PR TITLE
[master] fix(middlewared/vm): Fix vnc bind interface issue. Now bhyves call vnc_init_server passing IPV4 address attached on fbuf.

### DIFF
--- a/gui/vm/forms.py
+++ b/gui/vm/forms.py
@@ -266,7 +266,7 @@ class DeviceForm(ModelForm):
     def ipv4_list(self):
         choices = ()
         with client as c:
-            ipv4_addresses = c.call('interfaces.ipv4_in_use')
+            ipv4_addresses = c.call('vm.get_vnc_ifaces')
         for ipv4_addr in ipv4_addresses:
             choices = choices + ((ipv4_addr, ipv4_addr),)
         return choices

--- a/gui/vm/forms.py
+++ b/gui/vm/forms.py
@@ -266,7 +266,7 @@ class DeviceForm(ModelForm):
     def ipv4_list(self):
         choices = ()
         with client as c:
-            ipv4_addresses = c.call('vm.get_vnc_ifaces')
+            ipv4_addresses = c.call('vm.get_vnc_ipv4')
         for ipv4_addr in ipv4_addresses:
             choices = choices + ((ipv4_addr, ipv4_addr),)
         return choices

--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -564,7 +564,13 @@ class VMService(CRUDService):
         return vnc_devices
 
     @accepts()
-    def get_vnc_ifaces(self):
+    def get_vnc_ipv4(self):
+        """
+        Get all available IPv4 address in the system.
+
+        Returns:
+           list: will return a list of available IPv4 address.
+        """
         default_ifaces = ['0.0.0.0', '127.0.0.1']
         ifaces = self.middleware.call_sync('interfaces.ipv4_in_use')
 

--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -563,6 +563,14 @@ class VMService(CRUDService):
                 vnc_devices.append(vnc)
         return vnc_devices
 
+    @accepts()
+    def get_vnc_ifaces(self):
+        default_ifaces = ['0.0.0.0', '127.0.0.1']
+        ifaces = self.middleware.call_sync('interfaces.ipv4_in_use')
+
+        default_ifaces.extend(ifaces)
+        return default_ifaces
+
     @accepts(Str('pool'),
              Bool('stop', default=False),)
     async def stop_by_pool(self, pool, stop):


### PR DESCRIPTION
Note: It depends of libhyve-remote 0.1.4.1 and also os/pull/53.

Ticket: #24884