### PR TITLE
 do not grant extra privileges to users

### DIFF
--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -1704,7 +1704,9 @@ def main():
                 smb4_tdb,
                 privatedir + "/passdb.tdb"
             )
-            smb4_grant_rights()
+            if role != 'member':
+                smb4_grant_rights()
+
             client.call('notifier.samba4', 'user_import_sentinel_file_create')
 
         smb4_map_groups(client)


### PR DESCRIPTION
These are inappropriate from a security perspective in an AD / LDAP environment, and they can negatively impact boot times.

(cherry picked from commit ee5064581cd5696fa2adb3fe035e305d22c1921b)

(11.1-stable)
Ticket: #40704