### PR TITLE
[MASTER] - Don't recreate grub.cfg everytime a docker vm is launched.

### DIFF
--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -468,14 +468,15 @@ class VMUtils(object):
 
         VMUtils.__mkdirs(vm_private_dir)
 
-        with open(grub_file, 'w') as grubcfg:
-            for line in grub_default_args:
-                grubcfg.write(line)
-                grubcfg.write('\n')
-            for line in grub_additional_args[vmOS]:
-                grubcfg.write(line)
-                grubcfg.write('\n')
-            grubcfg.write('}')
+        if not os.path.exists(grub_file):
+            with open(grub_file, 'w') as grubcfg:
+                for line in grub_default_args:
+                    grubcfg.write(line)
+                    grubcfg.write('\n')
+                for line in grub_additional_args[vmOS]:
+                    grubcfg.write(line)
+                    grubcfg.write('\n')
+                grubcfg.write('}')
 
         return vm_private_dir
 


### PR DESCRIPTION
  Usually when we update RancherOS image it comes with a new kernel
  version as well as a new initrd; so legacy images must be run with
  previous settings we must keep them.

Ticket: #28230