### PR TITLE
fix(collectd): Fix restoring rrds from /data/rrd_dir.tar.bz2

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-collectd
+++ b/src/freenas/etc/ix.rc.d/ix-collectd
@@ -130,25 +130,23 @@ generate_collectd()
         fi
     fi
 
-    if [ -f "${rrdfile}" ]; then
-        if use_rrd_dataset && [ -d "${rrdmnt}" ]; then
-            if tar -tf "${rrdfile}"|egrep -q '^collectd/rrd/$'; then
-                cd "${rrdmnt}"
-                tar -jxf "${rrdfile}"
-                mv collectd/rrd/* "${rrdmnt}/"
-                mv "${rrdfile}" "${rrdmnt}/"
-                rm -rf collectd
-            fi
-        elif [ -d "/var/db" -a ! -d "${datadir}" ]; then
-            (cd /var/db && tar jxf "${rrdfile}")
-        fi
-    fi
-
     if use_rrd_dataset; then
         cd "${rrdmnt}" || exit 1
     else
         cd "${datadir}" || exit 1
     fi
+
+    if [ -f "${rrdfile}" ]; then
+        if tar -tf "${rrdfile}" | egrep -q '^collectd/rrd/$'; then
+            tar -jxf "${rrdfile}"
+            mv collectd/rrd/* .
+            rm -rf collectd
+        fi
+        if use_rrd_dataset; then
+            rm "${rrdfile}"
+        fi
+    fi
+
     # Migrate from old version, where "${hostname}" was a real directory
     # and "localhost" was a symlink.
     # Skip the case where "${hostname}" is "localhost", so symlink was not


### PR DESCRIPTION
$datadir was created on previous step so `! -d "${datadir}"` was always false
and `tar jxf "${rrdfile}"` was never executed

Ticket: #28862
Ticket: #27909