### PR TITLE
EFI uses "efi" for its video console, not "vidconsole".

### DIFF
--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -364,10 +364,17 @@ save_serial_settings() {
     USESERIAL=$((`sysctl -n debug.boothowto` & 0x1000))
     if [ "$USESERIAL" -eq 0 ] ; then return 0; fi
 
+    # BIOS has vidconsole, UEFI has efi.
+    if [ "$BOOTMODE" = "efi" ] ; then
+       videoconsole="efi"
+    else
+       videoconsole="vidconsole"
+    fi
+
     # Enable serial/internal for BSD loader
     echo 'boot_multicons="YES"' >> ${_mnt}/boot/loader.conf
     echo 'boot_serial="YES"' >> ${_mnt}/boot/loader.conf
-    echo 'console="comconsole,vidconsole"' >> ${_mnt}/boot/loader.conf
+    echo "console=\"comconsole,${videoconsole}\"" >> ${_mnt}/boot/loader.conf
 
     chroot ${_mnt} /usr/local/bin/sqlite3 /data/freenas-v1.db "update system_advanced set adv_serialconsole = 1"
     SERIALSPEED=`kenv hw.uart.console | sed -En 's/.*br:([0-9]+).*/\1/p'`

--- a/src/freenas/etc/ix.rc.d/ix-loader
+++ b/src/freenas/etc/ix.rc.d/ix-loader
@@ -48,16 +48,26 @@ update_persistent_file()
 loader_serial()
 {
 	local serial_enable=0
+	local bootmethod
+	local videoconsole
 
 	serial_enable=$(${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "SELECT adv_serialconsole FROM system_advanced ORDER BY -id LIMIT 1")
 
 	if [ "${serial_enable}" != "0" ]; then
 		serial_port=$(${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "SELECT adv_serialport FROM system_advanced ORDER BY -id LIMIT 1")
 		serial_speed=$(${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "SELECT adv_serialspeed FROM system_advanced ORDER BY -id LIMIT 1")
+
+		bootmethod=`sysctl -n machdep.bootmethod`
+		if [ "$bootmethod" = "UEFI" ] ; then
+			videoconsole='efi'
+		else
+			videoconsole='vidconsole'
+		fi
+
 		echo "comconsole_port=\"${serial_port}\""
 		echo "comconsole_speed=\"${serial_speed}\""
 		echo 'boot_multicons="YES"'
-		echo 'console="comconsole,vidconsole"'
+		echo "console=\"comconsole,${videoconsole}\""
 		# Above lines do not work in GRUB, so we have to duplicate.
 		echo "hw.uart.console=\"io:${serial_port},br:${serial_speed}\""
 	fi


### PR DESCRIPTION
When the migration to FreeBSD's loader took place the following construct was used to set up multiple consoles when using serial:

```
console="comconsole,vidconsole"
```

Unfortunately `vidconsole` is only present under BIOS/VESA not under UEFI which uses `efi` instead. This change conditionalises the use of `vidconsole` or `efi` on either the user-indicated boot method preference (in the installer) or on the method used to boot the system (in the ix-loader rc.d script).