### PR TITLE
Fixes boot expect script

### DIFF
--- a/tests/boot.exp
+++ b/tests/boot.exp
@@ -8,7 +8,7 @@ set PID [spawn vm console "$vm"]
 send_user "Spawned PID: $PID \n"
 
 expect {
-  "Enter an option from 1-12:" {
+  "Enter an option from 1-11:" {
     sleep .5
     exit
   }


### PR DESCRIPTION
* After changes "Enter an option from 1-12:" no longer displays in console.
* Now we have to look for "Enter an option from 1-11:" to exit expect properly.