### PR TITLE
fix(plugin/vm): Try to use the hosts's IP instead of 0.0.0.0 for VNC

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -715,6 +715,34 @@ class InterfacesService(Service):
 
         return list_of_ip
 
+    @accepts(
+        Str('name', default='nginx'),
+        Str('port', default='80')
+    )
+    async def get_process_ip(self, name, port):
+        """
+        Grabs the current IP address binded to the process
+        """
+        final_ip = None
+        sockstat = await Popen([
+            '/usr/bin/sockstat', '-46P', 'tcp', '-p', port
+        ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+        sockstat_stdout, _ = await sockstat.communicate()
+
+        for line in sockstat_stdout.splitlines():
+            line = line.decode().split()
+            cmd = line[1],
+            ip = line[5].split(':')[0]
+
+            if cmd == name and ip != '*':
+                final_ip = ip
+                break
+
+        return final_ip
+
 
 class RoutesService(Service):
 

--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -186,7 +186,10 @@ class VMSupervisor(object):
 
                 vnc_resolution = device['attributes'].get('vnc_resolution', None)
                 vnc_port = int(device['attributes'].get('vnc_port', 5900 + self.vm['id']))
-                vnc_bind = device['attributes'].get('vnc_bind', '0.0.0.0')
+                nginx_ip = await self.middleware.call(
+                    'interfaces.get_process_ip') if not None else '0.0.0.0'
+                vnc_bind = device['attributes'].get(
+                    'vnc_bind', nginx_ip)
                 vnc_password = device['attributes'].get('vnc_password', None)
                 vnc_web = device['attributes'].get('vnc_web', None)
 


### PR DESCRIPTION
Best effort attempt at using the IP that the web interface is bound to. This should allow the user to see the VNC client.

- Add a generic method for finding what IP address is bound to a process, defaults to nginx and port 80.

Ticket: #36293