### PR TITLE
stay connected if we can contact any LDAP server

### DIFF
--- a/src/middlewared/middlewared/plugins/service_monitor.py
+++ b/src/middlewared/middlewared/plugins/service_monitor.py
@@ -24,6 +24,7 @@ from freenasUI.common.freenasldap import (
     FLAGS_DBINIT
 )
 
+
 class ServiceMonitorThread(threading.Thread):
     def __init__(self, **kwargs):
         super(ServiceMonitorThread, self).__init__()
@@ -96,7 +97,7 @@ class ServiceMonitorThread(threading.Thread):
             for i in range(0, max_tries):
                 try:
                     # Use SRV records to identify LDAP servers in domain.
-                    host_list = fnldap.get_ldap_servers(host) 
+                    host_list = fnldap.get_ldap_servers(host)
                     break
 
                 except Exception:

--- a/src/middlewared/middlewared/plugins/service_monitor.py
+++ b/src/middlewared/middlewared/plugins/service_monitor.py
@@ -18,7 +18,11 @@ if not apps.ready:
     django.setup()
 
 from freenasUI.common.freenassysctl import freenas_sysctl as _fs
-
+from freenasUI.common.freenasldap import (
+    FreeNAS_ActiveDirectory,
+    FreeNAS_LDAP,
+    FLAGS_DBINIT
+)
 
 class ServiceMonitorThread(threading.Thread):
     def __init__(self, **kwargs):
@@ -82,31 +86,47 @@ class ServiceMonitorThread(threading.Thread):
         return enabled
 
     @private
-    def tryConnect(self, host, port):
+    def tryConnect(self, host, port, fnldap):
         max_tries = 3
         connected = False
 
+        host_list = []
+        if self.name == 'activedirectory':
+            # Make three attempts to get SRV records from DNS
+            for i in range(0, max_tries):
+                try:
+                    # Use SRV records to identify LDAP servers in domain.
+                    host_list = fnldap.get_ldap_servers(host) 
+                    break
+
+                except Exception:
+                    self.logger.debug("[ServiceMonitorThread] Query for SRV records for %s failed" % (host))
+                    if i == max_tries:
+                        return False
+
+        else:
+            # Future services that need monitoring (???) will need an explicit configuration
+            self.logger.debug("[ServiceMonitorThread] no monitoring has been written for %s " % self.name)
+            return False
+
         timeout = _fs().middlewared.plugins.service_monitor.socket_timeout
 
-        for i in range(0, max_tries):
-            # XXX What about UDP?
+        for h in host_list:
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             s.settimeout(timeout)
-
             try:
-                s.connect((host, port))
+                s.connect((str(h.target), h.port))
                 connected = True
+                self.logger.debug("[ServiceMonitorThread] Connected: %s:%d" % (str(h.target), h.port))
+                return connected
 
             except Exception as e:
-                self.logger.debug("[ServiceMonitorThread] Cannot connect: %s:%d with error: %s" % (host, port, e))
+                self.logger.debug("[ServiceMonitorThread] Cannot connect: %s:%d with error: %s" % (str(h.target), h.port, e))
                 connected = False
 
             finally:
                 s.settimeout(None)
                 s.close()
-
-            if connected:
-                break
 
         return connected
 
@@ -125,13 +145,20 @@ class ServiceMonitorThread(threading.Thread):
         ntries = 0
         service = self.name
 
+        if service == 'activedirectory':
+            fnldap = FreeNAS_ActiveDirectory(flags=FLAGS_DBINIT)
+        elif service == 'ldap':
+            fnldap = FreeNAS_LDAP(flags=FLAGS_DBINIT)
+        else:
+            fnldap = None
+
         while True:
             self.finished.wait(self.frequency)
             #
             # We should probably have a configurable threshold for number of
             # failures before starting or stopping the service
             #
-            connected = self.tryConnect(self.host, self.port)
+            connected = self.tryConnect(self.host, self.port, fnldap)
             started = self.getStarted(service)
             enabled = self.isEnabled(service)
 


### PR DESCRIPTION
Ticket #33453
There have been numerous situations where users have had AD taken down by our monitoring. Tests returned connected=false started=true enabled=true.

In AD environment started=true (wbinfo -t success) implies we have a good connection. This strongly indicates our test is bad. Revised test to use DNS to enumerate LDAP servers in DOMAIN, then query them sequentially. If one responds, then return connected=true.