### PR TITLE
Don't need to cleanup old /etc/fstab entries on old BE's, this is

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-bsdloader
+++ b/src/freenas/etc/ix.rc.d/ix-bsdloader
@@ -54,25 +54,6 @@ migrate_bsd_loader()
 	# Get the current BE
 	curBE=$(mount | grep 'on / ' | awk '{print $1}' | cut -d '/' -f 3)
 
-	# Sanitize the old BE's by removing grub fstab entries
-	for _be in `zfs list -H -d 1 freenas-boot/ROOT | awk '{print $1}' | cut -d '/' -f 3`
-	do
-		# Skip the currently mounted BE
-		if [ "$curBE" = "${_be}" ] ; then continue ; fi
-
-		# Mount the old BE and start cleaning
-		mount -t zfs freenas-boot/ROOT/${_be} ${_cDir}
-		if [ -e ${_cDir}/conf/base/etc/fstab ] ; then
-			ed ${_cDir}/conf/base/etc/fstab << EOF
-g#^freenas-boot/grub#d
-w
-q
-EOF
-		fi
-		umount -f ${_cDir}
-	done
-	rmdir ${_cDir}
-
 	# Cleanup current BE environment
 	ed /conf/base/etc/fstab << EOF
 g#^freenas-boot/grub#d


### PR DESCRIPTION
to keep updater happy on those versions