### PR TITLE
fix(middlewared): problem related with VCP deployment.

### DIFF
--- a/gui/vcp/utils.py
+++ b/gui/vcp/utils.py
@@ -266,7 +266,8 @@ def update_plugin_zipfile(
 
 
 def encrypt_string(password, key):
-    cipher = DES.new(key, DES.MODE_CFB, key)
+    key_bytes = bytes(key, encoding="utf8")
+    cipher = DES.new(key_bytes, DES.MODE_CFB, key_bytes)
     resolved = cipher.encrypt(password.encode('ISO-8859-1'))
     return resolved.decode('ISO-8859-1')
 


### PR DESCRIPTION
 The problem was related with encrypt key/iv in Python 3.

```
Traceback (most recent call last):
  File "./freenasUI/vcp/utils.py", line 314, in create_propertyFile
    password, enc_key))
  File "./freenasUI/vcp/utils.py", line 281, in encrypt_string
    cipher = DES.new(key, DES.MODE_CFB, key)
  File "/usr/local/lib/python3.6/site-packages/Crypto/Cipher/DES.py", line 147, in new
    return _create_cipher(sys.modules[__name__], key, mode, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/Crypto/Cipher/__init__.py", line 55, in _create_cipher
    return modes[mode](factory, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/Crypto/Cipher/_mode_cfb.py", line 232, in _create_cfb_cipher
    cipher_state = factory._create_base_cipher(kwargs)
  File "/usr/local/lib/python3.6/site-packages/Crypto/Cipher/DES.py", line 69, in _create_base_cipher
    expect_byte_string(key)
  File "/usr/local/lib/python3.6/site-packages/Crypto/Ut
Feb 23 18:21:13 truenas03a uwsgi: il/_raw_api.py", line 194, in expect_byte_string
    raise TypeError("Only byte strings can be passed to C code")
TypeError: Only byte strings can be passed to C code
```