### PR TITLE
Make the ddb capture buffer 4KB instead of 512B

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix_textdump
+++ b/src/freenas/etc/ix.rc.d/ix_textdump
@@ -29,7 +29,7 @@ ix_textdump_start()
 	ddb script "kdb.enter.default=write cn_mute 1; watchdog 38; capture on; bt; show allpcpu; ps; alltrace; write cn_mute 0; textdump dump; reset"
 	sysctl debug.ddb.textdump.pending=1
 	sysctl debug.debugger_on_panic=1
-	sysctl debug.ddb.capture.bufsize=524288
+	sysctl debug.ddb.capture.bufsize=4194304
 	mkdir -p "/data/crash"
 	chmod 775 "/data/crash"
 }


### PR DESCRIPTION
We have a lot more processes these days, especially on larger systems, so setting aside a bit more space for the ddb capture buffer seems prudent.