### PR TITLE
Remove warning that vfs_full_audit may cause transfer problems with the

### DIFF
--- a/gui/sharing/admin.py
+++ b/gui/sharing/admin.py
@@ -74,13 +74,10 @@ class CIFSShareFAdmin(BaseFreeAdmin):
         if action not in ('add', 'edit'):
             return
         form = kwargs['form']
-        full_audit_form = 'full_audit' in form.cleaned_data.get('cifs_vfsobjects')
-        full_audit_instance = 'full_audit' in form._original_cifs_vfsobjects
-        if full_audit_form and not full_audit_instance:
-            return _(
-                'full_audit VFS object is known to have file transfer issues '
-                'with Windows 10. Do you wish to continue?'
-            )
+        warn = []
+
+        if warn:
+            return ('<br/><br/>\n' + _('Also,') + '<br/><br/>\n').join(warn)
 
 
 class NFSShareFAdmin(BaseFreeAdmin):

--- a/gui/sharing/admin.py
+++ b/gui/sharing/admin.py
@@ -73,11 +73,8 @@ class CIFSShareFAdmin(BaseFreeAdmin):
     def get_confirm_message(self, action, **kwargs):
         if action not in ('add', 'edit'):
             return
-        form = kwargs['form']
-        warn = []
 
-        if warn:
-            return ('<br/><br/>\n' + _('Also,') + '<br/><br/>\n').join(warn)
+        return
 
 
 class NFSShareFAdmin(BaseFreeAdmin):
@@ -128,13 +125,14 @@ class WebDAVShareFAdmin(BaseFreeAdmin):
     icon_view = "ViewAllWebDAVSharesIcon"
     icon_object = "WebDAVShareIcon"
     fields = (
-          'webdav_name',
-          'webdav_comment',
-          'webdav_path',
-          'webdav_ro',
-          'webdav_perm',
+        'webdav_name',
+        'webdav_comment',
+        'webdav_path',
+        'webdav_ro',
+        'webdav_perm',
     )
     resource_name = 'sharing/webdav'
+
 
 site.register(models.AFP_Share, AFPShareFAdmin)
 site.register(models.CIFS_Share, CIFSShareFAdmin)


### PR DESCRIPTION
Windows 10. The issue isn't W10 specific and was caused by the high
additional load on the server with the default setting of "all" for
logging of all file operations. The default has been changed to be
"none".

Ticket: #32055
(cherry picked from commit 70cfbf1a70b82668dc775b1b6a5e8c556f5b02f9)