### PR TITLE
Conform to RFC-7530 when using NFSv3 UID-GIDs with NFSv4 28105

### DIFF
--- a/src/freenas/etc/rc.conf.local
+++ b/src/freenas/etc/rc.conf.local
@@ -572,9 +572,11 @@ _gen_conf()
 				# with the >16 group support.
 				echo "nfsuserd_enable=\"NO\""
 				sysctl vfs.nfsd.enable_stringtouid=1 > /dev/null
+				sysctl vfs.nfs.enable_uidtostring=1 > /dev/null
 			else
 				echo "nfsuserd_enable=\"YES\""
 				sysctl vfs.nfsd.enable_stringtouid=0 > /dev/null
+				sysctl vfs.nfs.enable_uidtostring=0 > /dev/null
 				if [ "$(${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "SELECT nfs_srv_16 FROM services_nfs")" = 1 ]; then
 					# >16 group support
 					echo "nfsuserd_flags=\"-manage-gids\""

--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -781,8 +781,8 @@ class ServiceService(CRUDService):
         if nfs['nfs_srv_v4']:
             sysctl.filter('vfs.nfsd.server_max_nfsvers')[0].value = 4
             if nfs['nfs_srv_v4_v3owner']:
-                #Per RFC7530, sending NFSv3 style UID/GIDs across the wire is now allowed
-                #You must have both of these sysctl's set to allow the desired functionality
+                # Per RFC7530, sending NFSv3 style UID/GIDs across the wire is now allowed
+                # You must have both of these sysctl's set to allow the desired functionality
                 sysctl.filter('vfs.nfsd.enable_stringtouid')[0].value = 1
                 sysctl.filter('vfs.nfs.enable_uidtostring')[0].value = 1
                 await self._service("nfsuserd", "stop", force=True, **kwargs)

--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -781,10 +781,14 @@ class ServiceService(CRUDService):
         if nfs['nfs_srv_v4']:
             sysctl.filter('vfs.nfsd.server_max_nfsvers')[0].value = 4
             if nfs['nfs_srv_v4_v3owner']:
+                #Per RFC7530, sending NFSv3 style UID/GIDs across the wire is now allowed
+                #You must have both of these sysctl's set to allow the desired functionality
                 sysctl.filter('vfs.nfsd.enable_stringtouid')[0].value = 1
+                sysctl.filter('vfs.nfs.enable_uidtostring')[0].value = 1
                 await self._service("nfsuserd", "stop", force=True, **kwargs)
             else:
                 sysctl.filter('vfs.nfsd.enable_stringtouid')[0].value = 0
+                sysctl.filter('vfs.nfs.enable_uidtostring')[0].value = 0
                 await self._service("nfsuserd", "start", quiet=True, **kwargs)
         else:
             sysctl.filter('vfs.nfsd.server_max_nfsvers')[0].value = 3


### PR DESCRIPTION
Per RFC7530, NFSv3 style UID/GID's can be used in RPC requests coming from the clients.

To conform to RFC7530, we must enable another sysctl value "vfs.nfs.enable_uidtostring=1"