### PR TITLE
Revert "Force FC ports to N-Port mode (block loop modes, not working with NPIV)"

### DIFF
--- a/src/freenas/boot/loader.conf
+++ b/src/freenas/boot/loader.conf
@@ -32,12 +32,6 @@ hint.isp.1.role=2
 hint.isp.2.role=2
 hint.isp.3.role=2
 
-# Force FC ports to N-Port mode (block loop modes, not working with NPIV)
-hint.isp.0.topology="nport-only"
-hint.isp.1.topology="nport-only"
-hint.isp.2.topology="nport-only"
-hint.isp.3.topology="nport-only"
-
 # Possible kernel module locations
 module_path="/boot/kernel;/boot/modules;/usr/local/modules"
 


### PR DESCRIPTION
This reverts commit 64520af70eb6b3e66583315d166ef1970d9ff578.

There are still existing FC JBODs using only the loop mode.  Since FreeNAS
does not really utilize NPIV now, revert this to make default configuration
more universal.

Ticket:	#27417