### PR TITLE
Don't grant privileges to users when role=member

### DIFF
--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -1,9 +1,9 @@
-#!/usr/local/bin/python
+ #!/usr/local/bin/python
 
 from middlewared.client import Client
 from middlewared.client.utils import Struct
 from middlewared.plugins.smb import LOGLEVEL_MAP
-
+ 
 import os
 import pwd
 import re
@@ -1610,7 +1610,6 @@ def main():
                 smb4_tdb,
                 "/var/db/samba4/private/passdb.tdb"
             )
-
             client.call('notifier.samba4', 'user_import_sentinel_file_create')
 
         smb4_map_groups(client)

--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -1,9 +1,9 @@
- #!/usr/local/bin/python
+#!/usr/local/bin/python
 
 from middlewared.client import Client
 from middlewared.client.utils import Struct
 from middlewared.plugins.smb import LOGLEVEL_MAP
- 
+
 import os
 import pwd
 import re

--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -1453,61 +1453,6 @@ def smb4_import_users(client, smb_conf_path, smb4_tdb, exportfile=None):
                     continue
                 print(line)
 
-
-def smb4_grant_user_rights(user):
-    args = [
-        "/usr/local/bin/net",
-        "-d 0",
-        "sam",
-        "rights",
-        "grant"
-    ]
-
-    rights = [
-        "SeTakeOwnershipPrivilege",
-        "SeBackupPrivilege",
-        "SeRestorePrivilege"
-    ]
-
-    net_cmd = "%s %s %s" % (
-        ' '.join(args),
-        user,
-        ' '.join(rights)
-    )
-
-    p = pipeopen(net_cmd)
-    net_out = p.communicate()
-    if net_out and net_out[0]:
-        for line in net_out[0].split('\n'):
-            if not line:
-                continue
-            print(line)
-
-    if p.returncode != 0:
-        return False
-
-    return True
-
-
-def smb4_grant_rights():
-    args = [
-        "/usr/local/bin/pdbedit",
-        "-d 0",
-        "-L"
-    ]
-
-    p = pipeopen(' '.join(args))
-    pdbedit_out = p.communicate()
-    if pdbedit_out and pdbedit_out[0]:
-        for line in pdbedit_out[0].split('\n'):
-            if not line:
-                continue
-
-            parts = line.split(':')
-            user = parts[0]
-            smb4_grant_user_rights(user)
-
-
 def get_groups(client):
     _groups = {}
 
@@ -1665,8 +1610,6 @@ def main():
                 smb4_tdb,
                 "/var/db/samba4/private/passdb.tdb"
             )
-            if role != 'member':
-                smb4_grant_rights()
 
             client.call('notifier.samba4', 'user_import_sentinel_file_create')
 

--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -1665,7 +1665,9 @@ def main():
                 smb4_tdb,
                 "/var/db/samba4/private/passdb.tdb"
             )
-            smb4_grant_rights()
+            if role != 'member':
+                smb4_grant_rights()
+
             client.call('notifier.samba4', 'user_import_sentinel_file_create')
 
         smb4_map_groups(client)


### PR DESCRIPTION
Iterating through each ldap user and granting rights has been observed to hang boot in large LDAP environments.