### PR TITLE
Print stats since boot for first line

### DIFF
--- a/src/freenas/usr/local/bin/arcstat.py
+++ b/src/freenas/usr/local/bin/arcstat.py
@@ -437,7 +437,6 @@ def main():
         if i == 0:
             print_header()
 
-        snap_stats()
         calculate()
         print_values()
 
@@ -448,6 +447,7 @@ def main():
 
         i = 0 if i == hdr_intr else i + 1
         time.sleep(sint)
+        snap_stats()
 
     if out:
         out.close()


### PR DESCRIPTION
init() already calls snap_stats(), don't call it again the first time through.