### PR TITLE
freenas-debug -B should only be run when explicitly specified via cli

### DIFF
--- a/src/freenas/usr/local/bin/freenas-debug
+++ b/src/freenas/usr/local/bin/freenas-debug
@@ -274,6 +274,10 @@ main()
 	if $all_debug; then
 		func_pids=""
 		for opt in ${opts_spaced} ; do
+			if [ ${opt} == 'B' ]
+			then
+				continue
+			fi
 
 			var=\$$(echo "module_func_${opt}")
 			func=$(eval "echo ${var}")

--- a/src/freenas/usr/local/bin/freenas-debug
+++ b/src/freenas/usr/local/bin/freenas-debug
@@ -274,7 +274,7 @@ main()
 	if $all_debug; then
 		func_pids=""
 		for opt in ${opts_spaced} ; do
-			if [ ${opt} == 'B' ]
+			if [ "${opt}" = "B" ]
 			then
 				continue
 			fi


### PR DESCRIPTION
When running the "Save Debug" from the webUI it will pass the "-A" option which will run all modules of the debug script. I have removed the "-B" option from being run because having a text based dump of the database any time you want to save a debug can have security implications since these debug files are routinely used in public spaces (forums, redmine etc)