### PR TITLE
fix(plugins/jail): get_activated_pool errantly reraising

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -161,7 +161,7 @@ class JailService(CRUDService):
         """Returns the activated pool if there is one, or None"""
         try:
             pool = ioc.IOCage(skip_jails=True).get("", pool=True)
-        except:
+        except Exception:
             pool = None
 
         return pool

--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -159,14 +159,10 @@ class JailService(CRUDService):
     @accepts()
     def get_activated_pool(self):
         """Returns the activated pool if there is one, or None"""
-        pool = None
-
         try:
             pool = ioc.IOCage(skip_jails=True).get("", pool=True)
-        except KeyError:
-            pass
-        else:
-            raise
+        except:
+            pool = None
 
         return pool
 


### PR DESCRIPTION
It was trying to raise a non-existent exception. This is now a generic catch-all, as it's either None or a pool.