### PR TITLE
fix(sharing/iscsi): Don't check peer_secret if peer_user isn't supplied

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi.py
+++ b/src/middlewared/middlewared/plugins/iscsi.py
@@ -337,28 +337,30 @@ class iSCSITargetAuthCredentialService(CRUDService):
         peer_secret = data.get('peersecret') or ''
         peer_user = data.get('peeruser', '')
 
-        if peer_user:
-            if not peer_secret:
-                verrors.add(
-                    f'{schema_name}.peersecret',
-                    'The peer secret is required if you set a peer user.')
-            elif peer_secret == secret:
-                verrors.add(
-                    f'{schema_name}.peersecret',
-                    'The peer secret cannot be the same as user secret.')
-        else:
-            if peer_secret:
-                verrors.add(
-                    f'{schema_name}.peersecret',
-                    'The peer user is required if you set a peer secret.')
+        if not peer_user and peer_secret:
+            verrors.add(
+                f'{schema_name}.peersecret',
+                'The peer user is required if you set a peer secret.')
 
         if len(secret) < 12 or len(secret) > 16:
             verrors.add(f'{schema_name}.secret',
                         'Secret must be between 12 and 16 characters.')
 
-        if len(peer_secret) < 12 or len(peer_secret) > 16:
-            verrors.add(f'{schema_name}.peersecret',
-                        'Peer Secret must be between 12 and 16 characters.')
+        if not peer_user:
+            return
+
+        if not peer_secret:
+            verrors.add(
+                f'{schema_name}.peersecret',
+                'The peer secret is required if you set a peer user.')
+        elif peer_secret == secret:
+            verrors.add(
+                f'{schema_name}.peersecret',
+                'The peer secret cannot be the same as user secret.')
+        elif peer_secret:
+            if len(peer_secret) < 12 or len(peer_secret) > 16:
+                verrors.add(f'{schema_name}.peersecret',
+                            'Peer Secret must be between 12 and 16 characters.')
 
     @private
     async def extend(self, data):


### PR DESCRIPTION
Tighten up the logic and return early if the peer user is not supplied. 

Ticket: #35599