### PR TITLE
Fix typo in install_loader

### DIFF
--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -320,7 +320,7 @@ install_loader() {
 
     _mnt="$1"
     shift
-    disks="$*"
+    _disks="$*"
 
 
     # When doing inplace upgrades, its entirely possible we've


### PR DESCRIPTION
This typo caused the list of disks passed to install_loader to be ignored and instead used a different list from a variable in a different scope. The lists only differ when a SATA DOM configured for RAID is present. 
Ticket: #37053