### PR TITLE
Remove subdirs that apparently may be present after the system dataset migration.

### DIFF
--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -322,7 +322,7 @@ class SystemDatasetService(ConfigService):
             proc = await Popen(f'zfs list -H -o name {_from}/.system|xargs zfs destroy -r', shell=True)
             await proc.communicate()
 
-        os.rmdir('/tmp/system.new')
+        shutil.rmtree('/tmp/system.new')
 
         for i in restart:
             await self.middleware.call('service.start', i)


### PR DESCRIPTION
Ticket: #27967
I'll create a PR for stable after this gets accepted.
It would be nice to simplify/rewrite some of the system dataset migration logic after the 11.1-u2.