### PR TITLE
stay connected if we can contact any LDAP server

### DIFF
--- a/src/middlewared/middlewared/plugins/service_monitor.py
+++ b/src/middlewared/middlewared/plugins/service_monitor.py
@@ -87,7 +87,7 @@ class ServiceMonitorThread(threading.Thread):
         return enabled
 
     @private
-    def tryConnect(self, host, port, freenasldap_class):
+    def tryConnect(self, host, port, fnldap):
         max_tries = 3
         connected = False
 
@@ -97,7 +97,7 @@ class ServiceMonitorThread(threading.Thread):
             for i in range(0, max_tries):
                 try:  
                     # Use SRV records to identify LDAP servers in domain. 
-                    host_list = freenasldap_class.get_ldap_servers(host) 
+                    host_list = fnldap.get_ldap_servers(host) 
                     break 
 
                 except Exception:
@@ -147,11 +147,11 @@ class ServiceMonitorThread(threading.Thread):
         service = self.name
 
         if service == 'activedirectory':
-            freenasldap_class = FreeNAS_ActiveDirectory(flags=FLAGS_DBINIT)
+            fnldap = FreeNAS_ActiveDirectory(flags=FLAGS_DBINIT)
         elif service == 'ldap':
-            freenasldap_class = FreeNAS_LDAP(flags=FLABS_DBINIT)
+            fnldap = FreeNAS_LDAP(flags=FLABS_DBINIT)
         else:
-            freenasldap_class = None      
+            fnldap = None      
 
         while True:
             self.finished.wait(self.frequency)
@@ -159,7 +159,7 @@ class ServiceMonitorThread(threading.Thread):
             # We should probably have a configurable threshold for number of
             # failures before starting or stopping the service
             #
-            connected = self.tryConnect(self.host, self.port, freenasldap_class)
+            connected = self.tryConnect(self.host, self.port, fnldap)
             started = self.getStarted(service)
             enabled = self.isEnabled(service)
 

--- a/src/middlewared/middlewared/plugins/service_monitor.py
+++ b/src/middlewared/middlewared/plugins/service_monitor.py
@@ -94,7 +94,7 @@ class ServiceMonitorThread(threading.Thread):
             if service == 'activedirectory':
                 service = 'ad'
             ssl_enabled = ds["%s_ssl" % service]
- 
+
             # Make three attempts to get SRV records from DNS
             for i in range(0, max_tries):
                 try:
@@ -111,7 +111,7 @@ class ServiceMonitorThread(threading.Thread):
                 except:
                     self.logger.debug("[ServiceMonitorThread] DNS query for LDAP SRV records for %s failed" % (host))
                     if i == max_tries:
-                        return False 
+                        return False
 
         else:
             # Future services that need monitoring (???) will need an explicit configuration
@@ -127,7 +127,7 @@ class ServiceMonitorThread(threading.Thread):
                 s.connect((str(h.target), h.port))
                 connected = True
                 self.logger.debug("[ServiceMonitorThread] Connected: %s:%d" % (str(h.target), h.port))
-                return connected 
+                return connected
 
             except Exception as e:
                 self.logger.debug("[ServiceMonitorThread] Cannot connect: %s:%d with error: %s" % (str(h.target), h.port, e))


### PR DESCRIPTION
Ticket #33453
There have been numerous situations where users have had AD taken down by our monitoring. Tests returned connected=false started=true enabled=true.

In AD environment started=true (wbinfo -t success) implies we have a good connection. This strongly indicates our test is bad. Revised test to use DNS to enumerate LDAP servers in DOMAIN, then query them sequentially. If one responds, then return connected=true.