### PR TITLE
Allow users to complete CSR

### DIFF
--- a/gui/system/forms.py
+++ b/gui/system/forms.py
@@ -2751,12 +2751,23 @@ class CertificateCSREditForm(MiddlewareModelForm, ModelForm):
         required=True,
         help_text=models.Certificate._meta.get_field('cert_CSR').help_text
     )
+    cert_certificate = forms.CharField(
+        label=models.Certificate._meta.get_field('cert_certificate').verbose_name,
+        widget=forms.Textarea(),
+        required=False,
+        help_text=models.Certificate._meta.get_field('cert_certificate').help_text
+    )
 
     def __init__(self, *args, **kwargs):
         super(CertificateCSREditForm, self).__init__(*args, **kwargs)
 
-        self.fields['cert_name'].widget.attrs['readonly'] = True
         self.fields['cert_CSR'].widget.attrs['readonly'] = True
+
+    def middleware_clean(self, data):
+        data.pop('CSR', None)
+        if not data.get('certificate'):
+            data.pop('certificate', None)
+        return data
 
     class Meta:
         fields = [


### PR DESCRIPTION
This commit allows users to paste the contents of the certificates they have got signed from an external CA in the CSR object for 11.2. We are going to disallow this in 11.3 and have a separate section to facilitate this behaviour
Ticket: #37694