### PR TITLE
Remove RAID3, RAID5 and GATE GEOM modules from load.

### DIFF
--- a/src/freenas/etc/rc.conf
+++ b/src/freenas/etc/rc.conf
@@ -45,7 +45,7 @@ ix_textdump_enable="YES"
 savecore_enable="NO"
 
 # A set of storage supporting kernel modules, they must be loaded before ix-fstab.
-early_kld_list="geom_mirror geom_stripe geom_raid3 geom_raid5 geom_gate geom_multipath"
+early_kld_list="geom_mirror geom_multipath"
 
 # A set of kernel modules that can be loaded after mounting local filesystems.
 kld_list="dtraceall ipmi hwpmc t3_tom t4_tom"


### PR DESCRIPTION
We are not using the first two for years, and the last I can't recall
we used ever.  If somebody need them -- they are still built and can
be loaded manually.  This should speedup both booting and disk tasting
by GEOM.

Ticket:	#28026