### PR TITLE
fix(28944) minor typo fix in freenas-debug script

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/zfs/zfs.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/zfs/zfs.sh
@@ -81,7 +81,7 @@ zfs_func()
 	section_header  "pool joined to storage"
 		cat  /tmp/pool.normal  |   ${FREENAS_DEBUG_MODULEDIR}/zfs/join_pool.nawk
 	section_footer
-	section_header  "enclusure data joined to pool"
+	section_header  "enclosure data joined to pool"
 		cat  /tmp/ses.normal  |   ${FREENAS_DEBUG_MODULEDIR}/zfs/join_ses.nawk
 	section_footer
 }


### PR DESCRIPTION
in zfs.sh, "enclosure" is misspelled "enclusure"