### PR TITLE
fix(rc.d): Don't stomp on daemon's pid

### DIFF
--- a/nas_ports/freenas/py-middlewared/files/middlewared.in
+++ b/nas_ports/freenas/py-middlewared/files/middlewared.in
@@ -46,9 +46,8 @@ middlewared_stop() {
 
 	if checkyesno middlewared_debug; then
 		/usr/local/bin/tmux kill-session -t 'middlewared'
+		rm $pidfile
 	fi
-
-	rm $pidfile
 }
 
 name="middlewared"

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -1158,8 +1158,9 @@ def main():
     os.environ['MIDDLEWARED'] = str(os.getpid())
 
     if args.foreground:
-        with open(pidpath, "w") as _pidfile:
-            _pidfile.write(f"{str(os.getpid())}\n")
+        if not os.path.exists(pidpath):
+            with open(pidpath, "w") as _pidfile:
+                _pidfile.write(f"{str(os.getpid())}\n")
 
     Middleware(
         loop_monitor=not args.disable_loop_monitor,


### PR DESCRIPTION
Previous behavior would overwrite the pid of the daemon process, thus rc.d is killing the wrong process.