### PR TITLE
Bug fix

### DIFF
--- a/src/middlewared/middlewared/plugins/crypto.py
+++ b/src/middlewared/middlewared/plugins/crypto.py
@@ -305,7 +305,7 @@ class CertificateService(CRUDService):
         if cert['type'] == CERT_TYPE_CSR:
             obj = csr_obj
         elif cert_obj:
-            obj = cert_obj
+            obj = crypto.load_certificate(crypto.FILETYPE_PEM, cert['certificate'])
             notBefore = obj.get_notBefore()
             t1 = dateutil.parser.parse(notBefore)
             t2 = t1.astimezone(dateutil.tz.tzutc())


### PR DESCRIPTION
Ticket: #34675

This PR aims to keep the same behavior of properties in certs as it was in GUi. Right now, Middlewared was displaying values of 3 properties differently. If a chain was present,  it was showing the values of the 3 properties as they were for the last cert in the chain. However in GUI, it displayed for the first and in my opinion it should be similar. Reason being, the first cert is the one in light, rest are it's parents or signedby entities with the last one being the root in the chain