### PR TITLE
fix(gui): modify existing migration to get the value from sentinel file

### DIFF
--- a/gui/network/migrations/0007_globalconfiguration_gc_hostname_virtual.py
+++ b/gui/network/migrations/0007_globalconfiguration_gc_hostname_virtual.py
@@ -3,7 +3,25 @@
 from __future__ import unicode_literals
 
 import django.core.validators
+import os
 from django.db import migrations, models
+
+
+SENTINEL = '/data/sentinels/gc_hostname_virtual_out_of_order'
+
+
+def existing_virtual_hostname(apps, schema_editor):
+
+    if not os.path.exists(SENTINEL):
+        return
+
+    with open(SENTINEL, 'r') as f:
+        hostname_virtual = f.read()
+
+    GlobalConfiguration = apps.get_model('network', 'GlobalConfiguration')
+    for o in GlobalConfiguration.objects.all():
+        o.gc_hostname_virtual = hostname_virtual
+        o.save()
 
 
 class Migration(migrations.Migration):
@@ -18,4 +36,5 @@ class Migration(migrations.Migration):
             name='gc_hostname_virtual',
             field=models.CharField(blank=True, max_length=120, null=True, validators=[django.core.validators.RegexValidator(regex='^[a-zA-Z\\.\\-\\_0-9]+$')], verbose_name='Hostname (Virtual)'),
         ),
+        migrations.RunPython(existing_virtual_hostname),
     ]


### PR DESCRIPTION
11.0-U6 had a migration out of order which means we need to restore
virtual hostname.

Ticket:	#27607
(cherry picked from commit b07ae7590bd7a26be63cfd8cf15f495f72f300a4)