### PR TITLE
Fix unneeded stops and restarts in AD monitoring

### DIFF
--- a/gui/common/freenasldap.py
+++ b/gui/common/freenasldap.py
@@ -1148,8 +1148,9 @@ class FreeNAS_ActiveDirectory_Base(object):
         )
 
         r = resolver.Resolver()
+        r.rotate = True
+        r.timeout = _fs().directoryservice.activedirectory.dns.timeout
         r.lifetime = _fs().directoryservice.activedirectory.dns.lifetime
-        r.timeout = r.lifetime / 3
 
         try:
 

--- a/gui/common/freenasldap.py
+++ b/gui/common/freenasldap.py
@@ -1304,10 +1304,13 @@ class FreeNAS_ActiveDirectory_Base(object):
             )
 
     @staticmethod
-    def port_is_listening(host, port, errors=[]):
+    def port_is_listening(host, port, errors=[], timeout=0):
         ret = False
 
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        if timeout:
+            s.settimeout(timeout)
+
         try:
             s.connect((host, port))
             ret = True

--- a/gui/common/freenasldap.py
+++ b/gui/common/freenasldap.py
@@ -1148,8 +1148,8 @@ class FreeNAS_ActiveDirectory_Base(object):
         )
 
         r = resolver.Resolver()
-        r.timeout = _fs().directoryservice.activedirectory.dns.timeout
         r.lifetime = _fs().directoryservice.activedirectory.dns.lifetime
+        r.timeout = r.lifetime / 3 
 
         try:
 

--- a/gui/common/freenasldap.py
+++ b/gui/common/freenasldap.py
@@ -1149,7 +1149,7 @@ class FreeNAS_ActiveDirectory_Base(object):
 
         r = resolver.Resolver()
         r.lifetime = _fs().directoryservice.activedirectory.dns.lifetime
-        r.timeout = r.lifetime / 3 
+        r.timeout = r.lifetime / 3
 
         try:
 

--- a/src/middlewared/middlewared/plugins/service_monitor.py
+++ b/src/middlewared/middlewared/plugins/service_monitor.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import socket
 import sys
 import threading
 import time
@@ -17,7 +16,11 @@ from django.apps import apps
 if not apps.ready:
     django.setup()
 
-from freenasUI.common.freenassysctl import freenas_sysctl as _fs
+from freenasUI.common.freenasldap import (
+    FreeNAS_ActiveDirectory,
+    FreeNAS_LDAP,
+    FLAGS_DBINIT
+)
 
 
 class ServiceMonitorThread(threading.Thread):
@@ -82,31 +85,36 @@ class ServiceMonitorThread(threading.Thread):
         return enabled
 
     @private
-    def tryConnect(self, host, port):
+    def tryConnect(self, host, port, fnldap):
         max_tries = 3
         connected = False
 
-        timeout = _fs().middlewared.plugins.service_monitor.socket_timeout
+        if self.name == 'activedirectory':
+            host_list = []
 
-        for i in range(0, max_tries):
-            # XXX What about UDP?
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.settimeout(timeout)
+            for i in range(0, max_tries):
+                # Make three attempts to get SRV records from DNS
+                host_list = fnldap.get_ldap_servers(host)
+                if host_list:
+                    break
+                else:
+                    self.logger.debug("[ServiceMonitorThread] Attempt %d to query SRV records failed " % (i))
 
-            try:
-                s.connect((host, port))
-                connected = True
+            if not host_list:
+                self.logger.debug("[ServiceMonitorThread] Query for SRV records for %s failed" % (host))
+                return False
 
-            except Exception as e:
-                self.logger.debug("[ServiceMonitorThread] Cannot connect: %s:%d with error: %s" % (host, port, e))
+        else:
+            self.logger.debug("[ServiceMonitorThread] no monitoring has been written for %s " % self.name)
+            return False
+
+        for h in host_list:
+            port_is_listening = fnldap.port_is_listening(str(h.target), h.port, errors=[])
+            if port_is_listening:
+                return True
+            else:
+                self.logger.debug("[ServiceMonitorThread] Cannot connect: %s:%d " % (str(h.target), h.port))
                 connected = False
-
-            finally:
-                s.settimeout(None)
-                s.close()
-
-            if connected:
-                break
 
         return connected
 
@@ -125,15 +133,28 @@ class ServiceMonitorThread(threading.Thread):
         ntries = 0
         service = self.name
 
+        if service == 'activedirectory':
+            fnldap = FreeNAS_ActiveDirectory(flags=FLAGS_DBINIT)
+        elif service == 'ldap':
+            fnldap = FreeNAS_LDAP(flags=FLAGS_DBINIT)
+        else:
+            fnldap = None
+
         while True:
             self.finished.wait(self.frequency)
             #
             # We should probably have a configurable threshold for number of
             # failures before starting or stopping the service
             #
-            connected = self.tryConnect(self.host, self.port)
+            connected = self.tryConnect(self.host, self.port, fnldap)
             started = self.getStarted(service)
             enabled = self.isEnabled(service)
+
+            # Try less disruptive recovery attempt first before restarting AD service
+            if not started and service == 'activedirectory':
+                self.logger.debug("[ServiceMonitorThread] reloading Active Directory")
+                self.middleware.call_sync('service.reload', 'activedirectory')
+                started = self.getStarted(service)
 
             self.logger.trace("[ServiceMonitorThread] connected=%s started=%s enabled=%s", connected, started, enabled)
             # Everything is OK

--- a/src/middlewared/middlewared/plugins/service_monitor.py
+++ b/src/middlewared/middlewared/plugins/service_monitor.py
@@ -17,10 +17,7 @@ if not apps.ready:
     django.setup()
 
 from freenasUI.common.freenassysctl import freenas_sysctl as _fs
-from freenasUI.common.freenasldap import (
-    FreeNAS_ActiveDirectory,
-    FLAGS_DBINIT
-)
+from freenasUI.common.freenasldap import FreeNAS_ActiveDirectory
 
 
 class ServiceMonitorThread(threading.Thread):

--- a/src/middlewared/middlewared/plugins/service_monitor.py
+++ b/src/middlewared/middlewared/plugins/service_monitor.py
@@ -93,7 +93,7 @@ class ServiceMonitorThread(threading.Thread):
             host_list = []
 
             for i in range(0, max_tries):
-                # Make three attempts to get SRV records from DNS
+                # Make max_tries attempts to get SRV records from DNS
                 host_list = fnldap.get_ldap_servers(host)
                 if host_list:
                     break

--- a/src/middlewared/middlewared/plugins/service_monitor.py
+++ b/src/middlewared/middlewared/plugins/service_monitor.py
@@ -84,7 +84,7 @@ class ServiceMonitorThread(threading.Thread):
         return enabled
 
     @private
-    def tryConnect(self, host, port, fnldap):
+    def tryConnect(self, host, port):
         max_tries = 3
         connected = False
         host_list = []


### PR DESCRIPTION
Ticket #33453

There are a several distinct situations where our AD monitoring will either turn off the Active Directory service or restart the Active Directory service when it is not required.
The improvements are as follows:
1) Use SRV records to enumerate the LDAP servers in the environment and then check to see if the LDAP port is listening on any of them. If we pass this check, then we do not turn off AD service.
Simplify checks to see if the AD service is properly running, by reducing it to a single test "wbinfo -t". This reduces the liklihood of a false-positive that we are no longer joined to the domain.
2) Add a low-impact recovery attempt if we fail the getStarted() check. Winbind in its current form establishes a connection to only a single DC. It has been observed in testing that if this DC goes down, then we will fail the getStarted() check. Restarting winbind was sufficient in these situations to put the domain join back into a healthy state. Try this first before performing a more disruptive recovery attempt.
3) The default AD DNS timeout and lifetime values make it so that if Nameserver 1 in the FreeNAS configuration is down, then get_SRV_records() in freenasldap.py will always fail (we never try to get SRV records from Nameserver 2). If we reduce the timeout to 1/3 of the overall lifetime, then we will query other nameservers and AD will stay up.
