### PR TITLE
Always add 'zfs_space' and 'zfsacl' modules to vfsobjects if not present yet

### DIFF
--- a/gui/sharing/migrations/0002_cifs_vfsobjects_change_default.py
+++ b/gui/sharing/migrations/0002_cifs_vfsobjects_change_default.py
@@ -5,15 +5,13 @@ from __future__ import unicode_literals
 from django.db import migrations
 import freenasUI.freeadmin.models.fields
 
+
 def change_cifs_vfsobjects_defaults(apps, schema_editor):
     cifs_shares = apps.get_model('sharing', 'CIFS_Share').objects.all()
-    if not cifs_shares:
+    if not cifs_shares.exists():
         return
 
     for share in cifs_shares:
-        if not share.cifs_vfsobjects:
-            continue 
-
         new_vfs_objects = []
         if 'zfs_space' not in share.cifs_vfsobjects:
             new_vfs_objects.append('zfs_space')


### PR DESCRIPTION
At this point we may have shares with empty vfsobjects, inherited from the
FreeNAS 9.* and 10.*. We still want them to get default 'zfs_space' and
'zfsacl' modules.

Ticket: #26994

(cherry picked from commit 94228b09efe22e26f59c04274476850c87dbe135)
Signed-off-by: Timur I. Bakeyev <timur@iXsystems.com>