### PR TITLE
Add -v to zpool status in freenas-debug script

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/zfs/zfs.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/zfs/zfs.sh
@@ -37,7 +37,7 @@ zfs_func()
 	section_footer
 
 	section_header "ZFS Pools Status"
-	zpool status
+	zpool status -v
 	section_footer
 
 	section_header "ZFS Pools History - excepting replication"


### PR DESCRIPTION
Per the man page -v provides:

"Displays verbose data error information, printing out a complete list of all data errors since the last complete pool scrub."

This is useful for TrueNAS/FreeNAS support team in determining, quickly, which files are corrupt (if any) and will prompt for closer investigation.