### PR TITLE
Resolve hostname validator fix

### DIFF
--- a/src/middlewared/middlewared/async_validators.py
+++ b/src/middlewared/middlewared/async_validators.py
@@ -20,10 +20,9 @@ async def resolve_hostname(middleware, verrors, name, hostname):
             try:
                 ip = IpAddress()
                 ip(hostname)
+                return hostname
             except ShouldBe:
                 return socket.gethostbyname(hostname)
-            else:
-                return socket.gethostbyaddr(hostname)
         except Exception:
             return False
 


### PR DESCRIPTION
In some cases when the PTR record wasn't available for an ip, the validator raised an issue. This commit removes resolving ips from resolve hostname validator
Ticket: #36008