### PR TITLE
Adding ssh & ftp to api2 tests and fix for the other api2 tests

### DIFF
--- a/tests/api1/ad_bsd.py
+++ b/tests/api1/ad_bsd.py
@@ -112,8 +112,9 @@ def test_08_Creating_a_SMB_share_on_SMB_PATH():
 @bsd_host_cfg
 @ad_test_cfg
 def test_09_creating_smb_mountpoint():
-    assert SSH_TEST('mkdir -p "%s" && sync' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('mkdir -p "%s" && sync' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 # The ADUSER user must exist in AD with this password
@@ -122,7 +123,8 @@ def test_09_creating_smb_mountpoint():
 def test_10_Store_AD_credentials_in_a_file_for_mount_smbfs():
     cmd = 'echo "[TESTNAS:ADUSER]" > ~/.nsmbrc && '
     cmd += 'echo "password=12345678" >> ~/.nsmbrc'
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
@@ -130,49 +132,56 @@ def test_10_Store_AD_credentials_in_a_file_for_mount_smbfs():
 def test_11_Mounting_SMB():
     cmd = 'mount_smbfs -N -I %s -W AD01 ' % ip
     cmd += '"//aduser@testnas/%s" "%s"' % (SMB_NAME, MOUNTPOINT)
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
 @ad_test_cfg
 def test_13_Creating_SMB_file():
-    assert SSH_TEST('touch "%s/testfile"' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('touch "%s/testfile"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
 @ad_test_cfg
 def test_14_Moving_SMB_file():
     cmd = 'mv "%s/testfile" "%s/testfile2"' % (MOUNTPOINT, MOUNTPOINT)
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
 @ad_test_cfg
 def test_15_Copying_SMB_file():
     cmd = 'cp "%s/testfile2" "%s/testfile"' % (MOUNTPOINT, MOUNTPOINT)
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
 @ad_test_cfg
 def test_16_Deleting_SMB_file_1_2():
-    assert SSH_TEST('rm "%s/testfile"' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('rm "%s/testfile"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
 @ad_test_cfg
 def test_17_Deleting_SMB_file_2_2():
-    assert SSH_TEST('rm "%s/testfile2"' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('rm "%s/testfile2"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
 @ad_test_cfg
 def test_18_Unmounting_SMB():
-    assert SSH_TEST('umount "%s"' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('umount "%s"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Update tests
@@ -180,48 +189,55 @@ def test_18_Unmounting_SMB():
 def test_19_Mounting_SMB():
     cmd = 'mount_smbfs -N -I %s -W AD01 ' % ip
     cmd += '"//aduser@testnas/%s" "%s"' % (SMB_NAME, MOUNTPOINT)
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
 @ad_test_cfg
 def test_20_Creating_SMB_file():
-    assert SSH_TEST('touch "%s/testfile"' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('touch "%s/testfile"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
 @ad_test_cfg
 def test_21_Moving_SMB_file():
     cmd = 'mv "%s/testfile" "%s/testfile2"' % (MOUNTPOINT, MOUNTPOINT)
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
 @ad_test_cfg
 def test_22_Copying_SMB_file():
     cmd = 'cp "%s/testfile2" "%s/testfile"' % (MOUNTPOINT, MOUNTPOINT)
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
 @ad_test_cfg
 def test_23_Deleting_SMB_file_1_2():
-    assert SSH_TEST('rm "%s/testfile"' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('rm "%s/testfile"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
 @ad_test_cfg
 def test_24_Deleting_SMB_file_2_2():
-    assert SSH_TEST('rm "%s/testfile2"' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('rm "%s/testfile2"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @ad_test_cfg
 def test_25_Unmounting_SMB():
-    assert SSH_TEST('umount "%s"' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('umount "%s"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Delete tests
@@ -229,7 +245,8 @@ def test_25_Unmounting_SMB():
 @ad_test_cfg
 def test_26_Removing_SMB_mountpoint():
     cmd = 'test -d "%s" && rmdir "%s" || exit 0' % (MOUNTPOINT, MOUNTPOINT)
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Disable Active Directory Directory

--- a/tests/api1/ad_osx.py
+++ b/tests/api1/ad_osx.py
@@ -106,8 +106,9 @@ def test_08_Creating_a_SMB_share_on_SMB_PATH():
 @osx_host_cfg
 @ad_test_cfg
 def test_10_Create_mount_point_for_SMB_on_OSX_system():
-    assert SSH_TEST('mkdir -p "%s"' % MOUNTPOINT,
-                    OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST('mkdir -p "%s"' % MOUNTPOINT,
+                       OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 @osx_host_cfg
@@ -115,14 +116,16 @@ def test_10_Create_mount_point_for_SMB_on_OSX_system():
 def test_11_Mount_SMB_share_on_OSX_system():
     cmd = 'mount -t smbfs "smb://%s:' % ADUSERNAME
     cmd += '%s@%s/%s" "%s"' % (ADPASSWORD, ip, SMB_NAME, MOUNTPOINT)
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 @osx_host_cfg
 @ad_test_cfg
 def test_13_Create_file_on_SMB_share_via_OSX_to_test_permissions():
-    assert SSH_TEST('touch "%s/testfile.txt"' % MOUNTPOINT,
-                    OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST('touch "%s/testfile.txt"' % MOUNTPOINT,
+                       OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Move test file to a new location on the SMB share
@@ -132,7 +135,8 @@ def test_14_Moving_SMB_test_file_into_a_new_directory():
     cmd = 'mkdir -p "%s/tmp" && ' % MOUNTPOINT
     cmd += 'mv "%s/testfile.txt" ' % MOUNTPOINT
     cmd += '"%s/tmp/testfile.txt"' % MOUNTPOINT
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Delete test file and test directory from SMB share
@@ -141,22 +145,25 @@ def test_14_Moving_SMB_test_file_into_a_new_directory():
 def test_15_Deleting_test_file_and_directory_from_SMB_share():
     cmd = 'rm -f "%s/tmp/testfile.txt" && ' % MOUNTPOINT
     cmd += 'rmdir "%s/tmp"' % MOUNTPOINT
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 @osx_host_cfg
 @ad_test_cfg
 def test_16_Verifying_that_test_file_directory_successfully_removed():
     cmd = 'find -- "%s/" -prune -type d -empty | grep -q .' % MOUNTPOINT
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Clean up mounted SMB share
 @osx_host_cfg
 @ad_test_cfg
 def test_17_Unmount_SMB_share():
-    assert SSH_TEST('umount -f "%s"' % MOUNTPOINT,
-                    OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST('umount -f "%s"' % MOUNTPOINT,
+                       OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Update tests
@@ -165,14 +172,16 @@ def test_17_Unmount_SMB_share():
 def test_18_Mount_SMB_share_on_OSX_system():
     cmd = 'mount -t smbfs "smb://%s:' % ADUSERNAME
     cmd += '%s@%s/%s" "%s"' % (ADPASSWORD, ip, SMB_NAME, MOUNTPOINT)
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 @osx_host_cfg
 @ad_test_cfg
 def test_19_Create_file_on_SMB_share_via_OSX_to_test_permissions():
-    assert SSH_TEST('touch "%s/testfile.txt"' % MOUNTPOINT,
-                    OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST('touch "%s/testfile.txt"' % MOUNTPOINT,
+                       OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Move test file to a new location on the SMB share
@@ -182,7 +191,8 @@ def test_20_Moving_SMB_test_file_into_a_new_directory():
     cmd = 'mkdir -p "%s/tmp" && ' % MOUNTPOINT
     cmd += 'mv "%s/testfile.txt" ' % MOUNTPOINT
     cmd += '"%s/tmp/testfile.txt"' % MOUNTPOINT
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Delete test file and test directory from SMB share
@@ -191,22 +201,25 @@ def test_20_Moving_SMB_test_file_into_a_new_directory():
 def test_21_Deleting_test_file_and_directory_from_SMB_share():
     cmd = 'rm -f "%s/tmp/testfile.txt" && ' % MOUNTPOINT
     cmd += 'rmdir "%s/tmp"' % MOUNTPOINT
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 @osx_host_cfg
 @ad_test_cfg
 def test_22_Verifying_test_file_directory_were_successfully_removed():
     cmd = 'find -- "%s/" -prune -type d -empty | grep -q .' % MOUNTPOINT
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Clean up mounted SMB share
 @osx_host_cfg
 @ad_test_cfg
 def test_23_Unmount_SMB_share():
-    assert SSH_TEST('umount -f "%s"' % MOUNTPOINT,
-                    OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST('umount -f "%s"' % MOUNTPOINT,
+                       OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Delete tests
@@ -214,7 +227,8 @@ def test_23_Unmount_SMB_share():
 @ad_test_cfg
 def test_24_Removing_SMB_mountpoint():
     cmd = 'test -d "%s" && rmdir "%s" || exit 0' % (MOUNTPOINT, MOUNTPOINT)
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Disable Active Directory Directory

--- a/tests/api1/afp_osx.py
+++ b/tests/api1/afp_osx.py
@@ -75,22 +75,25 @@ def test_06_Creating_a_AFP_share_on_AFP_PATH():
 @mount_test_cfg
 @osx_host_cfg
 def test_07_Create_mount_point_for_AFP_on_OSX_system():
-    assert SSH_TEST('mkdir -p "%s"' % MOUNTPOINT,
-                    OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST('mkdir -p "%s"' % MOUNTPOINT,
+                       OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @osx_host_cfg
 def test_08_Mount_AFP_share_on_OSX_system():
     cmd = 'mount -t afp "afp://%s/%s" "%s"' % (ip, AFP_NAME, MOUNTPOINT)
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @osx_host_cfg
 def test_10_Create_file_on_AFP_share_via_OSX_to_test_permissions():
-    assert SSH_TEST('touch "%s/testfile.txt"' % MOUNTPOINT,
-                    OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST('touch "%s/testfile.txt"' % MOUNTPOINT,
+                       OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Move test file to a new location on the AFP share
@@ -100,7 +103,8 @@ def test_11_Moving_AFP_test_file_into_a_new_directory():
     cmd = 'mkdir -p "%s/tmp" && ' % MOUNTPOINT
     cmd += 'mv "%s/testfile.txt" ' % MOUNTPOINT
     cmd += '"%s/tmp/testfile.txt"' % MOUNTPOINT
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Delete test file and test directory from AFP share
@@ -109,22 +113,25 @@ def test_11_Moving_AFP_test_file_into_a_new_directory():
 def test_12_Deleting_test_file_and_directory_from_AFP_share():
     cmd = 'rm -f "%s/tmp/testfile.txt" && ' % MOUNTPOINT
     cmd += 'rmdir "%s/tmp"' % MOUNTPOINT
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @osx_host_cfg
 def test_13_Verifying_test_file_directory_were_successfully_removed():
     cmd = 'find -- "%s/" -prune -type d -empty | grep -q .' % MOUNTPOINT
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Clean up mounted AFP share
 @mount_test_cfg
 @osx_host_cfg
 def test_14_Unmount_AFP_share():
-    assert SSH_TEST("umount -f '%s'" % MOUNTPOINT,
-                    OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST("umount -f '%s'" % MOUNTPOINT,
+                       OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Update tests
@@ -132,14 +139,16 @@ def test_14_Unmount_AFP_share():
 @osx_host_cfg
 def test_16_Mount_AFP_share_on_OSX_system():
     cmd = 'mount -t afp "afp://%s/%s" "%s"' % (ip, AFP_NAME, MOUNTPOINT)
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @osx_host_cfg
 def test_17_Create_file_on_AFP_share_via_OSX_to_test_permissions():
-    assert SSH_TEST('touch "%s/testfile.txt"' % MOUNTPOINT,
-                    OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST('touch "%s/testfile.txt"' % MOUNTPOINT,
+                       OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Move test file to a new location on the AFP share
@@ -149,7 +158,8 @@ def test_18_Moving_AFP_test_file_into_a_new_directory():
     cmd = 'mkdir -p "%s/tmp" && ' % MOUNTPOINT
     cmd += 'mv "%s/testfile.txt" ' % MOUNTPOINT
     cmd += '"%s/tmp/testfile.txt"' % MOUNTPOINT
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Delete test file and test directory from AFP share
@@ -158,22 +168,25 @@ def test_18_Moving_AFP_test_file_into_a_new_directory():
 def test_19_Deleting_test_file_and_directory_from_AFP_share():
     cmd = 'rm -f "%s/tmp/testfile.txt" && ' % MOUNTPOINT
     cmd += 'rmdir "%s/tmp"' % MOUNTPOINT
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @osx_host_cfg
 def test_20_Verifying_test_file_directory_were_successfully_removed():
     cmd = 'find -- "%s/" -prune -type d -empty | grep -q .' % MOUNTPOINT
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Clean up mounted AFP share
 @mount_test_cfg
 @osx_host_cfg
 def test_21_Unmount_AFP_share():
-    assert SSH_TEST('umount -f "%s"' % MOUNTPOINT,
-                    OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST('umount -f "%s"' % MOUNTPOINT,
+                       OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Delete tests
@@ -181,7 +194,8 @@ def test_21_Unmount_AFP_share():
 @osx_host_cfg
 def test_22_Removing_SMB_mountpoint():
     cmd = 'test -d "%s" && rmdir "%s" || exit 0' % (MOUNTPOINT, MOUNTPOINT)
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Test disable AFP

--- a/tests/api1/alerts.py
+++ b/tests/api1/alerts.py
@@ -20,7 +20,8 @@ alert_file = "/tmp/self-test-alert"
 # Create tests
 def test_01_Create_an_alert_on_the_remote_system():
     cmd = 'echo "[%s] %s" > %s' % (alert_status, alert_msg, alert_file)
-    assert SSH_TEST(cmd, user, password, ip) is True
+    results = SSH_TEST(cmd, user, password, ip)
+    assert results['result'] is True, results['output']
 
 
 # Update tests

--- a/tests/api1/cronjob.py
+++ b/tests/api1/cronjob.py
@@ -37,7 +37,8 @@ def test_03_Wait_a_minute():
 # Update tests
 # Ensure test file does exist
 # def test_04_Verify_cronjob_has_created_the_test_file():
-#     assert SSH_TEST('test -f "%s"' % TESTFILE, user, password, ip) == True
+#     results = SSH_TEST('test -f "%s"' % TESTFILE, user, password, ip)
+#     assert results['result'] is True, results['output']
 
 
 # Update cronjob to disabled with new cron_command
@@ -56,7 +57,8 @@ def test_06_Checking_that_API_reports_the_cronjob_as_updated():
 # Delete test file so we can verify it is no longer being created later
 # in the delete/cronjob test
 def test_07_Deleting_test_file_created_by_cronjob():
-    assert SSH_TEST('rm -f "%s"' % TESTFILE, user, password, ip) is True
+    results = SSH_TEST('rm -f "%s"' % TESTFILE, user, password, ip)
+    assert results['result'] is True, results['output']
 
 
 # Delete tests

--- a/tests/api1/ftp.py
+++ b/tests/api1/ftp.py
@@ -13,7 +13,7 @@ from functions import PUT, GET_OUTPUT, RC_TEST
 from auto_config import ip
 
 
-# Delete tests
+# Create tests
 def test_01_Configuring_ftp_service():
     payload = {"ftp_clients": 10, "ftp_rootlogin": "true"}
     results = PUT("/services/ftp/", payload)

--- a/tests/api1/iscsi.py
+++ b/tests/api1/iscsi.py
@@ -110,7 +110,8 @@ def test_08_Verify_the_iSCSI_service_is_enabled():
 @bsd_host_cfg
 def test_09_Connecting_to_iSCSI_target():
     cmd = 'iscsictl -A -p %s:3620 -t %s' % (ip, TARGET_NAME)
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
@@ -118,7 +119,7 @@ def test_09_Connecting_to_iSCSI_target():
 def test_10_Waiting_for_iscsi_connection_before_grabbing_device_name():
     while True:
         SSH_TEST('iscsictl -L', BSD_USERNAME, BSD_PASSWORD,
-                 BSD_HOST) is True
+                 BSD_HOST)
         state = 'cat /tmp/.sshCmdTestStdOut | '
         state += 'awk \'$2 == "%s:3620" {print $3}\'' % ip
         iscsi_state = return_output(state)
@@ -128,6 +129,7 @@ def test_10_Waiting_for_iscsi_connection_before_grabbing_device_name():
             iscsi_dev = return_output(dev)
             global DEVICE_NAME
             DEVICE_NAME = iscsi_dev
+            assert True
             break
         sleep(3)
 
@@ -135,23 +137,25 @@ def test_10_Waiting_for_iscsi_connection_before_grabbing_device_name():
 @mount_test_cfg
 @bsd_host_cfg
 def test_11_Format_the_target_volume():
-    assert SSH_TEST('newfs "/dev/%s"' % DEVICE_NAME,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('newfs "/dev/%s"' % DEVICE_NAME,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_12_Creating_iSCSI_mountpoint():
-    assert SSH_TEST('mkdir -p "%s"' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('mkdir -p "%s"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_13_Mount_the_target_volume():
     cmd = 'mount "/dev/%s" "%s"' % (DEVICE_NAME, MOUNTPOINT)
-    assert SSH_TEST(cmd,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
@@ -160,85 +164,97 @@ def test_14_Creating_file():
     cmd = 'touch "%s/testfile"' % MOUNTPOINT
     # The line under doesn't make sence
     # "umount '${MOUNTPOINT}'; rmdir '${MOUNTPOINT}'"
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_15_Moving_file():
     cmd = 'mv "%s/testfile" "%s/testfile2"' % (MOUNTPOINT, MOUNTPOINT)
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_16_Copying_file():
     cmd = 'cp "%s/testfile2" "%s/testfile"' % (MOUNTPOINT, MOUNTPOINT)
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_17_Deleting_file():
-    assert SSH_TEST('rm "%s/testfile2"' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('rm "%s/testfile2"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_18_Unmounting_iSCSI_volume():
-    assert SSH_TEST('umount "%s"' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('umount "%s"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_19_Mount_the_target_volume():
-    SSH_TEST('mount "/dev/%s" "%s"' % (DEVICE_NAME, MOUNTPOINT),
-             BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('mount "/dev/%s" "%s"' % (DEVICE_NAME, MOUNTPOINT),
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_20_Creating_45MB_file_to_verify_vzol_size_increase():
-    SSH_TEST('dd if=/dev/zero of=/tmp/45Mfile.img bs=1M count=45',
-             BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('dd if=/dev/zero of=/tmp/45Mfile.img bs=1M count=45',
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_21_Moving_45MB_file_to_verify_vzol_size_increase():
-    SSH_TEST('mv /tmp/45Mfile.img "%s/testfile1"' % MOUNTPOINT,
-             BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('mv /tmp/45Mfile.img "%s/testfile1"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_22_Deleting_file():
-    SSH_TEST('rm "%s/testfile1"' % MOUNTPOINT,
-             BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('rm "%s/testfile1"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_23_Unmounting_iSCSI_volume():
-    SSH_TEST('umount -f "%s"' % MOUNTPOINT,
-             BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('umount -f "%s"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Delete tests
 @mount_test_cfg
 @bsd_host_cfg
 def test_24_Removing_iSCSI_volume_mountpoint():
-    SSH_TEST('rm -rf "%s"' % MOUNTPOINT,
-             BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('rm -rf "%s"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_25_Disconnect_iSCSI_target():
-    SSH_TEST('iscsictl -R -t %s' % TARGET_NAME,
-             BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('iscsictl -R -t %s' % TARGET_NAME,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Disable the iSCSI service

--- a/tests/api1/ldap_bsd.py
+++ b/tests/api1/ldap_bsd.py
@@ -128,8 +128,9 @@ def test_09_Creating_a_SMB_share_on_SMB_PATH():
 @bsd_host_cfg
 @ldap_test_cfg
 def test_10_Creating_SMB_mountpoint():
-    assert SSH_TEST('mkdir -p "%s" && sync' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('mkdir -p "%s" && sync' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 # The LDAPUSER user must exist in LDAP with this password
@@ -138,7 +139,8 @@ def test_10_Creating_SMB_mountpoint():
 def test_11_Store_LDAP_credentials_for_mount_smbfs():
     cmd = 'echo "[TESTNAS:LDAPUSER]" > ~/.nsmbrc && '
     cmd += 'echo "password=12345678" >> ~/.nsmbrc'
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
@@ -146,56 +148,64 @@ def test_11_Store_LDAP_credentials_for_mount_smbfs():
 def test_12_Mounting_SMB():
     cmd = 'mount_smbfs -N -I %s -W LDAP01 ' % ip
     cmd += '//ldapuser@testnas/%s "%s"' % (SMB_NAME, MOUNTPOINT)
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
 @ldap_test_cfg
 def test_14_Creating_SMB_file():
-    assert SSH_TEST('touch "%s/testfile"' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('touch "%s/testfile"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
 @ldap_test_cfg
 def test_15_Moving_SMB_file():
     cmd = 'mv "%s/testfile" "%s/testfile2"' % (MOUNTPOINT, MOUNTPOINT)
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
 @ldap_test_cfg
 def test_16_Copying_SMB_file():
     cmd = 'cp "%s/testfile2" "%s/testfile"' % (MOUNTPOINT, MOUNTPOINT)
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
 @ldap_test_cfg
 def test_17_Deleting_SMB_file_1_2():
-    assert SSH_TEST('rm "%s/testfile"' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('rm "%s/testfile"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
 @ldap_test_cfg
 def test_18_Deleting_SMB_file_2_2():
-    assert SSH_TEST('rm "%s/testfile2"' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('rm "%s/testfile2"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
 @ldap_test_cfg
 def test_19_Unmounting_SMB():
-    assert SSH_TEST('umount -f "%s"' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('umount -f "%s"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
 @ldap_test_cfg
 def test_20_Verifying_SMB_share_was_unmounted():
-    assert SSH_TEST('mount | grep -qv "%s"' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('mount | grep -qv "%s"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Update tests
@@ -225,63 +235,72 @@ def test_22_Checking_LDAPd():
 def test_23_Mounting_SMB():
     cmd = 'mount_smbfs -N -I %s -W LDAP02 ' % ip
     cmd += '"//ldapuser@testnas/%s" "%s"' % (SMB_NAME, MOUNTPOINT)
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
 @up_ldap_test_cfg
 def test_24_Creating_SMB_file():
-    assert SSH_TEST('touch "%s/testfile"' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('touch "%s/testfile"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
 @up_ldap_test_cfg
 def test_25_Moving_SMB_file():
     cmd = 'mv "%s/testfile" "%s/testfile2"' % (MOUNTPOINT, MOUNTPOINT)
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
 @up_ldap_test_cfg
 def test_26_Copying_SMB_file():
     cmd = 'cp "%s/testfile2" "%s/testfile"' % (MOUNTPOINT, MOUNTPOINT)
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
 @up_ldap_test_cfg
 def test_27_Deleting_SMB_file_1_2():
-    assert SSH_TEST('rm "%s/testfile"' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('rm "%s/testfile"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
 @up_ldap_test_cfg
 def test_28_Deleting_SMB_file_2_2():
-    assert SSH_TEST('rm "%s/testfile2"' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('rm "%s/testfile2"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
 @up_ldap_test_cfg
 def test_29_Unmounting_SMB():
-    assert SSH_TEST('umount -f "%s"' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('umount -f "%s"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
 @up_ldap_test_cfg
 def test_30_Verifying_SMB_share_was_unmounted():
-    assert SSH_TEST('mount | grep -qv "%s"' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('mount | grep -qv "%s"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
 @up_ldap_test_cfg
 def test_31_Removing_SMB_mountpoint():
     cmd = 'test -d "%s" && rmdir "%s" || exit 0' % (MOUNTPOINT, MOUNTPOINT)
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Delete tests
@@ -290,7 +309,8 @@ def test_31_Removing_SMB_mountpoint():
 def test_32_Removing_SMB_mountpoint():
     cmd = 'test -d "%s" && ' % MOUNTPOINT
     cmd += 'rmdir "%s" || exit 0' % MOUNTPOINT
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @up_ldap_test_cfg

--- a/tests/api1/ldap_osx.py
+++ b/tests/api1/ldap_osx.py
@@ -119,8 +119,9 @@ def test_08_Creating_a_SMB_share_on_SMB_PATH():
 @osx_host_cfg
 @ldap_test_cfg
 def test_09_Create_mount_point_for_SMB_on_OSX_system():
-    assert SSH_TEST('mkdir -p "%s"' % MOUNTPOINT,
-                    OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST('mkdir -p "%s"' % MOUNTPOINT,
+                       OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 @osx_host_cfg
@@ -128,14 +129,16 @@ def test_09_Create_mount_point_for_SMB_on_OSX_system():
 def test_10_Mount_SMB_share_on_OSX_system():
     cmd = 'mount -t smbfs "smb://ldapuser:12345678'
     cmd += '@%s/%s" %s' % (ip, SMB_NAME, MOUNTPOINT)
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 @osx_host_cfg
 @ldap_test_cfg
 def test_11_Create_file_on_SMB_share_via_OSX_to_test_permissions():
-    assert SSH_TEST('touch "%s/testfile.txt"' % MOUNTPOINT,
-                    OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST('touch "%s/testfile.txt"' % MOUNTPOINT,
+                       OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Move test file to a new location on the SMB share
@@ -145,7 +148,8 @@ def test_12_Moving_SMB_test_file_into_a_new_directory():
     cmd = 'mkdir -p "%s/tmp" && ' % MOUNTPOINT
     cmd += 'mv "%s/testfile.txt" ' % MOUNTPOINT
     cmd += '"%s/tmp/testfile.txt"' % MOUNTPOINT
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Delete test file and test directory from SMB share
@@ -154,22 +158,25 @@ def test_12_Moving_SMB_test_file_into_a_new_directory():
 def test_13_Deleting_test_file_and_directory_from_SMB_share():
     cmd = 'rm -f "%s/tmp/testfile.txt" && ' % MOUNTPOINT
     cmd += 'rmdir "%s/tmp"' % MOUNTPOINT
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 @osx_host_cfg
 @ldap_test_cfg
 def test_14_Verifying_test_file_directory_were_successfully_removed():
     cmd = 'find -- "%s/" -prune -type d -empty | grep -q .' % MOUNTPOINT
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Clean up mounted SMB share
 @osx_host_cfg
 @ldap_test_cfg
 def test_15_Unmount_SMB_share():
-    assert SSH_TEST('umount -f "%s"' % MOUNTPOINT,
-                    OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST('umount -f "%s"' % MOUNTPOINT,
+                       OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Update tests
@@ -199,14 +206,16 @@ def test_17_Checking_LDAP():
 def test_18_Mount_SMB_share_on_OSX_system():
     cmd = 'mount -t smbfs "smb://ldapuser:12345678'
     cmd += '@%s/%s" "%s"' % (ip, SMB_NAME, MOUNTPOINT)
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 @osx_host_cfg
 @up_ldap_test_cfg
 def test_20_Create_file_on_SMB_share_via_OSX_to_test_permissions():
-    assert SSH_TEST('touch "%s/testfile.txt"' % MOUNTPOINT,
-                    OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST('touch "%s/testfile.txt"' % MOUNTPOINT,
+                       OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Move test file to a new location on the SMB share
@@ -216,7 +225,8 @@ def test_21_Moving_SMB_test_file_into_a_new_directory():
     cmd = 'mkdir -p "%s/tmp" && ' % MOUNTPOINT
     cmd += 'mv "%s/testfile.txt" ' % MOUNTPOINT
     cmd += '"%s/tmp/testfile.txt"' % MOUNTPOINT
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Delete test file and test directory from SMB share
@@ -225,22 +235,25 @@ def test_21_Moving_SMB_test_file_into_a_new_directory():
 def test_22_Deleting_test_file_and_directory_from_SMB_share():
     cmd = 'rm -f "%s/tmp/testfile.txt" && ' % MOUNTPOINT
     cmd += 'rmdir "%s/tmp"' % MOUNTPOINT
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 @osx_host_cfg
 @up_ldap_test_cfg
 def test_23_Verifying_test_file_directory_were_successfully_removed():
     cmd = 'find -- "%s/" -prune -type d -empty | grep -q .' % MOUNTPOINT
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Clean up mounted SMB share
 @osx_host_cfg
 @up_ldap_test_cfg
 def test_24_Unmount_SMB_share():
-    assert SSH_TEST('umount -f "%s"' % MOUNTPOINT,
-                    OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST('umount -f "%s"' % MOUNTPOINT,
+                       OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Delete tests
@@ -248,7 +261,8 @@ def test_24_Unmount_SMB_share():
 @ldap_test_cfg
 def test_25_Removing_SMB_mountpoint():
     cmd = 'test -d "%s" && rmdir "%s" || exit 0' % (MOUNTPOINT, MOUNTPOINT)
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 def test_26_Removing_SMB_share_on_SMB_PATH():

--- a/tests/api1/nfs.py
+++ b/tests/api1/nfs.py
@@ -71,8 +71,9 @@ def test_04_Checking_to_see_if_NFS_service_is_enabled():
 @bsd_host_cfg
 # Now check if we can mount NFS / create / rename / copy / delete / umount
 def test_05_Creating_NFS_mountpoint():
-    assert SSH_TEST('mkdir -p "%s"' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('mkdir -p "%s"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
@@ -81,7 +82,8 @@ def test_06_Mounting_NFS():
     cmd = 'mount_nfs %s:%s %s' % (ip, NFS_PATH, MOUNTPOINT)
     # command below does not make sence
     # "umount '${MOUNTPOINT}' ; rmdir '${MOUNTPOINT}'" "60"
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
@@ -89,42 +91,48 @@ def test_06_Mounting_NFS():
 def test_07_Creating_NFS_file():
     cmd = 'touch "%s/testfile"' % MOUNTPOINT
     # 'umount "${MOUNTPOINT}"; rmdir "${MOUNTPOINT}"'
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_08_Moving_NFS_file():
     cmd = 'mv "%s/testfile" "%s/testfile2"' % (MOUNTPOINT, MOUNTPOINT)
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_09_Copying_NFS_file():
     cmd = 'cp "%s/testfile2" "%s/testfile"' % (MOUNTPOINT, MOUNTPOINT)
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_10_Deleting_NFS_file():
-    assert SSH_TEST('rm "%s/testfile2"' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('rm "%s/testfile2"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_11_Unmounting_NFS():
-    assert SSH_TEST('umount "%s"' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('umount "%s"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_12_Removing_NFS_mountpoint():
     cmd = 'test -d "%s" && rmdir "%s" || exit 0' % (MOUNTPOINT, MOUNTPOINT)
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Update test

--- a/tests/api1/smb_bsd.py
+++ b/tests/api1/smb_bsd.py
@@ -79,8 +79,9 @@ def test_06_Creating_a_SMB_share_on_SMB_PATH():
 @mount_test_cfg
 @bsd_host_cfg
 def test_07_Creating_SMB_mountpoint():
-    assert SSH_TEST('mkdir -p "%s" && sync' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('mkdir -p "%s" && sync' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
@@ -88,49 +89,56 @@ def test_07_Creating_SMB_mountpoint():
 def test_08_Mounting_SMB():
     cmd = 'mount_smbfs -N -I %s ' % ip
     cmd += '"//guest@testnas/%s" "%s"' % (SMB_NAME, MOUNTPOINT)
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_09_Creating_SMB_file():
-    assert SSH_TEST("touch %s/testfile" % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST("touch %s/testfile" % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_10_Moving_SMB_file():
     cmd = 'mv %s/testfile %s/testfile2' % (MOUNTPOINT, MOUNTPOINT)
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_11_Copying_SMB_file():
     cmd = 'cp %s/testfile2 %s/testfile' % (MOUNTPOINT, MOUNTPOINT)
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_12_Deleting_SMB_file_1_2():
-    assert SSH_TEST('rm "%s/testfile"' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('rm "%s/testfile"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_13_Deleting_SMB_file_2_2():
-    assert SSH_TEST('rm "%s/testfile2"' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('rm "%s/testfile2"' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_14_Unmounting_SMB():
-    assert SSH_TEST('umount -f %s' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('umount -f %s' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Update tests
@@ -139,49 +147,56 @@ def test_14_Unmounting_SMB():
 def test_15_Mounting_SMB():
     cmd = 'mount_smbfs -N -I %s ' % ip
     cmd += '"//guest@testnas/%s" "%s"' % (SMB_NAME, MOUNTPOINT)
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_16_Creating_SMB_file():
-    assert SSH_TEST('touch %s/testfile' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('touch %s/testfile' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_17_Moving_SMB_file():
     cmd = 'mv %s/testfile %s/testfile2' % (MOUNTPOINT, MOUNTPOINT)
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_18_Copying_SMB_file():
     cmd = 'cp %s/testfile2 %s/testfile' % (MOUNTPOINT, MOUNTPOINT)
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_19_Deleting_SMB_file_1_2():
-    assert SSH_TEST('rm %s/testfile' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('rm %s/testfile' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_20_Deleting_SMB_file_2_2():
-    assert SSH_TEST('rm %s/testfile2' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('rm %s/testfile2' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @bsd_host_cfg
 def test_21_Unmounting_SMB():
-    assert SSH_TEST('umount -f %s' % MOUNTPOINT,
-                    BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST('umount -f %s' % MOUNTPOINT,
+                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Delete tests
@@ -189,7 +204,8 @@ def test_21_Unmounting_SMB():
 @bsd_host_cfg
 def test_22_Removing_SMB_mountpoint():
     cmd = 'test -d "%s" && rmdir "%s" || exit 0' % (MOUNTPOINT, MOUNTPOINT)
-    assert SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST) is True
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    assert results['result'] is True, results['output']
 
 
 def test_23_SMB_share_on_SMB_PATH():

--- a/tests/api1/smb_osx.py
+++ b/tests/api1/smb_osx.py
@@ -75,8 +75,9 @@ def test_05_Checking_to_see_if_SMB_service_is_running():
 @mount_test_cfg
 @osx_host_cfg
 def test_06_Create_mount_point_for_SMB_on_OSX_system():
-    assert SSH_TEST('mkdir -p "%s"' % MOUNTPOINT,
-                    OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST('mkdir -p "%s"' % MOUNTPOINT,
+                       OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
@@ -84,14 +85,16 @@ def test_06_Create_mount_point_for_SMB_on_OSX_system():
 def test_07_Mount_SMB_share_on_OSX_system():
     cmd = 'mount -t smbfs "smb://guest'
     cmd += '@%s/%s" "%s"' % (ip, SMB_NAME, MOUNTPOINT)
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @osx_host_cfg
 def test_09_Create_file_on_SMB_share_via_OSX_to_test_permissions():
-    assert SSH_TEST('touch "%s/testfile.txt"' % MOUNTPOINT,
-                    OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST('touch "%s/testfile.txt"' % MOUNTPOINT,
+                       OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Move test file to a new location on the SMB share
@@ -101,7 +104,8 @@ def test_10_Moving_SMB_test_file_into_a_new_directory():
     cmd = 'mkdir -p "%s/tmp" ' % MOUNTPOINT
     cmd += '&& mv "%s/testfile.txt" ' % MOUNTPOINT
     cmd += '"%s/tmp/testfile.txt"' % MOUNTPOINT
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Delete test file and test directory from SMB share
@@ -110,22 +114,25 @@ def test_10_Moving_SMB_test_file_into_a_new_directory():
 def test_11_Deleting_test_file_and_directory_from_SMB_share():
     cmd = 'rm -f "%s/tmp/testfile.txt" ' % MOUNTPOINT
     cmd += '&& rmdir "%s/tmp"' % MOUNTPOINT
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @osx_host_cfg
 def test_12_Verifying_test_file_directory_were_successfully_removed():
     cmd = 'find -- "%s/" -prune -type d -empty | grep -q .' % MOUNTPOINT
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Clean up mounted SMB share
 @mount_test_cfg
 @osx_host_cfg
 def test_13_Unmount_SMB_share():
-    assert SSH_TEST('umount -f "%s"' % MOUNTPOINT,
-                    OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST('umount -f "%s"' % MOUNTPOINT,
+                       OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Update tests
@@ -134,14 +141,16 @@ def test_13_Unmount_SMB_share():
 def test_09_Mount_SMB_share_on_OSX_system():
     cmd = 'mount -t smbfs "smb://guest@'
     cmd += '%s/%s" "%s"' % (ip, SMB_NAME, MOUNTPOINT)
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @osx_host_cfg
 def test_11_Create_file_on_SMB_share_via_OSX_to_test_permissions():
-    assert SSH_TEST('touch "%s/testfile.txt"' % MOUNTPOINT,
-                    OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST('touch "%s/testfile.txt"' % MOUNTPOINT,
+                       OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Move test file to a new location on the SMB share
@@ -151,7 +160,8 @@ def test_12_Moving_SMB_test_file_into_a_new_directory():
     cmd = 'mkdir -p "%s/tmp" && ' % MOUNTPOINT
     cmd += 'mv "%s/testfile.txt" ' % MOUNTPOINT
     cmd += '"%s/tmp/testfile.txt"' % MOUNTPOINT
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Delete test file and test directory from SMB share
@@ -160,22 +170,25 @@ def test_12_Moving_SMB_test_file_into_a_new_directory():
 def test_13_Deleting_test_file_and_directory_from_SMB_share():
     cmd = 'rm -f "%s/tmp/testfile.txt" && ' % MOUNTPOINT
     cmd += 'rmdir "%s/tmp"' % MOUNTPOINT
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 @mount_test_cfg
 @osx_host_cfg
 def test_14_Verifying_test_file_directory_were_successfully_removed():
     cmd = 'find -- "%s/" -prune -type d -empty | grep -q .' % MOUNTPOINT
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Clean up mounted SMB share
 @mount_test_cfg
 @osx_host_cfg
 def test_15_Unmount_SMB_share():
-    assert SSH_TEST('umount -f "%s"' % MOUNTPOINT,
-                    OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST('umount -f "%s"' % MOUNTPOINT,
+                       OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 # Delete tests
@@ -183,7 +196,8 @@ def test_15_Unmount_SMB_share():
 @osx_host_cfg
 def test_22_Removing_SMB_mountpoint():
     cmd = 'test -d "%s" && rmdir "%s" || exit 0' % (MOUNTPOINT, MOUNTPOINT)
-    assert SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST) is True
+    results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
+    assert results['result'] is True, results['output']
 
 
 def test_14_Removing_SMB_share_on_SMB_PATH():

--- a/tests/api1/system.py
+++ b/tests/api1/system.py
@@ -9,8 +9,8 @@ import os
 
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from functions import PUT, POST, GET, SSH_TEST
-from auto_config import user, password, ip
+from functions import PUT, POST, GET  # , SSH_TEST
+# from auto_config import user, password, ip
 
 
 def test_01_Checking_system_version():
@@ -46,5 +46,6 @@ def test_03_Creating_system_tunable_dummynet():
 
 
 # Verify loader tunable
-def test_06_Verify_system_tunable_dummynet_load():
-    SSH_TEST('kldstat -m dummynet', user, password, ip)
+# def test_06_Verify_system_tunable_dummynet_load():
+#     results = SSH_TEST('kldstat -m dummynet', user, password, ip)
+#     assert results['result'] is True, results['output']

--- a/tests/api2/disk.py
+++ b/tests/api2/disk.py
@@ -9,7 +9,7 @@ import os
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from auto_config import disk1, disk2
-from functions import GET_ALL_OUTPUT
+from functions import GET
 
 disk0 = disk1[:-1] + '0'
 RunTest = True
@@ -17,58 +17,58 @@ TestName = "get disk information"
 
 
 def test_01_verifying_that_the_installer_created_all_disk():
-    assert len(GET_ALL_OUTPUT('/disk')) == 3
+    assert len(GET('/disk').json()) == 3
 
 
 def test_02_looking_for_disk0_was_created():
-    assert GET_ALL_OUTPUT('/disk')[0]['name'] == disk0
+    assert GET('/disk').json()[0]['name'] == disk0
 
 
 def test_03_looking_disk0_subsystem():
-    assert GET_ALL_OUTPUT('/disk')[0]['subsystem'] == disk0[:-1]
+    assert GET('/disk').json()[0]['subsystem'] == disk0[:-1]
 
 
 def test_04_looking_disk0_number():
-    assert GET_ALL_OUTPUT('/disk')[0]['number'] == 0
+    assert GET('/disk').json()[0]['number'] == 0
 
 
 def test_05_looking_disk0_identifier_and_serial_match():
-    identifier_serial = GET_ALL_OUTPUT('/disk')[0]['identifier'][8:]
-    serial = GET_ALL_OUTPUT('/disk')[0]['serial']
+    identifier_serial = GET('/disk').json()[0]['identifier'][8:]
+    serial = GET('/disk').json()[0]['serial']
     assert identifier_serial == serial
 
 
 def test_06_looking_for_disk1_was_created():
-    assert GET_ALL_OUTPUT('/disk')[1]['name'] == disk1
+    assert GET('/disk').json()[1]['name'] == disk1
 
 
 def test_07_looking_disk1_subsystem():
-    assert GET_ALL_OUTPUT('/disk')[1]['subsystem'] == disk1[:-1]
+    assert GET('/disk').json()[1]['subsystem'] == disk1[:-1]
 
 
 def test_08_looking_disk1_number():
-    assert GET_ALL_OUTPUT('/disk')[1]['number'] == 1
+    assert GET('/disk').json()[1]['number'] == 1
 
 
 def test_09_looking_disk1_identifier_and_serial_match():
-    identifier_serial = GET_ALL_OUTPUT('/disk')[1]['identifier'][8:]
-    serial = GET_ALL_OUTPUT('/disk')[1]['serial']
+    identifier_serial = GET('/disk').json()[1]['identifier'][8:]
+    serial = GET('/disk').json()[1]['serial']
     assert identifier_serial == serial
 
 
 def test_10_looking_for_disk2_was_created():
-    assert GET_ALL_OUTPUT('/disk')[2]['name'] == disk2
+    assert GET('/disk').json()[2]['name'] == disk2
 
 
 def test_11_looking_disk2_subsystem():
-    assert GET_ALL_OUTPUT('/disk')[2]['subsystem'] == disk2[:-1]
+    assert GET('/disk').json()[2]['subsystem'] == disk2[:-1]
 
 
 def test_12_looking_disk2_number():
-    assert GET_ALL_OUTPUT('/disk')[2]['number'] == 2
+    assert GET('/disk').json()[2]['number'] == 2
 
 
 def test_13_looking_disk2_identifier_and_serial_match():
-    identifier_serial = GET_ALL_OUTPUT('/disk')[2]['identifier'][8:]
-    serial = GET_ALL_OUTPUT('/disk')[2]['serial']
+    identifier_serial = GET('/disk').json()[2]['identifier'][8:]
+    serial = GET('/disk').json()[2]['serial']
     assert identifier_serial == serial

--- a/tests/api2/ftp.py
+++ b/tests/api2/ftp.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3.6
+
+# Author: Eric Turgeon
+# License: BSD
+# Location for tests into REST API 2.0 of FreeNAS
+
+import sys
+import os
+
+apifolder = os.getcwd()
+sys.path.append(apifolder)
+from functions import PUT, GET, POST  # , RC_TEST
+# from auto_config import ip
+
+
+def test_01_Configuring_ftp():
+    payload = {"clients": 10, "rootlogin": True}
+    results = PUT("/ftp", payload)
+    assert results.status_code == 200, results.text
+
+
+def test_02_Look_at_ftp_cofiguration():
+    results = GET("/ftp")
+    assert results.json()["clients"] == 10, results.text
+    assert results.json()["rootlogin"] == True, results.text
+
+
+def test_03_enable_ftp_service_at_boot():
+    payload = {"enable": True}
+    results = PUT('/service/id/6', payload)
+    assert results.status_code == 200, results.text
+
+
+def test_04_look_ftp_service_at_boot():
+    results = GET('/service')
+    assert results.json()[3]["enable"] == True
+
+
+def test_05_Starting_ftp_service():
+    payload = {"service": "ftp", "service-control": {"onetime": True}}
+    results = POST("/service/start", payload)
+    assert results.status_code == 200, results.text
+
+
+def test_06_Checking_to_see_if_FTP_service_is_enabled():
+    results = GET('/service')
+    assert results.json()[3]["state"] == "RUNNING"
+
+
+# def test_04_Fetching_file_via_FTP():
+#     cmd = "ftp -o /tmp/ftpfile ftp://testuser:test@" + ip + "/.cshrc"
+#     RC_TEST(cmd) is True

--- a/tests/api2/interfaces.py
+++ b/tests/api2/interfaces.py
@@ -3,29 +3,31 @@
 # Author: Eric Turgeon
 # License: BSD
 
-
+import pytest
 import sys
 import os
 
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from auto_config import interface, ip
-from functions import GET_ALL_OUTPUT
+from functions import GET
+from config import *
 
-RunTest = True
-TestName = "get interface information"
+BRIDGENETMASKReason = "BRIDGENETMASK not in ixautomation.conf"
 
 
 def test_01_get_interfaces_driver():
-    assert GET_ALL_OUTPUT('/interfaces/query')[0]['name'] == interface
+    assert GET('/interfaces/query').json()[0]['name'] == interface
 
 
 def test_02_get_interfaces_ip():
-    getip = GET_ALL_OUTPUT('/interfaces/query')[0]['aliases'][1]['address']
+    getip = GET('/interfaces/query').json()[0]['aliases'][1]['address']
     assert getip == ip
 
 
+@pytest.mark.skipif("BRIDGENETMASK" not in locals(),
+                    reason=BRIDGENETMASKReason)
 def test_03_get_interfaces_netmask():
-    getinfo = GET_ALL_OUTPUT('/interfaces/query')
+    getinfo = GET('/interfaces/query').json()
     getinfo = getinfo[0]['aliases'][1]['netmask']
-    assert getinfo == 23
+    assert str(getinfo) == BRIDGENETMASK

--- a/tests/api2/network.py
+++ b/tests/api2/network.py
@@ -10,26 +10,23 @@ import os
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from auto_config import interface, ip
-from functions import GET_ALL_OUTPUT
-try:
-    from config import BRIDGEGW
-except ImportError:
-    RunTest = False
-else:
-    RunTest = True
+from functions import GET
+from config import *
 
-TestName = "get network information"
-Reason = "BRIDGEGW ixautomation.conf"
+BRIDGEGWReason = "BRIDGEGW not in ixautomation.conf"
+BRIDGENETMASKReason = "BRIDGENETMASK not in ixautomation.conf"
 
 
+@pytest.mark.skipif("BRIDGENETMASK" not in locals(),
+                    reason=BRIDGENETMASKReason)
 def test_01_get_IPV4_info():
-    getinfo = GET_ALL_OUTPUT("/network/general/summary")
+    getinfo = GET("/network/general/summary").json()
     getinfo = getinfo['ips'][interface]['IPV4']
-    assert getinfo == ['%s/24' % ip]
+    assert getinfo == ['%s/%s' % (ip, BRIDGENETMASK)]
 
 
-@pytest.mark.skipif(RunTest is False, reason=Reason)
+@pytest.mark.skipif("BRIDGEGW" not in locals(), reason=BRIDGEGWReason)
 def test_02_get_default_routes_info():
-    getinfo = GET_ALL_OUTPUT("/network/general/summary")
+    getinfo = GET("/network/general/summary").json()
     getinfo = getinfo['default_routes'][0]
     assert getinfo == BRIDGEGW

--- a/tests/api2/network.py
+++ b/tests/api2/network.py
@@ -33,9 +33,3 @@ def test_02_get_default_routes_info():
     getinfo = GET_ALL_OUTPUT("/network/general/summary")
     getinfo = getinfo['default_routes'][0]
     assert getinfo == BRIDGEGW
-
-
-@pytest.mark.skipif(RunTest is False, reason=Reason)
-def test_03_get_nameserver_info():
-    getinfo = GET_ALL_OUTPUT("/network/general/summary")['nameservers'][0]
-    assert getinfo == BRIDGEGW

--- a/tests/api2/ssh.py
+++ b/tests/api2/ssh.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3.6
+
+# Author: Eric Turgeon
+# License: BSD
+
+import sys
+import os
+
+apifolder = os.getcwd()
+sys.path.append(apifolder)
+from functions import PUT, POST, GET, is_agent_setup, if_key_listed, SSH_TEST
+from auto_config import sshKey, password, user, ip
+
+
+def test_01_Configuring_ssh_settings_for_root_login():
+    payload = {"rootlogin": True}
+    results = PUT("/ssh", payload)
+    assert results.status_code == 200, results.text
+
+
+def test_02_Enabling_ssh_service_at_boot():
+    payload = {'enable': True}
+    results = PUT("/service/id/11", payload)
+    assert results.status_code == 200, results.text
+
+
+def test_03_Checking_ssh_enable_at_boot():
+    results = GET("/service")
+    assert results.json()[7]['enable'] == True
+
+
+def test_04_Start_ssh_service():
+    payload = {"service": "ssh", "service-control": {"onetime": True}}
+    results = POST("/service/start", payload)
+    assert results.status_code == 200, results.text
+
+
+def test_05_Checking_if_ssh_is_running():
+    results = GET("/service")
+    assert results.json()[7]['state'] == "RUNNING"
+
+
+def test_06_Ensure_ssh_agent_is_setup():
+    assert is_agent_setup() is True
+
+
+def test_07_Ensure_ssh_key_is_up():
+    assert if_key_listed() is True
+
+
+def test_08_Add_ssh_ky_to_root():
+    payload = {"sshpubkey": sshKey}
+    results = PUT("/user/id/1", payload)
+    assert results.status_code == 200, results.text
+
+
+def test_09_test_ssh_key():
+    cmd = 'ls -la'
+    results = SSH_TEST(cmd, user, password, ip)
+    assert results['result'] is True, results['output']

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -28,12 +28,6 @@ def GET_OUTPUT(testpath, inputs):
     return getit.json()[inputs]
 
 
-def GET_ALL_OUTPUT(testpath):
-    getit = requests.get(freenas_url + testpath, headers=header,
-                         auth=authentification)
-    return getit.json()
-
-
 def GET_USER(username):
     for uid in range(1, 1000):
         if GET_OUTPUT("/account/users/%s/" % uid,

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -98,17 +98,21 @@ def DELETE_ALL(testpath, payload):
 
 def SSH_TEST(command, username, passwrd, host):
     teststdout = "/tmp/.sshCmdTestStdOut"
-    cmd = "sshpass -p %s " % passwrd
+    if passwrd is None:
+        cmd = ""
+    else:
+        cmd = "sshpass -p %s " % passwrd
     cmd += "ssh -o StrictHostKeyChecking=no "
     cmd += "-o UserKnownHostsFile=/dev/null "
     cmd += "-o VerifyHostKeyDNS=no "
     cmd += "%s@%s '%s' " % (username, host, command)
     cmd += "> %s" % teststdout
     process = run(cmd, shell=True)
+    output = open(teststdout, 'r').read()
     if process.returncode != 0:
-        return False
+        return {'result': False, 'output': output}
     else:
-        return True
+        return {'result': True, 'output': output}
 
 
 def RC_TEST(command):

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -203,11 +203,17 @@ if api == "1.0":
               "api1/webdav_osx.py"])
 elif api == "2.0":
     call(["py.test-3.6", "-v", "--junitxml",
-          "%sinterfaces_test_tests_result.xml" % results_xml,
+          "%sinterfaces_tests_result.xml" % results_xml,
           "api2/interfaces.py"])
     call(["py.test-3.6", "-v", "--junitxml",
-          "%snetwork_user_tests_result.xml" % results_xml,
+          "%snetwork_tests_result.xml" % results_xml,
           "api2/network.py"])
     call(["py.test-3.6", "-v", "--junitxml",
-          "%sdisk_test_tests_result.xml" % results_xml,
+          "%sdisk_tests_result.xml" % results_xml,
           "api2/disk.py"])
+    call(["py.test-3.6", "-v", "--junitxml",
+          "%sftp_tests_result.xml" % results_xml,
+          "api2/ftp.py"])
+    call(["py.test-3.6", "-v", "--junitxml",
+          "%sssh_tests_result.xml" % results_xml,
+          "api2/ssh.py"])


### PR DESCRIPTION
adding ssh & ftp to api2 tests and adding SSH_TEST output to see errors for a remote test
replacing GET_ALL_OUTPUT by GET

