### PR TITLE
[STABLE] Fix problem related with VCP deployment. The problem was related with…

### DIFF
--- a/gui/vcp/utils.py
+++ b/gui/vcp/utils.py
@@ -266,7 +266,8 @@ def update_plugin_zipfile(
 
 
 def encrypt_string(password, key):
-    cipher = DES.new(key, DES.MODE_CFB, key)
+    key_bytes = bytes(key, encoding="utf8")
+    cipher = DES.new(key_bytes, DES.MODE_CFB, key_bytes)
     resolved = cipher.encrypt(password.encode('ISO-8859-1'))
     return resolved.decode('ISO-8859-1')
 


### PR DESCRIPTION
… encrypt key/iv in Python 3 (#897)

NOTE: We need it get into the next TrueNAS 11.1-u2.
Requested by: Luis