### PR TITLE
Wildcard IP's allowed for Portal creation

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi.py
+++ b/src/middlewared/middlewared/plugins/iscsi.py
@@ -115,6 +115,7 @@ class ISCSIPortalService(CRUDService):
             system_ips = [
                 ip['address'] for ip in await self.middleware.call('interfaces.ip_in_use')
             ]
+            system_ips.extend(['0.0.0.0', '::'])
             new_ips = set(i['ip'] for i in data['listen']) - set(i['ip'] for i in old['listen']) if old else set()
             for i in data['listen']:
                 filters = [


### PR DESCRIPTION
This commit adds the support of wildcard ips when creating portals in iSCSI - '0.0.0.0' and '::'
Ticket: #37610