### PR TITLE
Check GRUB presence via kenv instead of fstab.

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-bsdloader
+++ b/src/freenas/etc/ix.rc.d/ix-bsdloader
@@ -10,7 +10,7 @@
 
 migrate_bsd_loader()
 {
-	grep -q "grub" /conf/base/etc/fstab
+	kenv -q grub.platform >/dev/null
 	if [ $? -ne 0 ] ; then
 		# Nothing to do
 		return 0


### PR DESCRIPTION
It seems after #32412 we install empty fstab on update, overwriting
one with GRUB line in it, as result of what the GRUB removal script
doesn't activate.

Ticket:	#35653