### PR TITLE
Failing validation for rsync fix

### DIFF
--- a/src/middlewared/middlewared/plugins/rsync.py
+++ b/src/middlewared/middlewared/plugins/rsync.py
@@ -411,7 +411,8 @@ class RsyncTaskService(CRUDService):
 
             search = os.path.join(user.pw_dir, '.ssh', 'id_[edr]*')
             exclude_from_search = os.path.join(user.pw_dir, '.ssh', 'id_[edr]*pub')
-            if not set(glob.glob(search)) - set(glob.glob(exclude_from_search)):
+            key_files = set(glob.glob(search)) - set(glob.glob(exclude_from_search))
+            if not key_files:
                 verrors.add(
                     f'{schema}.user',
                     'In order to use rsync over SSH you need a user'
@@ -443,7 +444,9 @@ class RsyncTaskService(CRUDService):
                     with (await asyncio.wait_for(asyncssh.connect(
                             remote_host,
                             port=remote_port,
-                            username=remote_username), timeout=5)) as conn:
+                            username=remote_username,
+                            client_keys=key_files
+                    ), timeout=5)) as conn:
 
                         await conn.run(f'test -d {remote_path}', check=True)
 


### PR DESCRIPTION
Rsync validation was failing when mode was set to ssh. This commit fixes that.
Ticket: #37866