### PR TITLE
Do not grant extra rights to users

### DIFF
--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -1665,7 +1665,6 @@ def main():
                 smb4_tdb,
                 "/var/db/samba4/private/passdb.tdb"
             )
-            smb4_grant_rights()
             client.call('notifier.samba4', 'user_import_sentinel_file_create')
 
         smb4_map_groups(client)


### PR DESCRIPTION
Once users have setakeownership privilege they can take ownership of a file regardless of the file's ACL. We should be careful about granting these rights.