### PR TITLE
tkt-38711: Do boot-time disk.multipath_sync after ZFS volume imports

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-syncdisks
+++ b/src/freenas/etc/ix.rc.d/ix-syncdisks
@@ -13,10 +13,6 @@ syncdisks()
 	touch /tmp/.sync_disk_done
 	echo "Syncing disks..."
 	/usr/local/bin/midclt call --job true disk.sync_all > /dev/null
-	/usr/local/bin/midclt call disk.multipath_sync > /dev/null
-	if [ "$(/usr/local/bin/midclt call system.is_freenas)" = "False" ]; then
-		checkyesno failover_enable || /usr/local/bin/midclt call notifier.zpool_enclosure_sync > /dev/null
-	fi
 }
 
 name="ix-syncdisks"

--- a/src/freenas/etc/ix.rc.d/ix-syncmultipaths
+++ b/src/freenas/etc/ix.rc.d/ix-syncmultipaths
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# $FreeBSD$
+#
+
+# PROVIDE: ix-syncmultipaths
+# REQUIRE: FILESYSTEMS
+
+. /etc/rc.subr
+
+syncmultipaths()
+{
+	echo "Syncing multipaths..."
+	/usr/local/bin/midclt call disk.multipath_sync > /dev/null
+	if [ "$(/usr/local/bin/midclt call system.is_freenas)" = "False" ]; then
+		checkyesno failover_enable || /usr/local/bin/midclt call notifier.zpool_enclosure_sync > /dev/null
+	fi
+}
+
+name="ix-syncmultipaths"
+start_cmd='syncmultipaths'
+stop_cmd=''
+
+load_rc_config $name
+run_rc_command "$1"


### PR DESCRIPTION
86db25057ff12699b2619395e638c04cb7ab205a has moved it before ZFS volume
imports. Now it fails because it calls disk.get_reserved ->
pool.get_disks and pools are not imported yet.