### PR TITLE
Cross refer this page to system-> advanced for standalone debug log.

### DIFF
--- a/gui/templates/support/home.html
+++ b/gui/templates/support/home.html
@@ -88,7 +88,8 @@
 
 {% if sw_name == "freenas" %}
 <p style="margin-left: 15px;">{% trans "Before filing a bug report or feature request, search" %} <a href="http://bugs.freenas.org" target="_blank">http://bugs.freenas.org</a> {% trans "to ensure the issue has not already been reported. If it has, add a comment to the existing issue instead of creating a new one." %}<br />
-{% trans "For enterprise-grade storage solutions and support, please visit" %} <a href="http://www.ixsystems.com/storage/" target="_blank">http://www.ixsystems.com/storage/</a>.</p>
+{% trans "For enterprise-grade storage solutions and support, please visit" %} <a href="http://www.ixsystems.com/storage/" target="_blank">http://www.ixsystems.com/storage/</a>.<br />
+{% trans "A stand-alone debug log can be created and saved at System -> Advanced, if sensitive information must be removed before submission." %}</p>
 {% endif %}
 
 <div data-dojo-type="freeadmin/SupportTicket" data-dojo-props="softwareName: '{{ sw_name }}'{% if error_message %}, errorMessage: '{{ error_message|escapejs }}'{% endif %}{% if initial %}, initial: '{{ initial|escapejs }}'{% endif %}, categoriesUrl: '{% url "support_ticket_categories" %}', progressUrl: '{% url "support_ticket_progress" %}'"></div>


### PR DESCRIPTION
Because if someone visits this page to get support, but also wants to check the debug log for sensitive information, it's not obvious there is a separate page that allows it.