### PR TITLE
fix(stable) freenas-debug speed up and clean up

### DIFF
--- a/src/freenas/usr/local/bin/freenas-debug
+++ b/src/freenas/usr/local/bin/freenas-debug
@@ -263,7 +263,9 @@ main()
 	if $all_debug; then
 		func_pids=""
 		for opt in ${opts_spaced} ; do
-			if [ "${opt}" = "B" ]
+			# These functions must be explicitly called from the CLI
+			if [ "${opt}" = "B" ] || [ "${opt}" = "b" || [ "${opt}" = "E" ] \
+			|| [ "${opt}" = "L" ]
 			then
 				continue
 			fi

--- a/src/freenas/usr/local/libexec/freenas-debug/active_directory/active_directory.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/active_directory/active_directory.sh
@@ -40,10 +40,35 @@ active_directory_func()
 	local pamfiles
 	local onoff
 	local enabled="DISABLED"
+	local mon_onoff
+	local mon_enabled="DISABLED"
 
 
 	#
-	#	First, check if the Active Directory service is enabled.
+	#	First, check if the AD Monitoring service is enabled.
+	#
+	mon_onoff=$(${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "
+	SELECT
+		ad_enable_monitor
+	FROM
+		directoryservice_activedirectory
+	ORDER BY
+		-id
+	LIMIT 1
+	")
+		
+	mon_enabled="DISABLED"
+	if [ "${mon_onoff}" = "1" ]
+	then
+		mon_enabled="ENABLED"
+	fi
+
+	section_header "Active Directory Monitoring"
+	echo "Active Directory Monitoring is ${mon_enabled}"
+	section_footer
+
+	#
+	#	Second, check if the Active Directory service is enabled.
 	#
 	onoff=$(${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "
 	SELECT
@@ -61,7 +86,7 @@ active_directory_func()
 	then
 		enabled="ENABLED"
 	fi
-
+	
 	section_header "Active Directory Status"
 	echo "Active Directory is ${enabled}"
 	section_footer
@@ -156,24 +181,10 @@ __EOF__
 	section_footer
 
 	#
-	#	Try to generate an AD config file
-	#
-	section_header "adtool get config_file"
-	adtool get config_file
-	section_footer
-
-	#
 	#	Dump Active Directory domain info
 	#
 	section_header "Active Directory Domain Info - 'net ads info'"
 	net ads info
-	section_footer
-
-	#
-	#	Dump Active Directory domain status
-	#
-	section_header "Active Directory Domain Status - 'net ads status'"
-	net ads status
 	section_footer
 
 	#
@@ -210,20 +221,10 @@ __EOF__
 	#
 	#	Dump Active Directory users and groups
 	#
-	section_header "Active Directory Users and Groups"
-	section_header "Users - 'wbinfo -u'"
-	wbinfo -u | head -200
-	section_header "Groups - 'wbinfo -g'"
-	wbinfo -g | head -200
-	section_header "Using getent"
-	section_header "Users - 'getent passwd'"
-	getent passwd | head -200
-	section_header "Groups - 'getent group'"
-	getent group | head -200
+	section_header "Active Directory Users - 'wbinfo -u'"
+	wbinfo -u | head -50
+	section_header "Active Directory Groups - 'wbinfo -g'"
+	wbinfo -g | head -50
 	section_footer
 
-	#
-	#	Dump cache info
-	#
-	cache_func "AD"
 }

--- a/src/freenas/usr/local/libexec/freenas-debug/domain_controller/domain_controller.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/domain_controller/domain_controller.sh
@@ -73,7 +73,15 @@ domain_controller_func()
 	section_footer
 
 	#
-	#	Next, dump Domain Controller configuration
+	#	If Domain Controller isn't enabled, no need to run so exit
+	#
+	if [ "${onoff}" = "0" ]
+	then
+		exit 0
+	fi
+
+	#
+	#	If enabled, dump Domain Controller configuration
 	#
 	local IFS="|"
 	read realm domain role dns_backend dns_forwarder forest_level \
@@ -213,15 +221,19 @@ __EOF__
 	#
 	#	Dump Active Directory users and groups
 	#
-	section_header "Active Directory Users and Groups"
-	section_header "Users - 'wbinfo -u'"
-	wbinfo -u
-	section_header "Groups - 'wbinfo -g'"
-	wbinfo -g
-	section_header "Using getent"
-	section_header "Users - 'getent passwd'"
-	getent passwd
-	section_header "Groups - 'getent group'"
-	getent group
+	#
+	#	We limit the output here because the point of running
+	#	wbinfo and getent is not, necessarily, to find a
+	#	specific user or group. It's to simply see if we
+	#	are even enumerating users and groups
+	#
+	section_header "Active Directory Users - 'wbinfo -u'"
+	wbinfo -u | -head 50
+	section_header "Active Directory Groups - 'wbinfo -g'"
+	wbinfo -g | -head 50
+	section_header "Local Users database- 'getent passwd'"
+	getent passwd | -head 50
+	section_header "Local Groups database- 'getent group'"
+	getent group | -head 50
 	section_footer
 }

--- a/src/freenas/usr/local/libexec/freenas-debug/hardware/hardware.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/hardware/hardware.sh
@@ -117,15 +117,19 @@ hardware_func()
 		fi
 	done
 
-	if [ -c /dev/ipmi0 ]
-	then
-		for list_type in sel sdr
-		do
-			section_header "ipmitool $list_type list"
-			ipmitool $list_type list
-			section_footer
-		done
-	fi
+	#
+	#	This logic is being moved to the IPMI module
+	#	because we are running duplicate ipmitool commands
+	#
+	#if [ -c /dev/ipmi0 ]
+	#then
+	#	for list_type in sel sdr
+	#	do
+	#		section_header "ipmitool $list_type list"
+	#		ipmitool $list_type list
+	#		section_footer
+	#	done
+	#fi
 
 	if which getencstat > /dev/null
 	then

--- a/src/freenas/usr/local/libexec/freenas-debug/include.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/include.sh
@@ -131,11 +131,15 @@ section_footer()
 		fnd_section_elapsed_time=$(($fnd_section_end_time - $fnd_section_start_time))
 		echo "debug finished in $fnd_section_elapsed_time seconds for $name"
 		#$dirfunc is the module name passed to us by the debug torture suite
-		if [ -n "$dirfunc" ]; then
-			echo "command used:"
-			modname=`echo -n "$dirfunc" | sed -e 's/_directory//'`
-			echo  ${FREENAS_DEBUG_MODULEDIR}/$modname.sh
-		fi
+		#
+		#The information included with this output is not warranted and
+	        #is also producing the wrong output at certain times.
+		#There is no loss in functionality by disabling this section.	
+		#if [ -n "$dirfunc" ]; then
+		#	echo "command used:"
+		#	modname=`echo -n "$dirfunc" | sed -e 's/_directory//'`
+		#	echo  ${FREENAS_DEBUG_MODULEDIR}/$modname.sh
+		#fi
 
 
 	fi

--- a/src/freenas/usr/local/libexec/freenas-debug/ipmi/ipmi.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/ipmi/ipmi.sh
@@ -32,16 +32,30 @@ ipmi_help() { echo "Dump IPMI Configuration"; }
 ipmi_directory() { echo "IPMI"; }
 ipmi_func()
 {
+	#
+	#	Let's check if the character device exists.
+	#	We make this check because the x-series
+	#	doesn't have an internal /dev/ipmi device
+	#	If the /dev/ipmi0 doesn't exist, we prevent
+	#	the script from trying to run all the commands
+	#
+	
+	section_header "ipmitool sel elist && ipmitool sdr elist"
+	if [ -c /dev/ipmi0 ]
+        then
+               for list_type in sel sdr
+               do
+                       ipmitool $list_type elist
+                       section_footer
+               done
+	else
+		echo "/dev/ipmi0 device doesn't exist!"
+		echo "This is expected behavior on an x-series appliance!"
+		exit 0
+        fi
+	
 	section_header "ipmitool lan print"
 	ipmitool lan print
-	section_footer
-
-	section_header "ipmitool sel elist"
-	ipmitool sel elist
-	section_footer
-
-	section_header "ipmitool sdr list | grep Temp"
-	ipmitool sdr list | grep Temp
 	section_footer
 
 	section_header "ipmitool sensor"

--- a/src/freenas/usr/local/libexec/freenas-debug/iscsi/iscsi.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/iscsi/iscsi.sh
@@ -32,6 +32,45 @@ iscsi_help() { echo "Dump iSCSI Configuration"; }
 iscsi_directory() { echo "iSCSI"; }
 iscsi_func()
 {
+	#
+	#	If iSCSI is disabled, exit.
+	#
+
+	iscsi_enabled=$(${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "
+	SELECT
+		srv_enable	
+	FROM
+		services_services
+	WHERE
+		srv_service = 'iscsitarget'
+	")
+
+	if [ "${iscsi_enabled}" = "0" ]
+	then
+		section_header "iSCSI Status"
+		echo "iSCSI is DISABLED"
+		exit 0
+	fi
+
+	alua_enabled=$(${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "
+	SELECT
+		iscsi_alua
+	FROM
+		services_iscsitargetglobalconfiguration
+	")
+
+	if [ "${alua_enabled}" = "0" ]
+	then
+		section_header "iSCSI ALUA Status"
+		echo "ALUA is DISABLED"
+	fi
+
+	if [ "${alua_enabled}" = "1" ]
+	then
+		section_header "iSCSI ALUA Status"
+		echo "ALUA is ENABLED"
+	fi
+
 	section_header "/etc/ctl.conf"
 	sc "/etc/ctl.conf.shadow"
 	section_footer

--- a/src/freenas/usr/local/libexec/freenas-debug/ldap/ldap.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/ldap/ldap.sh
@@ -60,6 +60,15 @@ ldap_func()
 	section_footer
 
 	#
+	#	If LDAP is disabled, exit.
+	#
+
+	if [ "${onoff}" = "0" ]
+	then
+		exit 0
+	fi
+
+	#
 	#	Next, dump LDAP configuration
 	#
 	local IFS="|"
@@ -168,11 +177,10 @@ __EOF__
 	#
 	#	Dump LDAP users and groups
 	#
-	section_header "LDAP Users and Groups"
-	section_header "Users - 'getent passwd'"
-	getent passwd
-	section_header "Groups - 'getent group'"
-	getent group
+	section_header "LDAP Users - 'getent passwd'"
+	getent passwd | head -50
+	section_header "LDAP Groups - 'getent group'"
+	getent group | head -50
 	section_footer
 
 	#

--- a/src/freenas/usr/local/libexec/freenas-debug/nfs/nfs.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/nfs/nfs.sh
@@ -32,13 +32,28 @@ nfs_help() { echo "Dump NFS Configuration"; }
 nfs_directory() { echo "NFS"; }
 nfs_func()
 {
-	section_header "/etc/version"
-	sc "/etc/version"
-	section_footer
+	
+	#
+	#	If NFS is disabled, exit.
+	#
 
-	section_header "/etc/resolv.conf"
-	sc "/etc/resolv.conf"
-	section_footer
+	local nfs_enabled
+
+	nfs_enabled=$(${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "
+	SELECT
+		srv_enable
+	FROM
+		service_services
+	WHERE
+		srv_service = 'nfs'
+	")
+	
+	section_header "NFS Status"	
+	if [ "${nfs_enabled}" = "0" ]
+	then
+		echo "NFS is DISABLED"
+		exit 0
+	fi
 
 	section_header "/etc/hosts"
 	sc "/etc/hosts"
@@ -49,10 +64,7 @@ nfs_func()
 	section_footer
 
 	section_header "showmount -e"
-	if srv_enabled nfs
-	then
-		showmount -e
-	fi
+	showmount -e
 	section_footer
 
 	section_header "rpcinfo -p"
@@ -69,22 +81,6 @@ nfs_func()
 
 	section_header "nfsstat -s"
 	nfsstat -s
-	section_footer
-
-	section_header "netstat -m"
-	netstat -m
-	section_footer
-
-	section_header "netstat -s -p udp"
-	netstat -s -p udp
-	section_footer
-
-	section_header "getent passwd"
-	getent passwd
-	section_footer
-
-	section_header "getent group"
-	getent group
 	section_footer
 
 	section_header "nfsv4 locks: nfsdumpstate"

--- a/src/freenas/usr/local/libexec/freenas-debug/smb/smb.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/smb/smb.sh
@@ -64,6 +64,14 @@ smb_func()
 	section_footer
 
 	#
+	#	If SMB is disabled, exit
+	#
+	if [ "${onoff}" = "0" ]
+	then
+		exit 0
+	fi
+	
+	#
 	#	Dump samba version
 	#
 	section_header "smbd -V"
@@ -116,30 +124,25 @@ smb_func()
 	net getdomainsid
 	section_footer
 	section_header "net usersidlist"
-	net usersidlist | head -200
+	net usersidlist | head -50
 	section_footer
 	section_header "net groupmap list"
-	net groupmap list | head -200
+	net groupmap list | head -50
 	section_footer
 
 	section_header "net status sessions"
-	net status sessions | head -200
+	net status sessions | head -50
 	section_footer
 	section_header "net status shares"
 	net status shares
 	section_footer
 
+	section_header "Lock information"
+	smbstatus -L | head -50
+	section_footer
+	
 	section_header "ACLs - 'sharesec --view-all'"
 	sharesec --view-all
 	section_footer
 
-	#
-	#	Dump SMB users and groups
-	#
-	section_header "Users and Groups"
-	section_header "Users - 'wbinfo -u'"
-	wbinfo -u | head -200
-	section_header "Groups - 'wbinfo -g'"
-	wbinfo -g | head -200
-	section_footer
 }

--- a/src/freenas/usr/local/libexec/freenas-debug/zfs/zfs.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/zfs/zfs.sh
@@ -32,19 +32,23 @@ zfs_help() { echo "Dump ZFS Configuration"; }
 zfs_directory() { echo "ZFS"; }
 zfs_func()
 {
-	section_header "ZFS Pools"
+	section_header "zpool list"
 	zpool list
 	section_footer
 
-	section_header "ZFS Pools Status"
+	section_header "zfs list"
+	zfs list
+	section_footer
+
+	section_header "zpool status -v"
 	zpool status -v
 	section_footer
 
-	section_header "ZFS Pools History - excepting replication"
-	zpool history |  egrep -v "zfs.*(snapshot|destroy|recv).*"
+	section_header "zpool history - excepting replication"
+	zpool history | egrep -v "zfs.*(snapshot|destroy|recv).*"
 	section_footer
 
-	section_header "ZFS Pools Properties"
+	section_header "zpool get all"
 	pools=$(zpool list -H|awk '{ print $1 }'|xargs)
 	for p in ${pools}
 	do
@@ -54,15 +58,11 @@ zfs_func()
 	done
 	section_footer
 
-	section_header "ZFS Datasets and ZVols"
-	zfs list
-	section_footer
-
-	section_header "ZFS Snapshots"
+	section_header "zfs list -t snapshot"
 	zfs list -t snapshot -o name,used,available,referenced,mountpoint,freenas:state
 	section_footer
 
-	section_header "ZFS Datasets Properties"
+	section_header "zfs get all"
 	zfs list -o name -H | while read -r s
 	do
 		section_header "${s}"
@@ -73,15 +73,15 @@ zfs_func()
 
 	glabel status > /tmp/glabel.out 
 	section_header  "zpool disk membership normal form"
-		zpool status |  ${FREENAS_DEBUG_MODULEDIR}/zfs/normalize_pool.nawk  | tee /tmp/pool.normal
+		zpool status | ${FREENAS_DEBUG_MODULEDIR}/zfs/normalize_pool.nawk | tee /tmp/pool.normal
 	section_footer
 	section_header  "enclosure use normal form"
-		sesutil map  |  ${FREENAS_DEBUG_MODULEDIR}/zfs/normalize_ses.nawk  | tee /tmp/ses.normal
+		sesutil map | ${FREENAS_DEBUG_MODULEDIR}/zfs/normalize_ses.nawk | tee /tmp/ses.normal
 	section_footer
 	section_header  "pool joined to storage"
-		cat  /tmp/pool.normal  |   ${FREENAS_DEBUG_MODULEDIR}/zfs/join_pool.nawk
+		cat  /tmp/pool.normal | ${FREENAS_DEBUG_MODULEDIR}/zfs/join_pool.nawk
 	section_footer
 	section_header  "enclosure data joined to pool"
-		cat  /tmp/ses.normal  |   ${FREENAS_DEBUG_MODULEDIR}/zfs/join_ses.nawk
+		cat  /tmp/ses.normal | ${FREENAS_DEBUG_MODULEDIR}/zfs/join_ses.nawk
 	section_footer
 }


### PR DESCRIPTION
cherry-picking PR https://github.com/freenas/freenas/pull/1032 back into 11.1 stable so that the next 11.1-U5 release has these changes.

Redmine: https://redmine.ixsystems.com/issues/30729

This is mostly correcting verbiage, removing duplicate commands, and fixing parts of the script that have been failing for a long time. Also disable the flamegraph/dtrace scripts from being run every time freenas-debug is called. You can still run these portions of the script from the CLI explicitly. This should help the overall speed of the script.