### PR TITLE
Password fix for CHAP authentication

### DIFF
--- a/gui/services/models.py
+++ b/gui/services/models.py
@@ -867,6 +867,25 @@ class iSCSITargetAuthCredential(Model):
         verbose_name = _("Authorized Access")
         verbose_name_plural = _("Authorized Accesses")
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for attr in ('iscsi_target_auth_secret', 'iscsi_target_auth_peersecret'):
+            field = getattr(self, attr)
+            if field and self.id:
+                try:
+                    setattr(self, attr, notifier().pwenc_decrypt(field))
+                except Exception as e:
+                    log.debug(f'Failed to decrypt {attr} password', exc_info=True)
+                    setattr(self, attr, '')
+
+    def save(self, *args, **kwargs):
+        for attr in ('iscsi_target_auth_secret', 'iscsi_target_auth_peersecret'):
+            field = getattr(self, attr)
+            if field:
+                encrypted_val = notifier().pwenc_encrypt(field)
+                setattr(self, attr, encrypted_val)
+        return super().save(*args, **kwargs)
+
     def __str__(self):
         return str(self.iscsi_target_auth_tag)
 

--- a/src/middlewared/middlewared/plugins/iscsi.py
+++ b/src/middlewared/middlewared/plugins/iscsi.py
@@ -278,7 +278,6 @@ class iSCSITargetAuthCredentialService(CRUDService):
         namespace = 'iscsi.auth'
         datastore = 'services.iscsitargetauthcredential'
         datastore_prefix = 'iscsi_target_auth_'
-        datastore_extend = 'iscsi.auth.extend'
 
     @accepts(Dict(
         'iscsi_auth_create',
@@ -296,7 +295,6 @@ class iSCSITargetAuthCredentialService(CRUDService):
         if verrors:
             raise verrors
 
-        await self.compress(data)
         data['id'] = await self.middleware.call(
             'datastore.insert', self._config.datastore, data,
             {'prefix': self._config.datastore_prefix})
@@ -327,7 +325,6 @@ class iSCSITargetAuthCredentialService(CRUDService):
         if verrors:
             raise verrors
 
-        await self.compress(new)
         await self.middleware.call(
             'datastore.update', self._config.datastore, id, new,
             {'prefix': self._config.datastore_prefix})
@@ -372,30 +369,6 @@ class iSCSITargetAuthCredentialService(CRUDService):
             if len(peer_secret) < 12 or len(peer_secret) > 16:
                 verrors.add(f'{schema_name}.peersecret',
                             'Peer Secret must be between 12 and 16 characters.')
-
-    @private
-    async def extend(self, data):
-        secret = data.get('secret', '')
-        peersecret = data.get('peersecret', '')
-
-        data['secret'] = await self.middleware.call(
-            'notifier.pwenc_decrypt', secret)
-        data['peersecret'] = await self.middleware.call(
-            'notifier.pwenc_decrypt', peersecret)
-
-        return data
-
-    @private
-    async def compress(self, data):
-        secret = data.get('secret') or ''
-        peersecret = data.get('peersecret') or ''
-
-        data['secret'] = await self.middleware.call(
-            'notifier.pwenc_encrypt', secret)
-        data['peersecret'] = await self.middleware.call(
-            'notifier.pwenc_encrypt', peersecret)
-
-        return data
 
 
 class iSCSITargetExtentService(CRUDService):


### PR DESCRIPTION
Encryption/decryption was causing some unwanted changes in CHAP auth for iscsi plugin in legacy. This commit fixes that issue.
Ticket: #39213