### PR TITLE
Disable RRD write cache when ramdisk is used.

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-collectd
+++ b/src/freenas/etc/ix.rc.d/ix-collectd
@@ -258,8 +258,16 @@ LoadPlugin zfs_arc_v2
 
 <Plugin "rrdtool">
     DataDir "${datadir}"
+EOF
+
+if use_rrd_dataset; then
+    cat << EOF >> $cfg
     CacheTimeout 120
     CacheFlush 900
+EOF
+fi
+
+cat << EOF >> $cfg
 </Plugin>
 
 <Plugin "threshold">


### PR DESCRIPTION
It does not make much sense to cache writes to ramdisk, it has no wear,
but disabling it makes graphs much more interactive.

Ticket:	#35428