### PR TITLE
fix(smart): Fix line X of file /usr/local/etc/smartd.conf (including newline!) is more than MAXLINELEN=256 characters.

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-smartd
+++ b/src/freenas/etc/ix.rc.d/ix-smartd
@@ -207,7 +207,8 @@ EOF
 				printf ")"
 			} else printf $0 }')
 
-			echo -n " -s ${smarttest_type}/${nmonth}/${ndaymonth}/${ndayweek}/${nhour}"
+			echo "\\"
+			echo "-s ${smarttest_type}/${nmonth}/${ndaymonth}/${ndayweek}/${nhour}\\"
 			fi
 			echo " $disk_smartoptions"
 		done


### PR DESCRIPTION
Long user e-mails combined with refined smart test schedules can cause config lines to exceed MAXLINELEN.

Ticket: #27582