### PR TITLE
 do not grant extra privileges to users

### DIFF
--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -1708,7 +1708,9 @@ def main():
                 smb4_tdb,
                 privatedir + "/passdb.tdb"
             )
-            smb4_grant_rights()
+            if role != 'member':
+                smb4_grant_rights()
+
             client.call('notifier.samba4', 'user_import_sentinel_file_create')
 
         smb4_map_groups(client)


### PR DESCRIPTION
Ticket #28406
These are inappropriate from a security perspective in an AD / LDAP environment, and they can negatively impact boot times.