### PR TITLE
fix(middlewared): use full method name to call tasks

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -748,23 +748,24 @@ class Middleware(object):
                     else:
                         delay = method._periodic.interval
 
-                    self.logger.debug(f"Setting up periodic task {service_name}::{task_name} to run every {method._periodic.interval} seconds")
+                    method_name = f'{service_name}.{task_name}'
+                    self.logger.debug(f"Setting up periodic task {method_name} to run every {method._periodic.interval} seconds")
 
                     self.__loop.call_later(
                         delay,
                         functools.partial(
                             self.__call_periodic_task,
-                            method, service_name, service_obj, task_name, method._periodic.interval
+                            method, service_name, service_obj, method_name, method._periodic.interval
                         )
                     )
 
-    def __call_periodic_task(self, method, service_name, service_obj, task_name, interval):
-        self.__loop.create_task(self.__periodic_task_wrapper(method, service_name, service_obj, task_name, interval))
+    def __call_periodic_task(self, method, service_name, service_obj, method_name, interval):
+        self.__loop.create_task(self.__periodic_task_wrapper(method, service_name, service_obj, method_name, interval))
 
-    async def __periodic_task_wrapper(self, method, service_name, service_obj, task_name, interval):
-        self.logger.trace("Calling periodic task %s::%s", service_name, task_name)
+    async def __periodic_task_wrapper(self, method, service_name, service_obj, method_name, interval):
+        self.logger.trace("Calling periodic task %s", method_name)
         try:
-            await self._call(task_name, service_obj, method)
+            await self._call(method_name, service_obj, method)
         except Exception:
             self.logger.warning("Exception while calling periodic task", exc_info=True)
 
@@ -772,7 +773,7 @@ class Middleware(object):
             interval,
             functools.partial(
                 self.__call_periodic_task,
-                method, service_name, service_obj, task_name, interval
+                method, service_name, service_obj, method_name, interval
             )
         )
 


### PR DESCRIPTION
This should fix jobs to have right name attached to it (core.get_jobs)