### PR TITLE
prevent information leak on support page

### DIFF
--- a/gui/freeadmin/static/lib/js/freeadmin/SupportTicket.js
+++ b/gui/freeadmin/static/lib/js/freeadmin/SupportTicket.js
@@ -178,31 +178,11 @@ define([
             value: initial.username
           }, this.dapUsername);
 
-          on(this._username, 'change', function() {
-            if(!me._username.get('value') || !me._password.get('value')) {
-              return;
-            }
-            me.fetchCategories({
-              user: me._username.get('value'),
-              password: me._password.get('value')
-            });
-          });
-
           this._password = new TextBox({
             name: "password",
             type: "password",
             value: initial.password
           }, this.dapPassword);
-
-          on(this._password, 'change', function() {
-            if(!me._username.get('value') || !me._password.get('value')) {
-              return;
-            }
-            me.fetchCategories({
-              user: me._username.get('value'),
-              password: me._password.get('value')
-            });
-          });
 
           this._type = new Select({
             name: "type",


### PR DESCRIPTION
do not auto-submit field on mutation.

i just removed the offending code, outright.

this is a security issue.


if y'all don't want to remove this... then... at least... don't submit on value change. submit on field blur at the very least. otherwise, every character will trigger a submit, unless there is some kind of inherent throttling on the change event listeners.