### PR TITLE
- Return an error for users when the prebuilt RancherOS image downloaded has a checksum problem,

### DIFF
--- a/gui/vm/views.py
+++ b/gui/vm/views.py
@@ -72,16 +72,16 @@ def start(request, id):
                     status = __call.get('state')
                     utils.dump_download_progress(__call)
                     if status == 'FAILED':
-                        return HttpResponse('Error: failed to download the image!')
+                        return HttpResponse('Error: Image download failed!')
                     elif status == 'ABORTED':
-                        return HttpResponse('Error: download ABORTED!')
+                        return HttpResponse('Error: Download aborted!')
                 if status == 'SUCCESS':
                     prebuilt_image = c.call('vm.image_path', 'RancherOS')
                     if prebuilt_image and raw_file_cnt:
                         c.call('vm.decompress_gzip', prebuilt_image, raw_file_cnt)
                         c.call('vm.raw_resize', raw_file_cnt, raw_file_resize)
                     elif prebuilt_image is False:
-                        return HttpResponse('Error: Image downloaded has a checksum error and will be removed!')
+                        return HttpResponse('Error: Checksum error in downloaded image. Image removed. Please retry.')
         with client as c:
             c.call('vm.start', id)
         return JsonResp(request, message='VM Started')

--- a/gui/vm/views.py
+++ b/gui/vm/views.py
@@ -80,6 +80,8 @@ def start(request, id):
                     if prebuilt_image and raw_file_cnt:
                         c.call('vm.decompress_gzip', prebuilt_image, raw_file_cnt)
                         c.call('vm.raw_resize', raw_file_cnt, raw_file_resize)
+                    elif prebuilt_image is False:
+                        return HttpResponse('Error: Image downloaded has a checksum error and will be removed!')
         with client as c:
             c.call('vm.start', id)
         return JsonResp(request, message='VM Started')

--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -1011,23 +1011,13 @@ class VMService(CRUDService):
                     self.logger.debug("===> Checksum OK: {}".format(file_path))
                     return file_path
                 else:
-                    self.logger.debug("===> Checksum NOK: {}".format(file_path))
+                    self.logger.debug("===> Checksum NOK, removing file: {}".format(file_path))
+                    os.remove(file_path)
                     return False
             else:
                 return False
         else:
             return False
-
-    def decompress_hookreport(self, dst_file, job):
-        totalsize = 4756340736  # XXX: It will be parsed from a sha256 file.
-        fd = os.open(dst_file, os.O_RDONLY)
-        try:
-            size = os.lseek(fd, 0, os.SEEK_END)
-        finally:
-            os.close(fd)
-
-        percent = (size / totalsize) * 100
-        job.set_progress(int(percent), 'Decompress', {'decompressed': size, 'total': totalsize})
 
     @accepts(Str('src'), Str('dst'))
     def decompress_gzip(self, src, dst):


### PR DESCRIPTION
…also we remove the file because in the next attempt to start the VM, it will download again.
- Remove unused method decompress_hookreport.

Ticket: #27861