### PR TITLE
(stable)replace failover_licensed call with licensed.py

### DIFF
--- a/src/freenas/etc/rc.conf.local
+++ b/src/freenas/etc/rc.conf.local
@@ -512,7 +512,7 @@ _gen_conf()
 {
 	local failover_status="" failover_licensed=0
 	if ! is_freenas; then
-		if [ "$(ulimit -n 1000; /usr/local/bin/python /usr/local/www/freenasUI/middleware/notifier.py failover_licensed 2> /dev/null)" = "True" ]; then
+		if [ "$(/usr/local/bin/python /usr/local/www/freenasUI/failover/licensed.py 2> /dev/null)" = "True" ]; then
 			failover_licensed=1
 		fi
 		failover_status="$(ulimit -n 1000; /usr/local/bin/python /usr/local/www/freenasUI/middleware/notifier.py failover_status 2> /dev/null)"

--- a/src/freenas/etc/rc.conf.local
+++ b/src/freenas/etc/rc.conf.local
@@ -512,7 +512,7 @@ _gen_conf()
 {
 	local failover_status="" failover_licensed=0
 	if ! is_freenas; then
-		if [ "$(/usr/local/bin/python /usr/local/www/freenasUI/failover/licensed.py 2> /dev/null)" = "True" ]; then
+		if [ "$(ulimit -n 1000; /usr/local/bin/python /usr/local/www/freenasUI/failover/licensed.py 2> /dev/null)" = "True" ]; then
 			failover_licensed=1
 		fi
 		failover_status="$(ulimit -n 1000; /usr/local/bin/python /usr/local/www/freenasUI/middleware/notifier.py failover_status 2> /dev/null)"


### PR DESCRIPTION
(licensed.py runs about 3 seconds quicker)

Redmine: https://redmine.ixsystems.com/issues/32763