### PR TITLE
tkt#39982 -- optimizations for large AD environment

### DIFF
--- a/gui/common/freenasldap.py
+++ b/gui/common/freenasldap.py
@@ -65,6 +65,8 @@ from freenasUI.common.freenascache import (
     FLAGS_CACHE_WRITE_GROUP
 )
 
+from middlewared.client import Client
+
 log = logging.getLogger('common.freenasldap')
 
 FREENAS_LDAP_NOSSL = " off"
@@ -1059,6 +1061,13 @@ class FreeNAS_ActiveDirectory_Base(object):
         best_host = None
         latencies = {}
 
+        if len(srv_hosts) > 5:
+            for s in srv_hosts:
+                host = s.target.to_text(True)
+                port = int(s.port)
+                if FreeNAS_ActiveDirectory.port_is_listening(host, port, errors=[], timeout=1):
+                    return (host, port)
+
         def callback(host, port, duration):
             latencies.setdefault(host, 0)
             latencies[host] += duration
@@ -1819,12 +1828,15 @@ class FreeNAS_ActiveDirectory_Base(object):
                             break
 
         if ipv4_site and ipv6_site and ipv4_site == ipv6_site:
+            Client().call('datastore.update', 'directoryservice.activedirectory', '1', {'ad_site': ipv4_site})
             return ipv4_site
 
         if not ipv6_site and ipv4_site:
+            Client().call('datastore.update', 'directoryservice.activedirectory', '1', {'ad_site': ipv4_site})
             return ipv4_site
 
         if not ipv4_site and ipv6_site:
+            Client().call('datastore.update', 'directoryservice.activedirectory', '1', {'ad_site': ipv6_site})
             return ipv6_site
 
         return None


### PR DESCRIPTION
1) Don't try to figure out best host if the site has more than 5 DCs (perhaps make this configurable in the future).
2) If we auto-discover the site, store this info in the config DB.