### PR TITLE
tkt-40066: Nginx rule fix for plugins

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-nginx
+++ b/src/freenas/etc/ix.rc.d/ix-nginx
@@ -278,7 +278,7 @@ __EOF__
             rewrite ^.* /${default_ui}/;
         }
 
-        location ~ /(legacy|plugins|api/v1.0)/ {
+        location ~ ^/(legacy|plugins|api/v1.0)/ {
             include fastcgi_params;
             fastcgi_pass 127.0.0.1:9042;
             fastcgi_pass_header Authorization;


### PR DESCRIPTION
This commit fixes an issue where an unintended redirect was taking place when plugins was in the url.
Ticket: #40066