### PR TITLE
Fix builds

### DIFF
--- a/jenkins/Jenkinsfile-PR
+++ b/jenkins/Jenkinsfile-PR
@@ -10,7 +10,7 @@ pipeline {
 
    stage('Queued') {
         agent {
-        label 'JenkinsMaster'
+        label 'FreeNAS-PR-HOLD'
       }
       steps {
         echo "Build queued"

--- a/jenkins/Jenkinsfile-PR
+++ b/jenkins/Jenkinsfile-PR
@@ -25,10 +25,7 @@ pipeline {
         checkout scm
         echo '*** Checking out build repo ***'
         sh '(mount | grep "on /freenas-pr" | awk \'{print $3}\' | sort -r | xargs umount -f ) || true'
-	sh 'zfs destroy -r tank1/usr/obj 2>/dev/null || true'
 	sh 'zfs destroy tank1/freenas-pr 2>/dev/null || true'
-	sh 'zfs create -o mountpoint=/usr/obj tank1/usr/obj'
-	sh 'zfs create -o mountpoint=/usr/obj/freenas-pr tank1/usr/obj/freenas-pr'
 	sh 'zfs create -o mountpoint=/freenas-pr tank1/freenas-pr'
         sh 'git clone --depth=1 -b ${GH_BUILD_BRANCH} https://github.com/freenas/build.git /freenas-pr'
       }
@@ -113,7 +110,7 @@ pipeline {
   }
   post {
     always {
-      sh 'zfs destroy -r tank1/usr/obj || true'
+      sh 'rm -rf /usr/obj/freenas-pr'
       sh '(mount | grep "on /freenas-pr" | awk \'{print $3}\' | sort -r | xargs umount -f ) || true'
       sh 'zfs destroy tank1/freenas-pr || true'
       script {

--- a/jenkins/Jenkinsfile-PR
+++ b/jenkins/Jenkinsfile-PR
@@ -10,7 +10,7 @@ pipeline {
 
    stage('Queued') {
         agent {
-        label 'FreeNAS-PR-HOLD'
+        label 'JenkinsMaster'
       }
       steps {
         echo "Build queued"


### PR DESCRIPTION
After my initial attempt to make more use of ZFS I broke the repo-manifest while put zfs in place for /usr/obj/freenas-pr, but freenas build do some magics in Makefile.inc which leads to a corrupted repo-manifest. This patch fix that. Please take notes, after the patch is merged we have to sync all outstanding pull requests to make them pass the build test.