### PR TITLE
feat(cloudsync): Use @job(logs=True) for rclone logs

### DIFF
--- a/gui/api/resources.py
+++ b/gui/api/resources.py
@@ -1886,6 +1886,7 @@ class CloudSyncResourceMixin(NestedMixin):
                     job['state'],
                     job['error'],
                 )
+                bundle.data['job_id'] = job['id']
             else:
                 bundle.data['status'] = job['state']
         else:

--- a/gui/freeadmin/static/lib/js/freeadmin.js
+++ b/gui/freeadmin/static/lib/js/freeadmin.js
@@ -2698,6 +2698,16 @@ require([
             });
     }
 
+    jobLogs = function(job_id) {
+        commonDialog({
+            id: "job_logs_dialog",
+            style: "max-width: 75%;max-height:70%;background-color:white;overflow:auto;",
+            name: "Logs",
+            url: "/legacy/system/job/" + job_id + "/logs/",
+            nodes: []
+        });
+    }
+
     viewModel = function(name, url, tab) {
         var opened = false;
         var p = registry.byId("content");

--- a/gui/system/urls.py
+++ b/gui/system/urls.py
@@ -58,6 +58,7 @@ from .views import (
     certificate_import, certificate_create_internal, certificate_edit, CSR_edit,
     certificate_create_CSR, certificate_export_certificate, certificate_export_privatekey,
     certificate_export_certificate_and_privatekey,
+    job_logs,
 )
 
 
@@ -150,4 +151,5 @@ urlpatterns = [
     url(r'^certificate/export/certificate/(?P<id>\d+)$', certificate_export_certificate, name="certificate_export_certificate"),
     url(r'^certificate/export/privatekey/(?P<id>\d+)$', certificate_export_privatekey, name="certificate_export_privatekey"),
     url(r'^certificate/export/certificate/privatekey/(?P<id>\d+)$', certificate_export_certificate_and_privatekey, name="certificate_export_certificate_and_privatekey"),
+    url(r'^job/(?P<id>\d+)/logs/$', job_logs, name="job_logs"),
 ]

--- a/gui/system/views.py
+++ b/gui/system/views.py
@@ -2153,3 +2153,10 @@ def CA_info(request, id):
     return certificate_to_json(
         models.CertificateAuthority.objects.get(pk=int(id))
     )
+
+
+def job_logs(request, id):
+    with client as c:
+        job = c.call('core.get_jobs', [('id', '=', int(id))])[0]
+
+    return render_to_response('system/job_logs.html', job)

--- a/gui/tasks/admin.py
+++ b/gui/tasks/admin.py
@@ -82,6 +82,13 @@ class CloudSyncFAdmin(BaseFreeAdmin):
             'name': 'status',
             'label': _('Status'),
             'sortable': False,
+            'formatter': """function(value, obj) {
+                if (obj.job_id) {
+                    return '<a onclick="jobLogs(' + obj.job_id + '); return false;" style="cursor: pointer; text-decoration: underline;">' + value + '</a>';
+                }
+
+                return value;
+            }""",
         })
         for idx, column in enumerate(human_colums):
             columns.insert(4 + idx, dict(column))


### PR DESCRIPTION
Ticket: #27756

@william-gr how does new UI get the cloud sync now? In legacy UI / API 1.0 we have ugly hack with `core.get_jobs`, is it also implemented in new UI? I want this feature also to be present in new UI (as a reusable component for other jobs that produce logs).