### PR TITLE
Fix "Quota exceed" Email Typos

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -511,17 +511,18 @@ class ZFSQuoteService(Service):
                     self.logger.warning('Unable to query bsduser with uid %r', excess['uid'])
                     continue
 
-                hostname = socket.gethostname()
+                gc = await self.middleware.call('datastore.config', 'network.globalconfiguration')
+                hostname = f"{gc['gc_hostname']}.{gc['gc_domain']}"
 
                 try:
                     # FIXME: Translation
                     human_quota_type = excess["quota_type"][0].upper() + excess["quota_type"][1:]
                     await (await self.middleware.call('mail.send', {
                         'to': [bsduser['bsdusr_email']],
-                        'subject': '{}: {} exceed on dataset {}'.format(hostname, human_quota_type,
-                                                                        excess["dataset_name"]),
+                        'subject': '{}: {} exceeded on dataset {}'.format(hostname, human_quota_type,
+                                                                          excess["dataset_name"]),
                         'text': textwrap.dedent('''\
-                            %(quota_type)s exceed on dataset %(dataset_name)s.
+                            %(quota_type)s exceeded on dataset %(dataset_name)s.
                             Used %(percent_used).2f%% (%(used)s of %(quota_value)s)
                         ''') % {
                             "quota_type": human_quota_type,


### PR DESCRIPTION
Fix sending e-mail with subject line having a stray colon at the front
(this probably happens at startup when hostname is not set yet, similar to b8facb02f05353fdaae5f945555864953ce148db)

Ticket: #27063

Please note there won't be a mainstream PR, as this is already fixed in rewritten alerts system.