### PR TITLE
fix(gui): Fix Cloud Sync Status "WAITING" While Still Running

### DIFF
--- a/gui/api/resources.py
+++ b/gui/api/resources.py
@@ -1791,8 +1791,10 @@ class CloudSyncResourceMixin(NestedMixin):
     def dispatch_list(self, request, **kwargs):
         with client as c:
             self.__jobs = {}
-            for job in c.call('core.get_jobs', [('method', '=', 'backup.sync')], {'order_by': ['-id']}):
-                if job['arguments'] and job['arguments'][0] not in self.__jobs:
+            for job in c.call('core.get_jobs', [('method', '=', 'backup.sync')], {'order_by': ['id']}):
+                if job['arguments']:
+                    if job['arguments'][0] in self.__jobs and self.__jobs[job['arguments'][0]]['state'] == 'RUNNING':
+                        continue
                     self.__jobs[job['arguments'][0]] = job
         return super(CloudSyncResourceMixin, self).dispatch_list(request, **kwargs)
 

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -850,6 +850,9 @@ class Middleware(object):
         if hasattr(methodobj, '_pass_app'):
             args.append(app)
 
+        if params:
+            args.extend(params)
+
         # If the method is marked as a @job we need to create a new
         # entry to keep track of its state.
         job_options = getattr(methodobj, '_job', None)
@@ -858,12 +861,9 @@ class Middleware(object):
             job = Job(self, name, methodobj, args, job_options)
             # Add the job to the queue.
             # At this point an `id` is assinged to the job.
-            self.jobs.add(job)
+            job = self.jobs.add(job)
         else:
             job = None
-
-        if params:
-            args.extend(params)
 
         if job:
             return job

--- a/src/middlewared/middlewared/plugins/backup.py
+++ b/src/middlewared/middlewared/plugins/backup.py
@@ -310,7 +310,7 @@ class BackupService(CRUDService):
 
     @item_method
     @accepts(Int('id'))
-    @job(lock=lambda args: 'backup:{}'.format(args[-1]))
+    @job(lock=lambda args: 'backup:{}'.format(args[-1]), lock_queue_size=1)
     async def sync(self, job, id):
         """
         Run the backup job `id`, syncing the local data to remote.

--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -29,11 +29,12 @@ def item_method(fn):
     return fn
 
 
-def job(lock=None, process=False, pipe=False):
+def job(lock=None, lock_queue_size=None, process=False, pipe=False):
     """Flag method as a long running job."""
     def check_job(fn):
         fn._job = {
             'lock': lock,
+            'lock_queue_size': lock_queue_size,
             'process': process,
             'pipe': pipe,
         }


### PR DESCRIPTION
Cloud sync legacy GUI shows status of the last cloud sync task.
So if we have cloud sync running and start another one, we'll see
WAITING status (job is waiting for it's lock to be free). This commit
changes that behaviour: instead of showing status of the last
cloud sync job, we show status of the first RUNNING job (or, if it does
not exist, status of the last cloud sync job)

Ticker: #27284