### PR TITLE
feat(rc.d): --pidfile flag

### DIFF
--- a/nas_ports/freenas/py-middlewared/files/middlewared.in
+++ b/nas_ports/freenas/py-middlewared/files/middlewared.in
@@ -26,9 +26,9 @@ middlewared_start() {
 	/sbin/ifconfig lo0 127.0.0.1 up
 	if checkyesno middlewared_debug; then
 		/usr/local/bin/tmux new-session -s middlewared -d
-		/usr/local/bin/tmux send -t middlewared "env PATH=$PATH:/usr/local/sbin:/usr/local/bin LC_ALL=en_US.UTF-8 /usr/local/bin/middlewared -f ${plugins_dirs_arg}" ENTER
+		/usr/local/bin/tmux send -t middlewared "env PATH=$PATH:/usr/local/sbin:/usr/local/bin LC_ALL=en_US.UTF-8 /usr/local/bin/middlewared ${plugins_dirs_arg} -P" ENTER
 	else
-		env PATH=$PATH:/usr/local/sbin:/usr/local/bin LC_ALL=en_US.UTF-8 ${command} -f -P ${pidfile} -r /usr/local/bin/middlewared -f ${plugins_dirs_arg} --log-handler=file
+		env PATH=$PATH:/usr/local/sbin:/usr/local/bin LC_ALL=en_US.UTF-8 ${command} -f -P ${pidfile} -r /usr/local/bin/middlewared ${plugins_dirs_arg} --log-handler=file
 	fi
 	LD_LIBRARY_PATH=/usr/local/lib /usr/local/bin/midclt -t 120 waitready
 }
@@ -48,7 +48,9 @@ middlewared_stop() {
 		/usr/local/bin/tmux kill-session -t 'middlewared'
 	fi
 
-	rm $pidfile
+	if [ -f "${pidfile}" ] ; then
+		rm $pidfile
+	fi
 }
 
 name="middlewared"

--- a/src/middlewared/Makefile
+++ b/src/middlewared/Makefile
@@ -6,7 +6,7 @@ reinstall: clean
 	python setup.py install --single-version-externally-managed --record=/dev/null
 
 dev: reinstall
-	middlewared -f restart -L
+	middlewared restart -L -P
 
 reinstall-remote:
 	sh -c 'if [ -z "${HOST}" ]; then echo "You need to set HOST"; exit 1; fi;'

--- a/src/middlewared/Makefile
+++ b/src/middlewared/Makefile
@@ -6,7 +6,7 @@ reinstall: clean
 	python setup.py install --single-version-externally-managed --record=/dev/null
 
 dev: reinstall
-	middlewared restart -L -P
+	middlewared restart -L -P --debug-level 'TRACE'
 
 reinstall-remote:
 	sh -c 'if [ -z "${HOST}" ]; then echo "You need to set HOST"; exit 1; fi;'

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -1101,19 +1101,14 @@ def main():
         'INFO',
         'WARN',
         'ERROR',
-    ])
+    ], default='DEBUG')
     parser.add_argument('--log-handler', choices=[
         'console',
         'file',
     ], default='console')
     args = parser.parse_args()
 
-    if args.debug_level is None:
-        debug_level = 'TRACE'
-    else:
-        debug_level = args.debug_level or 'DEBUG'
-
-    _logger = logger.Logger('middleware', debug_level)
+    _logger = logger.Logger('middleware', args.debug_level)
     _logger.getLogger()
 
     pidpath = '/var/run/middlewared.pid'
@@ -1147,7 +1142,7 @@ def main():
     Middleware(
         loop_monitor=not args.disable_loop_monitor,
         plugins_dirs=args.plugins_dirs,
-        debug_level=debug_level,
+        debug_level=args.debug_level,
     ).run()
 
 

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -1114,7 +1114,7 @@ def main():
         debug_level = args.debug_level or 'DEBUG'
 
     _logger = logger.Logger('middleware', debug_level)
-    get_logger = _logger.getLogger()
+    _logger.getLogger()
 
     pidpath = '/var/run/middlewared.pid'
 


### PR DESCRIPTION
Previous behavior would overwrite the pid of the daemon process, thus rc.d would kill the wrong process. 

Middlewared no longer has a daemon mode, and always runs in foreground. To allow daemon(8) to control the pidfile, we have a flag for debug to create a pidfile in the absence of daemon(8)

Ticket: #29185