### PR TITLE
Nic choices updated to support vnet

### DIFF
--- a/gui/choices.py
+++ b/gui/choices.py
@@ -578,7 +578,7 @@ class NICChoices(object):
         if self.noepair:
             niclist = copy.deepcopy(self._NIClist)
             for nic in niclist:
-                if nic.startswith('epair'):
+                if nic.startswith('epair') or nic.startswith('vnet'):
                     self._NIClist.remove(nic)
 
         if self.notap:


### PR DESCRIPTION
This commit adds support where vnet nic's are treated similar to epairs and hence removed when epairs are removed from nic choices.
Ticket: #40076