### PR TITLE
tkt-41068: Fix exception when dismissing alert that has gone away

### DIFF
--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -142,7 +142,10 @@ class AlertService(Service):
     @accepts(Str("id"))
     def dismiss(self, id):
         node, source, key = id.split(";", 2)
-        alert = self.alerts[node][source][key]
+        try:
+            alert = self.alerts[node][source][key]
+        except KeyError:
+            return
         alert.dismissed = True
 
     @accepts(Str("id"))


### PR DESCRIPTION
(cherry-picked from commit 678f1ad8071d3d6d545af97495e08a7bb674ccc0)