### PR TITLE
catia needs to come before zfsacl

### DIFF
--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -263,7 +263,7 @@ def config_share_for_zfs(share):
 # for fruit, and if catia and fruit are used, catia comes before fruit
 #
 def order_vfs_objects(vfs_objects):
-    vfs_objects_special = ('catia', 'fruit', 'streams_xattr', 'recycle', 'aio_pthread')
+    vfs_objects_special = ('catia', 'zfs_space', 'zfsacl', 'fruit', 'streams_xattr', 'recycle', 'aio_pthread')
     vfs_objects_ordered = []
 
     if 'fruit' in vfs_objects:


### PR DESCRIPTION
Ticket #34146
Observed on customer system. Directories had ":" in them. Catia mapping of 0x3a:0xf022 did not allow access to directory because the ACL checks were happening prior to the catia mapping taking effect. This meant that Samba tried to get the ACL for a non-existent file "foo⋰bar" rather than "foo:bar".