### PR TITLE
socket.herror: Unknown host

### DIFF
--- a/src/afpusers/files/afpusers.py
+++ b/src/afpusers/files/afpusers.py
@@ -55,7 +55,6 @@ def AFPUsers():
                 except:
                     host = 'unknown ' + m.group(2)
                 mac[pid] = host
-
         p.wait()
 
     try:
@@ -98,8 +97,8 @@ def AFPUsers():
                         uid = temp.pw_uid
                         fname = temp.pw_gecos
                     yield (pid, uid, user, fname, time, mac[pid])
-
         p.wait()
+
 
 if __name__ == "__main__":
     print("PID      UID      Username         Name                 Logintime Mac")

--- a/src/afpusers/files/afpusers.py
+++ b/src/afpusers/files/afpusers.py
@@ -50,7 +50,10 @@ def AFPUsers():
             m = rx.match(line)
             if m is not None:
                 pid = int(m.group(1))
-                host = socket.gethostbyaddr(m.group(2))[0]
+                try:
+                   host = socket.gethostbyaddr(m.group(2))[0]
+                except:
+                    host = 'unknown ' + m.group(2)
                 mac[pid] = host
 
         p.wait()

--- a/src/afpusers/files/afpusers.py
+++ b/src/afpusers/files/afpusers.py
@@ -51,7 +51,7 @@ def AFPUsers():
             if m is not None:
                 pid = int(m.group(1))
                 try:
-                   host = socket.gethostbyaddr(m.group(2))[0]
+                    host = socket.gethostbyaddr(m.group(2))[0]
                 except:
                     host = 'unknown ' + m.group(2)
                 mac[pid] = host


### PR DESCRIPTION
It could be possible, that a hostname isn't known. 
```
Traceback (most recent call last):
  File "./upstream-afpusers.py", line 103, in <module>
    for (pid, uid, user, fname, time, mac) in AFPUsers():
  File "./upstream-afpusers.py", line 53, in AFPUsers
    host = socket.gethostbyaddr(m.group(2))[0]
socket.herror: [Errno 1] Unknown host
```