### PR TITLE
URL changed for FreeNAS logo in legacy UI

### DIFF
--- a/gui/templates/base.html
+++ b/gui/templates/base.html
@@ -57,7 +57,7 @@
         <div data-dojo-type="dijit.layout.ContentPane" id="topLayout" data-dojo-props="region: 'top'">
             <div id="page-header">
                  <div>
-                     <a href="/" title="{{ sw_name }}&reg;"><img src="{{ STATIC_URL }}images/ui/{{ sw_name|lower }}-logo.png?cache={{ cache_hash }}" alt="{{ sw_name }}&reg;" class="left" style="padding-left:10px;"/></a>
+                     <a href="/legacy/" title="{{ sw_name }}&reg;"><img src="{{ STATIC_URL }}images/ui/{{ sw_name|lower }}-logo.png?cache={{ cache_hash }}" alt="{{ sw_name }}&reg;" class="left" style="padding-left:10px;"/></a>
 		     <img src="{{ STATIC_URL }}ix/ix_header_logo.png" border="0" alt="iXsystems, Inc." style="padding-top: 10px; float: right; padding-right:10px;"/>
                  <div id="messages"></div>
 		 <div class="clear"></div>


### PR DESCRIPTION
Right now FreeNAS logo was rediricting users to the new UI when clicked. This commit changes that to directing the user to the legacy UI home page when clicked
Ticket: #36078