### PR TITLE
feat(plugins/jail, plugins/cache): Return plugin versions, cache timeout

### DIFF
--- a/src/middlewared/middlewared/plugins/cache.py
+++ b/src/middlewared/middlewared/plugins/cache.py
@@ -1,5 +1,7 @@
-from middlewared.schema import Any, Str, accepts
-from middlewared.service import Service
+from middlewared.schema import Any, Str, accepts, Int
+from middlewared.service import Service, private
+from collections import namedtuple
+import time
 
 
 class CacheService(Service):
@@ -10,6 +12,7 @@ class CacheService(Service):
     def __init__(self, *args, **kwargs):
         super(CacheService, self).__init__(*args, **kwargs)
         self.__cache = {}
+        self.kv_tuple = namedtuple('Cache', ['value', 'timeout'])
 
     @accepts(Str('key'))
     def has_key(self, key):
@@ -26,18 +29,46 @@ class CacheService(Service):
         Raises:
             KeyError: not found in the cache
         """
-        return self.__cache[key]
 
-    @accepts(Str('key'), Any('value'))
-    def put(self, key, value):
+        if self.__cache[key].timeout > 0:
+            self.get_timeout(key)
+
+        return self.__cache[key].value
+
+    @accepts(Str('key'), Any('value'), Int('timeout', default=0))
+    def put(self, key, value, timeout):
         """
         Put `key` of `value` in the cache.
         """
-        self.__cache[key] = value
+
+        if timeout != 0:
+            timeout = time.monotonic() + timeout
+
+        v = self.kv_tuple(value=value, timeout=timeout)
+        self.__cache[key] = v
 
     @accepts(Str('key'))
     def pop(self, key):
         """
         Removes and returns `key` from cache.
         """
-        return self.__cache.pop(key, None)
+        cache = self.__cache.pop(key, None)
+
+        if cache is not None:
+            cache = cache.value
+
+        return cache
+
+    @private
+    def get_timeout(self, key):
+        """
+        Check if 'key' has expired
+        """
+        now = time.monotonic()
+        value, timeout = self.__cache[key]
+
+        if now >= timeout:
+            # Bust the cache
+            del self.__cache[key]
+
+            raise KeyError(f'{key} has expired')

--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -4,6 +4,7 @@ import subprocess as su
 
 import iocage.lib.iocage as ioc
 import libzfs
+import requests
 from iocage.lib.ioc_check import IOCCheck
 from iocage.lib.ioc_clean import IOCClean
 from iocage.lib.ioc_fetch import IOCFetch
@@ -16,6 +17,7 @@ from middlewared.schema import Bool, Dict, Int, List, Str, accepts
 from middlewared.service import CRUDService, job, private
 from middlewared.service_exception import CallError
 from middlewared.utils import filter_list
+from middlewared.client import ClientException
 
 
 class JailService(CRUDService):
@@ -48,7 +50,6 @@ class JailService(CRUDService):
             if jail_identifier == 'default':
                 jail_dicts['host_hostuuid'] = 'default'
                 jails.append(jail_dicts)
-
             else:
                 for jail in jail_dicts:
                     jail = list(jail.values())[0]
@@ -480,3 +481,68 @@ class JailService(CRUDService):
         IOCImage().import_jail(jail)
 
         return True
+
+    @accepts()
+    def get_plugin_versions(self):
+        """
+        Fetches a list of pkg's from the http://pkg.cdn.trueos.org/iocage/
+        repo and returns a dictionary for each plugin
+        """
+        try:
+            pkgs = self.middleware.call_sync('cache.get', 'iocage_plugin_pkgs')
+
+            return pkgs
+        except ClientException as e:
+            # The jail plugin runs in another process, it's seen as a client
+            if e.trace and e.trace['class'] == 'KeyError':
+                pass  # It's either new or past cache date
+            else:
+                raise(e)
+
+        r_pkgs = requests.get('http://pkg.cdn.trueos.org/iocage/All')
+        r_pkgs.raise_for_status()
+
+        r_plugins = requests.get(
+            'https://raw.githubusercontent.com/freenas/'
+            'iocage-ix-plugins/master/INDEX'
+        )
+        r_plugins.raise_for_status()
+        r_plugins = r_plugins.json()
+
+        pkgs = {
+            'bruserver': ('N/A', '1'),
+            'sickrage': ('Git branch - master', '1')
+        }
+        pkg_dict = {}
+
+        for i in r_pkgs.iter_lines():
+            i = i.decode().split('"')
+
+            try:
+                pkg, version = i[1].rsplit('-', 1)
+                pkg_dict[pkg] = version
+            except (ValueError, IndexError):
+                continue  # It's not a pkg
+
+        for plugin, p_dict in r_plugins.items():
+            try:
+                primary_pkg = p_dict['primary_pkg'].split('/', 1)[-1]
+            except KeyError:
+                continue  # Plugin doesn't have a pkg, like bruserver
+
+            if primary_pkg in pkg_dict:
+                version = pkg_dict[primary_pkg]
+                pkgs[plugin] = (
+                    version.rsplit('%2', 1)[0].replace('.txz', ''),
+                    '1'
+                )
+            else:
+                if plugin not in pkgs:
+                    pkgs[plugin] = ('N/A', 'N/A')
+
+        self.middleware.call_sync(
+            'cache.put', 'iocage_plugin_pkgs', pkgs,
+            1209600
+        )
+
+        return pkgs


### PR DESCRIPTION
Will return a dictionary with a tuple containing the pkg version and the plugin revision (hardcoded at 1 for now until we implement it)

- jail plugin now returns the plugin versions
- the cache plugin now has an optional timeout integer that takes seconds

EXAMPLE:
```
{"bruserver": ["N/A", "1"], "sickrage": ["Git branch - master", "1"], "btsync": ["2.5.12_1", "1"], "backuppc": ["4.2.1", "1"], "clamav": ["0.100.0_1", "1"], "couchpotato": ["0.0.20170327_2", "1"], "emby": ["3.3.1.0_1", "1"], "gitlab": ["10.7.5_1", "1"], "jenkins": ["2.126", "1"], "jenkins-lts": ["2.107.3", "1"], "nextcloud": ["13.0.2", "1"], "plexmediaserver": ["N/A", "N/A"], "plexmediaserver-plexpass": ["1.13.2.5102", "1"], "quasselcore": ["0.12.5", "1"], "subsonic": ["6.0_6", "1"], "madsonic": ["6.0_6", "1"], "syncthing": ["0.14.47", "1"], "deluge": ["1.3.15_3", "1"], "sonarr": ["2.0.0.5163", "1"], "transmission": ["2.93_1", "1"], "tarsnap": ["1.0.39", "1"], "tt-rss": ["g20171120", "1"], "bacula-server": ["7.4.7_2", "1"], "xmrig": ["2.6.2", "1"]}
```
Ticket: #33114