### PR TITLE
WebDAV shares namespace change

### DIFF
--- a/gui/sharing/forms.py
+++ b/gui/sharing/forms.py
@@ -245,7 +245,7 @@ class WebDAV_ShareForm(MiddlewareModelForm, ModelForm):
 
     middleware_attr_schema = 'webdav_share'
     middleware_attr_prefix = 'webdav_'
-    middleware_plugin = 'webdav.share'
+    middleware_plugin = 'sharing.webdav'
     is_singletone = False
 
     class Meta:

--- a/src/middlewared/middlewared/plugins/webdav.py
+++ b/src/middlewared/middlewared/plugins/webdav.py
@@ -8,7 +8,7 @@ class WebDAVSharingService(CRUDService):
     class Config:
         datastore = 'sharing.webdav_share'
         datastore_prefix = 'webdav_'
-        namespace = 'webdav.share'
+        namespace = 'sharing.webdav'
 
     @private
     async def validate_data(self, data, schema):


### PR DESCRIPTION
Name space of webdav shares has been chagned to sharing.webdav from webdav.share in this commit
Ticket: #35741