### PR TITLE
fix consul message flood if notifier.get_alerts outputs an empty line…

### DIFF
--- a/src/freenas/usr/local/etc/consul-checks/freenas_health.sh
+++ b/src/freenas/usr/local/etc/consul-checks/freenas_health.sh
@@ -12,9 +12,12 @@ have_alert=0
 
 while read line
 do
+  if [ -z $line ] ; then
+    continue
+  fi
   echo $line | grep -q "^OK"
   if [ $? -eq 0 ] ; then
-	continue
+    continue
   fi
   echo "$line"
   have_alert=1


### PR DESCRIPTION
… (#711)

Ticket #26355
Submitted by: David Steinberger <@davidsteinberger>