### PR TITLE
Add more logging for AD monitoring

### DIFF
--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -597,10 +597,13 @@ class ServiceService(CRUDService):
     async def _started_activedirectory(self, **kwargs):
         for srv in ('kinit', 'activedirectory', ):
             if await self._system('/usr/sbin/service ix-%s status' % (srv, )) != 0:
+                self.logger.debug(f'AD monitor: Failed to get ix-{srv} status')
                 return False, []
         if await self._system('/usr/local/bin/wbinfo -p') != 0:
+                self.logger.debug('AD monitor: wbinfo -p failed')
                 return False, []
         if await self._system('/usr/local/bin/wbinfo -t') != 0:
+                self.logger.debug('AD monitor: wbinfo -t failed')
                 return False, []
         return True, []
 


### PR DESCRIPTION
Log the reason why we think that AD is not started.