### PR TITLE
Explicitly make serial console preferred when it is enabled.

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-loader
+++ b/src/freenas/etc/ix.rc.d/ix-loader
@@ -67,9 +67,8 @@ loader_serial()
 		echo "comconsole_port=\"${serial_port}\""
 		echo "comconsole_speed=\"${serial_speed}\""
 		echo 'boot_multicons="YES"'
+		echo 'boot_serial="YES"'
 		echo "console=\"comconsole,${videoconsole}\""
-		# Above lines do not work in GRUB, so we have to duplicate.
-		echo "hw.uart.console=\"io:${serial_port},br:${serial_speed}\""
 	fi
 }
 


### PR DESCRIPTION
Without this at least with UEFI loader it could be random to which
console init scripts will print their messages.

While there, remove variable setting needed only for GRUB.