### PR TITLE
Secret sauce for enabling multi channel in Samba

### DIFF
--- a/src/freenas-sysctl/services.c
+++ b/src/freenas-sysctl/services.c
@@ -76,11 +76,16 @@ static struct {
 		struct service_timeout s_st;
 	} smart;
 
+	/*
+	 * This should get its own file. We should add lots more
+	 * performance tuning options here as well. Coming soon?
+	 */
 	struct {
 		struct service_timeout s_st;
 		struct {
-			int server_min_protocol;
-			int server_max_protocol;
+			unsigned int server_min_protocol;
+			unsigned int server_max_protocol;
+			unsigned int server_multi_channel;
 		} config;
 	} smb;
 
@@ -324,7 +329,9 @@ services_init(void)
 
 	g_services->smb.config.server_min_protocol = SMB2;
 	g_services->smb.config.server_max_protocol = SMB3;
+	g_services->smb.config.server_multi_channel = 0;
 
+	/* SMB config */
 	if ((tmptree2 = SYSCTL_ADD_NODE(&g_freenas_sysctl_ctx,
 		SYSCTL_CHILDREN(tmptree), OID_AUTO,
 		"config", CTLFLAG_RD, NULL, NULL)) == NULL) {
@@ -342,6 +349,12 @@ services_init(void)
 		"server_max_protocol", CTLTYPE_STRING|CTLFLAG_RW,
 		&g_services->smb.config.server_max_protocol, 0,
 		sysctl_smb_server_proto, "A", "server max protocol");
+
+	SYSCTL_ADD_UINT(&g_freenas_sysctl_ctx,
+		SYSCTL_CHILDREN(tmptree2), OID_AUTO,
+		"server_multi_channel", CTLFLAG_RW,
+		&g_services->smb.config.server_multi_channel, 0,
+		"server multi channel support");
 
 	/* SNMP node */
 	if ((tmptree = SYSCTL_ADD_NODE(&g_freenas_sysctl_ctx,

--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -955,6 +955,10 @@ def generate_smb4_conf(client, smb4_conf, role):
     if server_max_protocol != 'NONE':
         confset2(smb4_conf, "server max protocol = %s", server_max_protocol)
 
+    server_multi_channel = fs().services.smb.config.server_multi_channel
+    if server_multi_channel != 0:
+        confset1(smb4_conf, "server multi channel support = yes")
+
     if cifs.bindip:
         interfaces = []
 


### PR DESCRIPTION
- This is experimental, so it's hidden
- We should add more Samba performance knobs here
- When adding sysctl's in the UI, we should probably look for the ones
  that control Samba options and re-generate the config and reload
  Samba when changed

Ticket: #17697