### PR TITLE
Remove remained '%s' literal from the config DB backup name.

### DIFF
--- a/gui/common/system.py
+++ b/gui/common/system.py
@@ -529,7 +529,7 @@ def backup_database():
         systemdataset["path"],
         f'configs-{systemdataset["uuid"]}',
         get_sw_version(),
-        f'{today}%s.db',
+        f'{today}.db',
     )
 
     dirname = os.path.dirname(newfile)


### PR DESCRIPTION
Ticket: #29521
(cherry picked from commit b7bdcaabf4a4fd5133afc7e558581142e96e5e0c)
Signed-off-by: Timur I. Bakeyev <timur@iXsystems.com>