### PR TITLE
[Stable]Replication "Last snapshot sent..." resets to "Not ran since boot" on every repl object after repl task deletion.

### DIFF
--- a/gui/storage/models.py
+++ b/gui/storage/models.py
@@ -954,7 +954,7 @@ class Replication(Model):
             try:
                 results = pickle.loads(data)
                 results.pop(self.id, None)
-                with open(REPL_RESULTFILE, 'w') as f:
+                with open(REPL_RESULTFILE, 'wb') as f:
                     f.write(pickle.dumps(results))
             except Exception as e:
                 log.debug('Failed to remove replication from state file %s', e)


### PR DESCRIPTION
fix: pickle returns a bytes object hence file mode has to be 'wb'
Ticket: 27930