### PR TITLE
feat(middlewared): increase time waiting for middlewared

### DIFF
--- a/nas_ports/freenas/py-middlewared/files/middlewared.in
+++ b/nas_ports/freenas/py-middlewared/files/middlewared.in
@@ -30,7 +30,7 @@ middlewared_start() {
 	else
 		env PATH=$PATH:/usr/local/sbin:/usr/local/bin LC_ALL=en_US.UTF-8 ${command} -f -P ${pidfile} -r /usr/local/bin/middlewared -f ${plugins_dirs_arg} --log-handler=file
 	fi
-	LD_LIBRARY_PATH=/usr/local/lib /usr/local/bin/midclt -t 60 waitready
+	LD_LIBRARY_PATH=/usr/local/lib /usr/local/bin/midclt -t 120 waitready
 }
 
 name="middlewared"


### PR DESCRIPTION
Middlewared got bigger also it may take some time on first boot to
import all modules because python byte code compiling.
We have also to take slow boot media into account.

This is not an elegant solution but works for now.

Ticket:	#27013