### PR TITLE
Downloading config bug fix

### DIFF
--- a/gui/freeadmin/static/lib/js/freeadmin.js
+++ b/gui/freeadmin/static/lib/js/freeadmin.js
@@ -2729,14 +2729,23 @@ require([
         dialog.show();
     };
 
-    editObject = function(name, url, nodes, onload, id="edit_dialog") {
+    editObject = function(name, url, nodes, onload) {
         commonDialog({
-            id: id,
+            id: "edit_dialog",
             style: "max-width: 75%;max-height:70%;background-color:white;overflow:auto;",
             name: name,
             url: url,
             nodes: nodes,
             onLoad: onload
+            });
+    }
+
+    configDownloadObject = function(name, url) {
+        commonDialog({
+            id: "config_download_dialog",
+            style: "max-width: 75%;max-height:70%;background-color:white;overflow:auto;",
+            name: name,
+            url: url,
             });
     }
 

--- a/gui/freeadmin/static/lib/js/freeadmin.js
+++ b/gui/freeadmin/static/lib/js/freeadmin.js
@@ -2729,9 +2729,9 @@ require([
         dialog.show();
     };
 
-    editObject = function(name, url, nodes, onload) {
+    editObject = function(name, url, nodes, onload, id="edit_dialog") {
         commonDialog({
-            id: "edit_dialog",
+            id: id,
             style: "max-width: 75%;max-height:70%;background-color:white;overflow:auto;",
             name: name,
             url: url,

--- a/gui/templates/system/manualupdate_wizard_0.html
+++ b/gui/templates/system/manualupdate_wizard_0.html
@@ -1,10 +1,12 @@
 {% extends "system/wizard.html" %}
 {% block form %}
 <tr>
-  <td colspan="2">
+  <td colspan="2" >
     {% url "system_configsave" as saveurl %}
-    <p>{% blocktrans with url=saveurl %}Consider downloading your configuration before proceeding, <a href="{{ url }}" target="_blank">click here</a>.{% endblocktrans %}</p>
+    <p>Consider downloading your configuration before proceeding,
+        <a href="javascript:void(0)" onclick="editObject('{% trans "Save Config"|escapejs %}', '{% url "system_configsave" %}', undefined, undefined, 'edit_dialog2')">Click here</a>.</p>
   </td>
 </tr>
+
 {{ block.super }}
 {% endblock %}

--- a/gui/templates/system/manualupdate_wizard_0.html
+++ b/gui/templates/system/manualupdate_wizard_0.html
@@ -2,9 +2,12 @@
 {% block form %}
 <tr>
   <td colspan="2" >
-    {% url "system_configsave" as saveurl %}
-    <p>Consider downloading your configuration before proceeding,
-        <a href="javascript:void(0)" onclick="editObject('{% trans "Save Config"|escapejs %}', '{% url "system_configsave" %}', undefined, undefined, 'edit_dialog2')">Click here</a>.</p>
+    <p>{% trans "Consider downloading your configuration before proceeding" %}
+        <a href="javascript:void(0)" onclick="configDownloadObject('{% trans "Save Config"|escapejs %}', '{% url "system_configsave" %}')">
+            {% trans "Click here" %}
+        </a>
+    </p>
+
   </td>
 </tr>
 

--- a/gui/templates/system/manualupdate_wizard_1.html
+++ b/gui/templates/system/manualupdate_wizard_1.html
@@ -19,9 +19,10 @@ doSubmit({
 {% block form %}
 <tr>
   <td colspan="2">
-    {% url "system_configsave" as saveurl %}
-    <p>Consider downloading your configuration before proceeding,
-        <a href="javascript:void(0)" onclick="editObject('{% trans "Save Config"|escapejs %}', '{% url "system_configsave" %}', undefined, undefined, 'edit_dialog2')">Click here</a>
+    <p>{% trans "Consider downloading your configuration before proceeding" %}
+        <a href="javascript:void(0)" onclick="configDownloadObject('{% trans "Save Config"|escapejs %}', '{% url "system_configsave" %}')">
+            {% trans "Click here" %}
+        </a>
     </p>
   </td>
 </tr>

--- a/gui/templates/system/manualupdate_wizard_1.html
+++ b/gui/templates/system/manualupdate_wizard_1.html
@@ -20,7 +20,9 @@ doSubmit({
 <tr>
   <td colspan="2">
     {% url "system_configsave" as saveurl %}
-    <p>{% blocktrans with url=saveurl %}Consider downloading your configuration before proceeding, <a href="{{ url }}" target="_blank">click here</a>.{% endblocktrans %}</p>
+    <p>Consider downloading your configuration before proceeding,
+        <a href="javascript:void(0)" onclick="editObject('{% trans "Save Config"|escapejs %}', '{% url "system_configsave" %}', undefined, undefined, 'edit_dialog2')">Click here</a>
+    </p>
   </td>
 </tr>
 {{ block.super }}


### PR DESCRIPTION
When a download is initiated for the system config in the update section in legacy UI, the end user was unable to download the config file. This commit fixes that.
Ticket: #35347