### PR TITLE
Fixed broken URL for vcp - moved location in version FN >=11.2.

### DIFF
--- a/gui/vcp/forms.py
+++ b/gui/vcp/forms.py
@@ -312,7 +312,7 @@ class VcenterConfigurationForm(ModelForm):
 
     def get_vcp_url(self, manage_ip, sys_guiprotocol):
         sys_guiport = self.get_sys_port()
-        file_address = 'static/' + utils.get_plugin_file_name()
+        file_address = 'legacy/static/' + utils.get_plugin_file_name()
         vcp_url = sys_guiprotocol + '://' + manage_ip + \
             ':' + sys_guiport + '/' + file_address
         return vcp_url


### PR DESCRIPTION
Fixed broken URL for vcp - moved location in version FN >=11.2.
Note: not sure, if we should keep it in legacy location or better already supply the vcp over new API.