### PR TITLE
Ticket #39167 allow kerberos auth provider with anon ldap binding

### DIFF
--- a/src/freenas/etc/directoryservice/LDAP/ctl
+++ b/src/freenas/etc/directoryservice/LDAP/ctl
@@ -1,4 +1,4 @@
-#!/bin/sh 
+#!/bin/sh
 
 . /etc/rc.freenas
 

--- a/src/freenas/etc/directoryservice/LDAP/ctl
+++ b/src/freenas/etc/directoryservice/LDAP/ctl
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh 
 
 . /etc/rc.freenas
 
@@ -151,7 +151,7 @@ ldapctl_start()
 	fi
 
 	anonbind="$(LDAP_get ldap_anonbind)"
-	if [ "${anonbind}" = "0" ]
+	if [ "${anonbind}" = "0" -o -n "${realm}" -o -n "${keytab_principal}" ]
 	then
 		ldapctl_cmd ${service} ix-sssd start	
 		if sssd_running
@@ -161,8 +161,7 @@ ldapctl_start()
 			sssd_start
 		fi
 
-	elif [ "${anonbind}" = "1" ]
-	then
+        else
 		ldapctl_cmd ${service} ix-pam quietstart
 		if nslcd_running
 		then

--- a/src/middlewared/middlewared/etc_files/nsswitch.conf
+++ b/src/middlewared/middlewared/etc_files/nsswitch.conf
@@ -23,8 +23,9 @@
         if ldap_enabled:
             ldap_anonymous_bind = safe_call('notifier.common', 'system', 'ldap_anonymous_bind')
             ldap_sudo_configured = safe_call('notifier.common', 'system', 'ldap_sudo_configured')
+            ldap = safe_call('datastore.query', 'directoryservice.LDAP')
 
-            if ldap_anonymous_bind:
+            if ldap_anonymous_bind and not ldap['ldap_kerberos_realm_id']:
                 group.append('ldap')
                 passwd.append('ldap')
             else:


### PR DESCRIPTION
If ldap anonymous binding is enabled, but kerberos principal and realm present. Start SSSD with LDAP id provider and krb5 auth provider.