### PR TITLE
Allow /etc/find_alias_for_smtplib.sh to be used by sudoers

### DIFF
--- a/src/freenas/usr/local/etc/sudoers
+++ b/src/freenas/usr/local/etc/sudoers
@@ -3,3 +3,4 @@ Defaults secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/
 
 # Let find_alias_for_smtplib.py runs as root (it needs database access)
 ALL ALL=(ALL) NOPASSWD: /etc/find_alias_for_smtplib.py
+ALL ALL=(ALL) NOPASSWD: /etc/find_alias_for_smtplib.sh


### PR DESCRIPTION
Ticket: #29805
(cherry picked from commit b962a59e75acce42373d7c7cdb90e3ac9b14c0d4)
(cherry picked from commit 6c7b4b6de59e15917c26b796220faf3552d8606f)

(11.1-stable)
Ticket: #40636