### PR TITLE
[MASTER] Fix for alert e-mails being improperly addressed

### DIFF
--- a/src/freenas/etc/find_alias_for_smtplib.py
+++ b/src/freenas/etc/find_alias_for_smtplib.py
@@ -125,7 +125,7 @@ def main():
     if not to and not args.parse_recipients:
         parser.exit(message=parser.format_usage())
     msg = sys.stdin.read()
-    syslog.syslog("sending mail to " + ','.join(to) + msg[0:140])
+    syslog.syslog("sending mail to " + ', '.join(to) + '\n' + msg[0:140])
     do_sendmail(msg, to_addrs=to, parse_recipients=args.parse_recipients)
 
 

--- a/src/freenas/etc/find_alias_for_smtplib.py
+++ b/src/freenas/etc/find_alias_for_smtplib.py
@@ -62,7 +62,7 @@ def do_sendmail(msg, to_addrs=None, parse_recipients=False):
     margs['extra_headers'].update({
         'X-Mailer': get_sw_name(),
         'X-%s-Host' % get_sw_name(): socket.gethostname(),
-        'To': to_addr,
+        'To': ', '.join(to_addrs_repl),
     })
     margs['subject'] = em.get('Subject')
 

--- a/src/middlewared/middlewared/plugins/mail.py
+++ b/src/middlewared/middlewared/plugins/mail.py
@@ -264,7 +264,7 @@ class MailService(ConfigService):
             # This is because FreeNAS doesn't run a full MTA.
             # else:
             #    server.connect()
-            syslog.syslog("sending mail to " + ','.join(to) + msg.as_string()[0:140])
+            syslog.syslog("sending mail to " + ', '.join(to) + '\n' + msg.as_string()[0:140])
             server.sendmail(config['fromemail'], to, msg.as_string())
             server.quit()
         except ValueError as ve:


### PR DESCRIPTION
I noticed after a recent round of upgrading several of my FreeNAS boxes from 9.10 to 11.1 that my inbox filters weren't properly catching FreeNAS e-mail alerts anymore.  Upon further investigation, this was because the messages were being delivered with unexpected and invalid "To:" addresses.

For example, when an alert was sent to the root user, the proper alias was being resolved for the Envelope To address, but not for the Message Header To address, resulting in legitimate FreeNAS alert messages being addressed to `root@some.intermediate.smtp.relay.com` instead of `the.actual.email.address.i.entered.in.freenas@my.real.mailhost.com`.  E-mail was delivered, but it broke my filters, looked weird, and is likely considered spammy by some mail servers.

This PR addresses three items I encountered while troubleshooting this issue:
1. It uses resolved aliases for Message Header To addressing instead of bare usernames
2. It properly handles multiple recipients by addressing the message to a comma-separated list of addresses.  The existing code arbitrarily addressed the message to only the final address in the recipient list.
3. It makes the output to `/var/log/maillog` easier to read by using reasonable whitespace.
