### PR TITLE
Silence warning about nut_upsshut not being set by, y'know, setting it.

### DIFF
--- a/src/freenas/etc/rc.conf.local
+++ b/src/freenas/etc/rc.conf.local
@@ -413,6 +413,7 @@ _nut_config() {
 		while read -r ups_mode ups_remotehost ups_remoteport ups_identifier; do
 			if [ "${ups_mode}" = "master" ]; then
 				echo "nut_enable=\"YES\""
+				echo "nut_upsshut=\"NO\""
 				echo "nut_upslog_ups=\"${ups_identifier}\""
 			else
 				echo "nut_upslog_ups=\"${ups_identifier}@${ups_remotehost}:${ups_remoteport}\""


### PR DESCRIPTION
https://redmine.ixsystems.com/issues/31400

The value of NO was picked due to matching existing behaviour and because I'm fairly sure people don't want their systems to power off when they turn the UPS service off.