### PR TITLE
tkt-33453: tkt#33453 -  additional fixes related to AD restarts

### DIFF
--- a/gui/common/freenasldap.py
+++ b/gui/common/freenasldap.py
@@ -1149,7 +1149,7 @@ class FreeNAS_ActiveDirectory_Base(object):
 
         r = resolver.Resolver()
         r.lifetime = _fs().directoryservice.activedirectory.dns.lifetime
-        r.timeout = r.lifetime / 3 
+        r.timeout = r.lifetime / 3
 
         try:
 

--- a/gui/common/freenasldap.py
+++ b/gui/common/freenasldap.py
@@ -1148,9 +1148,8 @@ class FreeNAS_ActiveDirectory_Base(object):
         )
 
         r = resolver.Resolver()
-        r.rotate = True
-        r.timeout = _fs().directoryservice.activedirectory.dns.timeout
         r.lifetime = _fs().directoryservice.activedirectory.dns.lifetime
+        r.timeout = r.lifetime / 3 
 
         try:
 

--- a/src/freenas/etc/directoryservice/ActiveDirectory/ctl
+++ b/src/freenas/etc/directoryservice/ActiveDirectory/ctl
@@ -4,6 +4,7 @@
 
 cifs_file="/tmp/.cifs_AD"
 status_file="/var/run/directoryservice.activedirectory"
+start_file="/tmp/.ad_start"
 service=/usr/sbin/service
 python=/usr/local/bin/python
 notifier=/usr/local/bin/midclt
@@ -76,10 +77,12 @@ adctl_start()
 {
 	local cifs_started=0	
 	local ad_started=0
+	touch "${start_file}"
 
 	if ! AD_init
 	then
 		activedirectory_set 0
+	        rm "${start_file}"
 		return 1
 	fi
 
@@ -109,6 +112,7 @@ adctl_start()
 	if ! adctl_cmd ${service} ix-kinit status
 	then
 		activedirectory_set 0
+	        rm "${start_file}"
 		return 1
 	fi
 
@@ -128,11 +132,13 @@ adctl_start()
 	if ! adctl_cmd ${service} ix-activedirectory quietstart
 	then
 		activedirectory_set 0
+	        rm "${start_file}"
 		return 1
 	fi
 	if ! adctl_cmd ${service} ix-activedirectory status
 	then
 		activedirectory_set 0
+	        rm "${start_file}"
 		return 1
 	fi
 
@@ -142,6 +148,7 @@ adctl_start()
 	adctl_cmd "${service} ix-cache quietstart &"
 
 	touch "${status_file}"
+	rm "${start_file}"
 	return 0
 }
 

--- a/src/middlewared/middlewared/plugins/service_monitor.py
+++ b/src/middlewared/middlewared/plugins/service_monitor.py
@@ -133,6 +133,8 @@ class ServiceMonitorThread(threading.Thread):
 
     def run(self):
         ntries = 0
+        delay_check = 0
+
         service = self.name
 
         while True:
@@ -145,6 +147,23 @@ class ServiceMonitorThread(threading.Thread):
                 # Thread.cancel() takes a while to propagate here
                 ServiceMonitorThread.reset_alerts(service)
                 return
+
+            if os.path.exists('/tmp/.ad_start'):
+                """
+                 Check to see if the file .ad_start file is stale. This file is generated
+                 by /etc/directoryservice/ActiveDirectory/ctl and indicates that an AD start
+                 is in progress. We should not restart while AD is initializing, on the other 
+                 hand, we don't want to be in a place where a stale file is causing AD to be down
+                 Two iterations of waiting the sm_frequency period should be enough to get the 
+                 service fully up.
+                """
+                self.logger.debug(f'[ServiceMonitorThread] AD is starting. Temporarily delaying service checks.')
+                if delay_check:
+                    os.remove('/tmp/.ad_start')
+                    delay_check = 0
+                else:
+                    delay_check = 1
+                continue
 
             connected = self.tryConnect(self.host, self.port)
             started = self.getStarted(service)

--- a/src/middlewared/middlewared/plugins/service_monitor.py
+++ b/src/middlewared/middlewared/plugins/service_monitor.py
@@ -152,9 +152,9 @@ class ServiceMonitorThread(threading.Thread):
                 """
                  Check to see if the file .ad_start file is stale. This file is generated
                  by /etc/directoryservice/ActiveDirectory/ctl and indicates that an AD start
-                 is in progress. We should not restart while AD is initializing, on the other 
+                 is in progress. We should not restart while AD is initializing, on the other
                  hand, we don't want to be in a place where a stale file is causing AD to be down
-                 Two iterations of waiting the sm_frequency period should be enough to get the 
+                 Two iterations of waiting the sm_frequency period should be enough to get the
                  service fully up.
                 """
                 self.logger.debug(f'[ServiceMonitorThread] AD is starting. Temporarily delaying service checks.')


### PR DESCRIPTION
tkt#33453 A few issues discovered during QA process

1) "rotate" was causing issues for users who had incorrect nameservers at the end of /etc/resolv.conf. It's better to just set the timeout to less than the lifetime and cycle down the list.
2) In a large AD environment, we need to prevent monitoring from interfering with the AD start process.