### PR TITLE
Fixed SNMP over IPv6 issue that regresses back into the 9.10 code tree (#28572)

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-snmpd
+++ b/src/freenas/etc/ix.rc.d/ix-snmpd
@@ -54,6 +54,8 @@ EOF
 
 		else
 			echo "rocommunity \"${snmp_community}\" default" >> ${snmp_config}
+			# Below line required for SNMP over IPv6, see bug 28572
+			echo "rocommunity6 \"${snmp_community}\" default" >> ${snmp_config}
 		fi
 
 	done


### PR DESCRIPTION
SNMP over IPv6 fix that regresses into 9.10, at the very least.  See bug 28572.