### PR TITLE
tkt-35062: fix(notifier/volume_detach): Stop jails related to the volume

### DIFF
--- a/gui/middleware/notifier.py
+++ b/gui/middleware/notifier.py
@@ -60,7 +60,6 @@ import syslog
 import tarfile
 import tempfile
 import time
-from freenasUI.middleware.client import client
 
 WWW_PATH = "/usr/local/www"
 FREENAS_PATH = os.path.join(WWW_PATH, "freenasUI")
@@ -2067,9 +2066,9 @@ class notifier(metaclass=HookMetaclass):
             if active_pool == vol_name:
                 jails = c.call('jail.query', [('state', '=', 'up')])
 
-            for j in jails:
-                _jail = j['host_hostuuid']
-                c.call('jail.stop', _jail)
+                for j in jails:
+                    _jail = j['host_hostuuid']
+                    c.call('jail.stop', _jail)
 
         p1 = self._pipeopen(cmd)
         stdout, stderr = p1.communicate()

--- a/gui/storage/views.py
+++ b/gui/storage/views.py
@@ -970,16 +970,6 @@ def volume_lock(request, object_id):
                 })
                 return JsonResp(request, confirm=message)
 
-        with client as c:
-            active_pool = c.call('jail.get_activated_pool')
-
-            if active_pool == volume:
-                jails = c.call('jail.query', [('state', '=', 'up')])
-
-                for j in jails:
-                    _jail = j['host_hostuuid']
-                    c.call('jail.stop', _jail)
-
         notifier().volume_detach(volume)
         if hasattr(notifier, 'failover_status') and notifier().failover_status() == 'MASTER':
             from freenasUI.failover.enc_helper import LocalEscrowCtl


### PR DESCRIPTION
Previously it only handled one use case, this makes sure both the New and Old UI properly stop all jails related to a volume being detached. (Not just locked)

Ticket: #35062