### PR TITLE
Make sure that `netbiosname_b` is mandatory field as well.

### DIFF
--- a/gui/directoryservice/forms.py
+++ b/gui/directoryservice/forms.py
@@ -237,7 +237,6 @@ class ActiveDirectoryForm(ModelForm):
     ad_netbiosname_b = forms.CharField(
         max_length=120,
         label=_("NetBIOS name"),
-        required=False,
     )
     ad_netbiosalias = forms.CharField(
         max_length=120,


### PR DESCRIPTION
 As it got deleted in the __init__ later for FreeNAS and non-HA TrueNAS, we are enforcing this requirement only for HA TrueNAS.

Ticket: #26002