### PR TITLE
Pool name changed for Jails Tests

### DIFF
--- a/tests/api2/jails.py
+++ b/tests/api2/jails.py
@@ -12,8 +12,7 @@ from functions import DELETE, GET, POST, PUT, PUT_TIMEOUT
 from config import *
 
 
-IOCAGE_POOL = 'jails'
-IOCAGE_POOL = 'vol1'
+IOCAGE_POOL = 'tank'
 JOB_ID = None
 RELEASE = None
 JAIL_NAME = 'jail1'


### PR DESCRIPTION
Pool name in ixautomation environment is different from the one set in jails tests previously. This commit changes that.
Ticket: #34870