### PR TITLE
feat(middlewared/jail): Allow supplying a jail identifier

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -31,7 +31,12 @@ class JailService(CRUDService):
     )
     def query(self, filters=None, options=None):
         options = options or {}
-        jail_identifier = options.pop("identifier", None)
+        jail_identifier = None
+
+        if filters and len(filters) == 1 and list(
+                filters[0][:2]) == ['jail', '=']:
+            jail_identifier = filters[0].pop(2)
+
         recursive = False if jail_identifier is not None else True
 
         try:

--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -31,13 +31,14 @@ class JailService(CRUDService):
     )
     def query(self, filters=None, options=None):
         options = options or {}
-        jails = []
-        try:
-            jails = [
-                list(jail.values())[0]
+        jail_identifier = options.pop("identifier", None)
+        recursive = False if jail_identifier is not None else True
 
-                for jail in ioc.IOCage().get("all", recursive=True)
-            ]
+        try:
+            jail_dicts = ioc.IOCage(
+                jail=jail_identifier).get('all', recursive=recursive)
+            jails = [list(jail.values())[0] for jail in jail_dicts
+                     ] if jail_identifier is None else [jail_dicts]
         except BaseException:
             # Brandon is working on fixing this generic except, till then I
             # am not going to make the perfect the enemy of the good enough!


### PR DESCRIPTION
This is required to prepopulate defaults as asked in ticket 31419. Also allows a quicker way for grabbing a specific jail dictionary instead of grabbing them all and iterating for a match.

TIcket: #31731