### PR TITLE
[STABLE] - Update RancherOS to 1.1.3.

### DIFF
--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -23,9 +23,9 @@ logger = middlewared.logger.Logger('vm').getLogger()
 
 CONTAINER_IMAGES = {
     "RancherOS": {
-        "URL": "http://download.freenas.org/bhyve-templates/rancheros-bhyve-v1.1.2/rancheros-bhyve-v1.1.2.img.gz",
-        "GZIPFILE": "rancheros-bhyve-v1.1.0.img.gz",
-        "SHA256": "062041d60160c298e6b395bb382bf3f37fb4b07c98da0b44bfd3745907b2c832",
+        "URL": "http://download.freenas.org/bhyve-templates/rancheros-bhyve-v1.1.3/rancheros-bhyve-v1.1.3.img.gz",
+        "GZIPFILE": "rancheros-bhyve-v1.1.3.img.gz",
+        "SHA256": "e9288df573e01f5468c1f7e4609fbeab481caa3ffc5855af9d003b49557dde84",
     }
 }
 BUFSIZE = 65536
@@ -441,8 +441,8 @@ class VMUtils(object):
         ]
 
         grub_additional_args = {
-            "RancherOS": ['linux /boot/vmlinuz-4.9.69-rancher rancher.password={0} printk.devkmsg=on rancher.state.dev=LABEL=RANCHER_STATE rancher.state.wait rancher.resize_device=/dev/sda'.format(quote(password)),
-                          'initrd /boot/initrd-v1.1.2']
+            "RancherOS": ['linux /boot/vmlinuz-4.9.75-rancher rancher.password={0} printk.devkmsg=on rancher.state.dev=LABEL=RANCHER_STATE rancher.state.wait rancher.resize_device=/dev/sda'.format(quote(password)),
+                          'initrd /boot/initrd-v1.1.3']
         }
 
         vm_private_dir = sharefs_path + '/configs/' + str(vm_id) + '_' + vm_name + '/' + 'grub/'


### PR DESCRIPTION
It includes a new microcode for the recent meltdown vulnerability.

Ticket: #27757