### PR TITLE
Place winbind after nis and ldap in nsswitch.conf

### DIFF
--- a/src/middlewared/middlewared/etc_files/nsswitch.conf
+++ b/src/middlewared/middlewared/etc_files/nsswitch.conf
@@ -20,10 +20,6 @@
         passwd = ['files']
         sudoers = ['files']
 
-        if ad_enabled or dc_enabled:
-            group.append('winbind')
-            passwd.append('winbind')
-
         if ldap_enabled:
             ldap_anonymous_bind = safe_call('notifier.common', 'system', 'ldap_anonymous_bind')
             ldap_sudo_configured = safe_call('notifier.common', 'system', 'ldap_sudo_configured')
@@ -41,6 +37,10 @@
             group.append('nis')
             hosts.append('nis')
             passwd.append('nis')
+
+        if ad_enabled or dc_enabled:
+            group.append('winbind')
+            passwd.append('winbind')
 %>
 
 group: ${' '.join(group)}


### PR DESCRIPTION
Ticket #36963
This allows us to use NIS as ID provider if idmap_nss is enabled. 