### PR TITLE
fix(plugins/jail): Bad caching on list_resource

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -283,8 +283,12 @@ class JailService(CRUDService):
                 )
         elif resource == "base":
             try:
-                resource_list = self.middleware.call_sync(
-                    'cache.get', 'iocage_remote_releases')
+                if remote:
+                    resource_list = self.middleware.call_sync(
+                        'cache.get', 'iocage_remote_releases')
+                else:
+                    resource_list = self.middleware.call_sync(
+                        'cache.get', 'iocage_local_releases')
 
                 return resource_list
             except ClientException as e:
@@ -294,12 +298,19 @@ class JailService(CRUDService):
                     pass  # It's either new or past cache date
                 else:
                     raise
+
             resource_list = iocage.fetch(list=True, remote=remote, http=True)
 
-            self.middleware.call_sync(
-                'cache.put', 'iocage_remote_releases', resource_list,
-                86400
-            )
+            if remote:
+                self.middleware.call_sync(
+                    'cache.put', 'iocage_remote_releases', resource_list,
+                    86400
+                )
+            else:
+                self.middleware.call_sync(
+                    'cache.put', 'iocage_local_releases', resource_list,
+                    10
+                )
         else:
             resource_list = iocage.list(resource)
 

--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -286,11 +286,8 @@ class JailService(CRUDService):
                 if remote:
                     resource_list = self.middleware.call_sync(
                         'cache.get', 'iocage_remote_releases')
-                else:
-                    resource_list = self.middleware.call_sync(
-                        'cache.get', 'iocage_local_releases')
 
-                return resource_list
+                    return resource_list
             except ClientException as e:
                 # The jail plugin runs in another process, it's seen as
                 # a client
@@ -305,11 +302,6 @@ class JailService(CRUDService):
                 self.middleware.call_sync(
                     'cache.put', 'iocage_remote_releases', resource_list,
                     86400
-                )
-            else:
-                self.middleware.call_sync(
-                    'cache.put', 'iocage_local_releases', resource_list,
-                    10
                 )
         else:
             resource_list = iocage.list(resource)


### PR DESCRIPTION
This caused a remote cache to be consumed by a local cache. They are now distinct.

Ticket: #37706