### PR TITLE
tkt-41052: Bug fix for zvol/dataset creation

### DIFF
--- a/gui/choices.py
+++ b/gui/choices.py
@@ -716,7 +716,7 @@ ZFS_DEDUP = (
     ('verify', _('Verify')),
     ('off', _('Off')))
 
-ZFS_DEDUP_INHERIT = (('inherit', _('Inherit'))) + ZFS_DEDUP
+ZFS_DEDUP_INHERIT = (('inherit', _('Inherit')), ) + ZFS_DEDUP
 
 TASK_INTERVAL = (
     (5, _("%(minutes)s minutes") % {'minutes': '5'}),


### PR DESCRIPTION
This commit fixes a bug which prevented the end user to create a zvol/dataset in FreeNAS 11.1-U6.
Ticket: #41052