### PR TITLE
Ticket #28063 Write local SID to correct DB file

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-post-samba
+++ b/src/freenas/etc/ix.rc.d/ix-post-samba
@@ -32,7 +32,7 @@ save_sambaSID()
 		sambaSID="$(/usr/local/bin/net getlocalsid | \
 			cut -f2 -d: | awk '{ print $1 }')"
 
-		${FREENAS_SQLITE_CMD} ${RO_FREENAS_CONFIG} "
+		${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "
 		UPDATE
 			services_cifs
 		SET

--- a/src/freenas/etc/ix.rc.d/ix-pre-samba
+++ b/src/freenas/etc/ix.rc.d/ix-pre-samba
@@ -48,7 +48,7 @@ save_sambaSID()
 	sambaSID="$(/usr/local/bin/net getlocalsid | \
 		cut -f2 -d: | awk '{ print $1 }')"
 
-	${FREENAS_SQLITE_CMD} ${RO_FREENAS_CONFIG} "
+	${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "
 	UPDATE
 		services_cifs
 	SET


### PR DESCRIPTION
We were writing the local SID to a "readonly" copy of the config file, hence it wasn't being preserved. This caused permissions for local groups to break on change to server netbios name.