### PR TITLE
get samba_server status when checking if AD started

### DIFF
--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -885,6 +885,12 @@ class ServiceService(CRUDService):
         await self._service("samba_server", "stop", force=True, **kwargs)
         await self._service("ix-post-samba", "start", quiet=True, **kwargs)
 
+    async def _started_cifs(self, **kwargs):
+        if await self._system('/usr/sbin/service samba_server status') !=0:
+            return False, []
+        else:
+            return True, []
+
     async def _start_snmp(self, **kwargs):
         await self._service("ix-snmpd", "start", quiet=True, **kwargs)
         await self._service("snmpd", "start", quiet=True, **kwargs)

--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -886,7 +886,7 @@ class ServiceService(CRUDService):
         await self._service("ix-post-samba", "start", quiet=True, **kwargs)
 
     async def _started_cifs(self, **kwargs):
-        if await self._system('/usr/sbin/service samba_server status') !=0:
+        if await self._service("samba_server", "status", quiet=True, **kwargs):
             return False, []
         else:
             return True, []

--- a/src/middlewared/middlewared/plugins/service_monitor.py
+++ b/src/middlewared/middlewared/plugins/service_monitor.py
@@ -118,6 +118,7 @@ class ServiceMonitorThread(threading.Thread):
             if service == 'activedirectory':
                 if not self.middleware.call_sync('service.started', 'cifs'):
                     self.logger.debug("[ServiceMonitorThread] restarting Samba service")
+                    self.middleware.call_sync('service.start', 'cifs')
             if self.middleware.call_sync('service.started', service):
                 return True
             time.sleep(1)

--- a/src/middlewared/middlewared/plugins/service_monitor.py
+++ b/src/middlewared/middlewared/plugins/service_monitor.py
@@ -115,6 +115,9 @@ class ServiceMonitorThread(threading.Thread):
         max_tries = 3
 
         for i in range(0, max_tries):
+            if service == 'activedirectory':
+                if not self.middleware.call_sync('service.started', 'cifs'):
+                    self.logger.debug("[ServiceMonitorThread] restarting Samba service")
             if self.middleware.call_sync('service.started', service):
                 return True
             time.sleep(1)


### PR DESCRIPTION
Ticket #34411
Add check to see if samba is running, if not start it. This gets us two things:
1) If for some reason master smbd process dies, we can restart it and restore services (this isn't caught by current monitoring code).
2) A quicker fix for winbindd being down (a full AD restart can take several minutes to complete).