### PR TITLE
let middleware handle the process of mounting geli providers

### DIFF
--- a/src/freenas/etc/rc.conf.local
+++ b/src/freenas/etc/rc.conf.local
@@ -733,13 +733,20 @@ _gen_conf()
 		fi
 	done
 
-	echo "geli_devices=\"`${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "SELECT encrypted_provider FROM storage_encrypteddisk e JOIN storage_volume v ON e.encrypted_volume_id = v.id WHERE v.vol_encrypt=1;" | \
-		tr \\\n \  `\""
-	${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "SELECT e.encrypted_provider,v.vol_encryptkey FROM storage_encrypteddisk e JOIN storage_volume v ON e.encrypted_volume_id = v.id WHERE v.vol_encrypt=1;" | \
-	while read -r provider key; do
-		_provider=`echo ${provider}|tr '/-' '_'`
-		echo "geli_${_provider}_flags=\"-p -k /data/geli/${key}.key\""
-	done
+	# See redmine #31350
+	# Automatically mounting the geli providers at this stage in the boot process \
+	# is no longer needed. This task was added to middleware and can be done from the webUI.
+	# Having this automount the geli providers in RAM at this stage in the boot process breaks \
+	# all TrueNAS HA customers because the passive controller will also decrypt and mount the providers.
+	# 
+	# Simply disabling this section will fix the problem
+	#echo "geli_devices=\"`${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "SELECT encrypted_provider FROM storage_encrypteddisk e JOIN storage_volume v ON e.encrypted_volume_id = v.id WHERE v.vol_encrypt=1;" | \
+		#tr \\\n \  `\""
+	#${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "SELECT e.encrypted_provider,v.vol_encryptkey FROM storage_encrypteddisk e JOIN storage_volume v ON e.encrypted_volume_id = v.id WHERE v.vol_encrypt=1;" | \
+	#while read -r provider key; do
+		#_provider=`echo ${provider}|tr '/-' '_'`
+		#echo "geli_${_provider}_flags=\"-p -k /data/geli/${key}.key\""
+	#done
 
 	${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "SELECT lldp_intdesc, lldp_country, lldp_location FROM services_lldp ORDER BY -id LIMIT 1" | \
 	while read -r lldp_intdesc lldp_country lldp_location; do

--- a/src/freenas/etc/rc.conf.local
+++ b/src/freenas/etc/rc.conf.local
@@ -33,21 +33,29 @@
 # Reference these variables in script to prevent from having to make \
 # duplicate middleware calls.
 
-is_licensed=1
-ha_status=1
+is_licensed()
+{
+	local is_licensed=1
+	
+	if ! is_freenas; then
+		if [ `ulimit -n 1000; /usr/local/bin/python /usr/local/www/freenasUI/middleware/notifier.py failover_licensed` = "True" ]
+        	then
+                	return 0
+        	fi
+	fi
+}
 
-if ! is_freenas; then
-
-        if [ `ulimit -n 1000; /usr/local/bin/python /usr/local/www/freenasUI/middleware/notifier.py failover_licensed` = "True" ]
-        then
-                is_licensed=0
-        fi
-        if [ `ulimit -n 1000; /usr/local/bin/python /usr/local/www/freenasUI/middleware/notifier.py failover_status` = "MASTER" ]
-        then
-                ha_status=0
-        fi
-fi
-
+ha_status()
+{
+	local ha_status=1
+	
+	if ! is_freenas; then
+		if [ `ulimit -n 1000; /usr/local/bin/python /usr/local/www/freenasUI/middleware/notifier.py failover_status` = "MASTER" ]
+        	then
+                	return 0
+        	fi
+	fi
+}
 http_ssl_enabled()
 {
 	local ssl=$(${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "
@@ -122,7 +130,7 @@ _interface_config()
 	if ! is_freenas; then
 
 		if [ "$(ha_mode)" = "MANUAL" ]; then
-			if [ $is_licensed = 0 ]; then
+			if is_licensed; then
 				configure_ifaces=0
 				echo "# Unable to determine HA hardware and node, skipping interfaces configuration" | tee /dev/console
 			fi
@@ -217,7 +225,7 @@ _interface_config()
 			else
 				int_passopt=""
 			fi
-			if [ $ha_status = 0 ]; then
+			if ha_status; then
 				carp1_skew="1"
 			fi
 			echo -n "ifconfig_${interface}_alias0=\"inet vhid ${int_vhid} advskew ${carp1_skew}${int_passopt} alias ${int_vip}/32"
@@ -638,13 +646,13 @@ _gen_conf()
 
 	_count_config powerd_enable system_advanced adv_powerdaemon =1
 	if ! is_freenas; then
-		if [ $is_licensed = 0 ]; then
+		if is_licensed; then
 			echo "failover_enable=\"YES\""
 			echo "pf_enable=\"YES\""
 		else
 			echo "failover_enable=\"NO\""
 		fi
-		if [ $ha_status = 0 ]; then
+		if ha_status; then
 			echo "collectd_enable=\"YES\""
 		fi
 
@@ -750,8 +758,7 @@ _gen_conf()
 		fi
 	done
 
-	if [ $is_licensed = 1 ];
-        then
+	if ! is_licensed; then
                 echo "geli_devices=\"`${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "SELECT encrypted_provider FROM storage_encrypteddisk e JOIN storage_volume v ON e.encrypted_volume_id = v.id WHERE v.vol_encrypt=1;" | \
                         tr \\\n \  `\""
                 ${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "SELECT e.encrypted_provider,v.vol_encryptkey FROM storage_encrypteddisk e JOIN storage_volume v ON e.encrypted_volume_id = v.id WHERE v.vol_encrypt=1;" | \

--- a/src/freenas/etc/rc.conf.local
+++ b/src/freenas/etc/rc.conf.local
@@ -1,7 +1,6 @@
 #!/bin/sh
 # THIS FILE IS RESERVED FOR THE EXCLUSIVE USE OF FREENAS CONFIG SYSTEM.
 # Please edit /etc/rc.conf instead.
-
 #-
 # Copyright (c) 2010, 2011 iXsystems, Inc., All rights reserved.
 #
@@ -29,6 +28,25 @@
 
 . /etc/rc.freenas
 
+
+# Make our calls to middleware once, and store the results in variables.
+# Reference these variables in script to prevent from having to make \
+# duplicate middleware calls.
+
+is_licensed=1
+ha_status=1
+
+if ! is_freenas; then
+
+        if [ `ulimit -n 1000; /usr/local/bin/python /usr/local/www/freenasUI/middleware/notifier.py failover_licensed` = "True" ]
+        then
+                is_licensed=0
+        fi
+        if [ `ulimit -n 1000; /usr/local/bin/python /usr/local/www/freenasUI/middleware/notifier.py failover_status` = "MASTER" ]
+        then
+                ha_status=0
+        fi
+fi
 
 http_ssl_enabled()
 {
@@ -104,7 +122,7 @@ _interface_config()
 	if ! is_freenas; then
 
 		if [ "$(ha_mode)" = "MANUAL" ]; then
-			if [ "$(ulimit -n 1000; /usr/local/bin/python /usr/local/www/freenasUI/middleware/notifier.py failover_licensed 2> /dev/null)" = "True" ]; then
+			if [ $is_licensed = 0 ]; then
 				configure_ifaces=0
 				echo "# Unable to determine HA hardware and node, skipping interfaces configuration" | tee /dev/console
 			fi
@@ -199,7 +217,7 @@ _interface_config()
 			else
 				int_passopt=""
 			fi
-			if [ $(ulimit -n 1000; LD_LIBRARY=/usr/local/lib /usr/local/bin/python /usr/local/www/freenasUI/middleware/notifier.py failover_status) = "MASTER" ]; then
+			if [ $ha_status = 0 ]; then
 				carp1_skew="1"
 			fi
 			echo -n "ifconfig_${interface}_alias0=\"inet vhid ${int_vhid} advskew ${carp1_skew}${int_passopt} alias ${int_vip}/32"
@@ -620,14 +638,13 @@ _gen_conf()
 
 	_count_config powerd_enable system_advanced adv_powerdaemon =1
 	if ! is_freenas; then
-		if [ "$(ulimit -n 1000; /usr/local/bin/python /usr/local/www/freenasUI/middleware/notifier.py failover_licensed 2> /dev/null)" = "True" ]; then
+		if [ $is_licensed = 0 ]; then
 			echo "failover_enable=\"YES\""
 			echo "pf_enable=\"YES\""
 		else
 			echo "failover_enable=\"NO\""
 		fi
-		local failover="$(ulimit -n 1000; /usr/local/bin/python /usr/local/www/freenasUI/middleware/notifier.py failover_status 2> /dev/null)"
-		if [ "${failover}" != "BACKUP" ]; then
+		if [ $ha_status = 0 ]; then
 			echo "collectd_enable=\"YES\""
 		fi
 
@@ -733,33 +750,16 @@ _gen_conf()
 		fi
 	done
 
-	# See redmine #31350
-	# Automatically mounting the geli providers at this stage in the boot process \
-	# causes problems for HA truenas.
-	# All TrueNAS HA customers are effected by this.
-	# 
-	# To get around this, we make a rudimentary check to make sure
-	# 1. there is no passphrase set
-	# 2. if there is no passphrase set, make sure it's not freenas or a single-node truenas
-	# 
-	# If any of the above conditions are met, then we mount the geli providers.
-	# Else we do not need to run this.
-
-        has_nopassphrase="$(${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "SELECT vol_encrypt FROM storage_volume WHERE vol_encrypt = '1' ORDER BY -id LIMIT 1;")"
-        if [ "${has_nopassphrase}" = "1" ];
+	if [ $is_licensed = 1 ];
         then
-                if [ "$(is_freenas)" = "0" ] || [ "$(ha_mode)" = "MANUAL" ];
-                then
-                        echo "geli_devices=\"`${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "SELECT encrypted_provider FROM storage_encrypteddisk e JOIN storage_volume v ON e.encrypted_volume_id = v.id WHERE v.vol_encrypt=1;" | \
-                                tr \\\n \  `\""
-                        ${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "SELECT e.encrypted_provider,v.vol_encryptkey FROM storage_encrypteddisk e JOIN storage_volume v ON e.encrypted_volume_id = v.id WHERE v.vol_encrypt=1;" | \
-                        while read -r provider key; do
-                                _provider=`echo ${provider}|tr '/-' '_'`
-                                echo "geli_${_provider}_flags=\"-p -k /data/geli/${key}.key\""
-                        done
-                fi
+                echo "geli_devices=\"`${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "SELECT encrypted_provider FROM storage_encrypteddisk e JOIN storage_volume v ON e.encrypted_volume_id = v.id WHERE v.vol_encrypt=1;" | \
+                        tr \\\n \  `\""
+                ${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "SELECT e.encrypted_provider,v.vol_encryptkey FROM storage_encrypteddisk e JOIN storage_volume v ON e.encrypted_volume_id = v.id WHERE v.vol_encrypt=1;" | \
+                while read -r provider key; do
+                        _provider=`echo ${provider}|tr '/-' '_'`
+                        echo "geli_${_provider}_flags=\"-p -k /data/geli/${key}.key\""
+                done
         fi
-
 
 	${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "SELECT lldp_intdesc, lldp_country, lldp_location FROM services_lldp ORDER BY -id LIMIT 1" | \
 	while read -r lldp_intdesc lldp_country lldp_location; do

--- a/src/freenas/etc/rc.conf.local
+++ b/src/freenas/etc/rc.conf.local
@@ -28,33 +28,32 @@
 
 . /etc/rc.freenas
 
-
-# Make our calls to middleware once, and store the results in variables.
-# Reference these variables in script to prevent from having to make \
-# duplicate middleware calls.
-
+# Redmine 31350
 is_licensed()
 {
-	local is_licensed=1
-	
+
 	if ! is_freenas; then
 		if [ `ulimit -n 1000; /usr/local/bin/python /usr/local/www/freenasUI/middleware/notifier.py failover_licensed` = "True" ]
         	then
                 	return 0
         	fi
 	fi
+	
+	return 0
 }
 
+# Redmine 31350
 ha_status()
 {
-	local ha_status=1
-	
+
 	if ! is_freenas; then
 		if [ `ulimit -n 1000; /usr/local/bin/python /usr/local/www/freenasUI/middleware/notifier.py failover_status` = "MASTER" ]
         	then
                 	return 0
         	fi
 	fi
+	
+	return 0
 }
 http_ssl_enabled()
 {

--- a/src/freenas/etc/rc.conf.local
+++ b/src/freenas/etc/rc.conf.local
@@ -735,18 +735,31 @@ _gen_conf()
 
 	# See redmine #31350
 	# Automatically mounting the geli providers at this stage in the boot process \
-	# is no longer needed. This task was added to middleware and can be done from the webUI.
-	# Having this automount the geli providers in RAM at this stage in the boot process breaks \
-	# all TrueNAS HA customers because the passive controller will also decrypt and mount the providers.
+	# causes problems for HA truenas.
+	# All TrueNAS HA customers are effected by this.
 	# 
-	# Simply disabling this section will fix the problem
-	#echo "geli_devices=\"`${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "SELECT encrypted_provider FROM storage_encrypteddisk e JOIN storage_volume v ON e.encrypted_volume_id = v.id WHERE v.vol_encrypt=1;" | \
-		#tr \\\n \  `\""
-	#${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "SELECT e.encrypted_provider,v.vol_encryptkey FROM storage_encrypteddisk e JOIN storage_volume v ON e.encrypted_volume_id = v.id WHERE v.vol_encrypt=1;" | \
-	#while read -r provider key; do
-		#_provider=`echo ${provider}|tr '/-' '_'`
-		#echo "geli_${_provider}_flags=\"-p -k /data/geli/${key}.key\""
-	#done
+	# To get around this, we make a rudimentary check to make sure
+	# 1. there is no passphrase set
+	# 2. if there is no passphrase set, make sure it's not freenas or a single-node truenas
+	# 
+	# If any of the above conditions are met, then we mount the geli providers.
+	# Else we do not need to run this.
+
+        has_nopassphrase="$(${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "SELECT vol_encrypt FROM storage_volume WHERE vol_encrypt = '1' ORDER BY -id LIMIT 1;")"
+        if [ "${has_nopassphrase}" = "1" ];
+        then
+                if [ "$(is_freenas)" = "0" ] || [ "$(ha_mode)" = "MANUAL" ];
+                then
+                        echo "geli_devices=\"`${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "SELECT encrypted_provider FROM storage_encrypteddisk e JOIN storage_volume v ON e.encrypted_volume_id = v.id WHERE v.vol_encrypt=1;" | \
+                                tr \\\n \  `\""
+                        ${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "SELECT e.encrypted_provider,v.vol_encryptkey FROM storage_encrypteddisk e JOIN storage_volume v ON e.encrypted_volume_id = v.id WHERE v.vol_encrypt=1;" | \
+                        while read -r provider key; do
+                                _provider=`echo ${provider}|tr '/-' '_'`
+                                echo "geli_${_provider}_flags=\"-p -k /data/geli/${key}.key\""
+                        done
+                fi
+        fi
+
 
 	${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "SELECT lldp_intdesc, lldp_country, lldp_location FROM services_lldp ORDER BY -id LIMIT 1" | \
 	while read -r lldp_intdesc lldp_country lldp_location; do


### PR DESCRIPTION
Redmine: https://redmine.ixsystems.com/issues/31035

Much more detail in that redmine ticket but I will summarize here.

We are auto-mounting geli providers early in the boot process. While this isn't necessarily a problem on a single-node system, this causes problems for all TrueNAS HA appliances. Functionality for managing the destruction/mounting/decrypting of geli providers has been added to the webUI and middleware so I'm disabling this section in rc.conf.local