### PR TITLE
Fix two issues during GRUB -> BSD Migration

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-bsdloader
+++ b/src/freenas/etc/ix.rc.d/ix-bsdloader
@@ -21,6 +21,11 @@ migrate_bsd_loader()
 
 	# Thow the new boot-loader on each disk
         for disk in $(sysctl -n kern.disks); do
+
+		# Why CD's show up in kern.disks? Dunno...
+		echo $disk | grep -q "^cd[0-9]"
+		if [ $? -eq 0 ] ; then continue ; fi
+
 		# Check if the disk has a gptid on the second "p2" partition
 		gptid=$(gpart list $disk | grep rawuuid | sed -n 2p | awk '{print $2}')
 		# If we didn't find a gptid for this disk / partition, set to a bogus name so we dont match
@@ -33,7 +38,7 @@ migrate_bsd_loader()
         	if gpart show ${disk} | grep -q bios-boot; then
 			gpart modify -i 1 -t freebsd-boot /dev/${disk}
 			gpart bootcode -b /boot/pmbr -p /boot/gptzfsboot -i 1 /dev/${disk}
-		elif sysctl -n machdep.bootmethod | fgrep -q "EFI" && gpart show ${disk} | grep -q efi; then
+		elif gpart show ${disk} | grep -q " efi "; then
 			if mount -t msdosfs /dev/${disk}p1 /boot/efi; then
 				cp /boot/boot1.efi /boot/efi/efi/boot/BOOTx64.efi
 				umount -f /boot/efi


### PR DESCRIPTION
1. We can skip cd[0-9] devices

2. On EFI systems, machdep isn't set by GRUB so we just want to
check the gpart status output instead