### PR TITLE
add db_dump module to freenas-debug redmine #27683

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/db_dump/db_dump.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/db_dump/db_dump.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #+
-# Copyright 2015 iXsystems, Inc.
+# Copyright 2018 iXsystems, Inc.
 # All rights reserved
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/freenas/usr/local/libexec/freenas-debug/db_dump/db_dump.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/db_dump/db_dump.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+#+
+# Copyright 2015 iXsystems, Inc.
+# All rights reserved
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted providing that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+#####################################################################
+
+
+db_dump_opt() { echo B; }
+db_dump_help() { echo "Dump freenas-v1.db"; }
+db_dump_directory() { echo "db_dump"; }
+db_dump_func()
+{
+
+	section_header "freenas-v1.db contents"
+	${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} .dump
+	section_footer
+}


### PR DESCRIPTION
This dumps the freenas-v1.db file to a .txt file. This is beneficial to the support department because it allows us to rebuild a customer's configuration database to a known working copy.