### PR TITLE
tkt-37263: Don't propose installing to the installer disk

### DIFF
--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -166,7 +166,7 @@ get_raid_present()
 
 get_physical_disks_list()
 {
-    local _boot=$(glabel status | awk ' /iso9660\/(Free|True)NAS/ { print $3;}')
+    local _boot=$(glabel status | awk ' /iso9660\/(FREE|TRUE)NAS/ { print $3;}')
     local _disk
 
     for _disk in $(sysctl -n kern.disks)


### PR DESCRIPTION
The installer disk label changed in the switch from GRUB to the BSD
loader, breaking the detection of the installer disk in the install
script.

Ticket: #37263