### PR TITLE
feat(middlewared): add endpoint to pass MIDDLEWARE_TOKEN to webui

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-nginx
+++ b/src/freenas/etc/ix.rc.d/ix-nginx
@@ -328,6 +328,9 @@ __EOF__
         }
 
         location /ui {
+            if ( $request_method ~ ^POST$ ) {
+                proxy_pass http://127.0.0.1:6000;
+            }
             try_files \$uri \$uri/ /index.html =404;
             alias /usr/local/www/webui;
         }

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -7,6 +7,7 @@ from .restful import RESTfulAPI
 from .schema import ResolverError, Error as SchemaError
 from .service import CallError, CallException, ValidationError, ValidationErrors
 from .utils import start_daemon_thread, load_modules, load_classes
+from .webui_auth import WebUIAuth
 from .worker import ProcessPoolExecutor, main_worker
 from aiohttp import web
 from aiohttp.web_exceptions import HTTPPermanentRedirect
@@ -1133,7 +1134,8 @@ class Middleware(object):
         ], loop=self.__loop)
         app.router.add_route('GET', '/websocket', self.ws_handler)
 
-        app.router.add_route("*", "/api/docs{path_info:.*}", WSGIHandler(apidocs_app))
+        app.router.add_route('*', '/api/docs{path_info:.*}', WSGIHandler(apidocs_app))
+        app.router.add_route('*', '/ui{path_info:.*}', WebUIAuth(self))
 
         self.fileapp = FileApplication(self, self.__loop)
         app.router.add_route('*', '/_download{path_info:.*}', self.fileapp.download)

--- a/src/middlewared/middlewared/webui_auth.py
+++ b/src/middlewared/middlewared/webui_auth.py
@@ -1,0 +1,21 @@
+from aiohttp import web
+
+
+class WebUIAuth(object):
+
+    def __init__(self, middleware):
+        self.middleware = middleware
+
+    async def __call__(self, request):
+        post = await request.post()
+        if 'auth_token' not in post:
+            return web.Response(status=400, text='No token provided.')
+        if not await self.middleware.call('auth.get_token', post['auth_token']):
+            return web.Response(status=400, text='Invalid token.')
+        with open('/usr/local/www/webui/index.html', 'r') as f:
+            index = f.read()
+        index = index.replace(
+            '</head>',
+            f'<script>var MIDDLEWARE_TOKEN = "{post["auth_token"]}";</script></head>',
+        )
+        return web.Response(status=200, body=index)


### PR DESCRIPTION
TrueView needs a way to authenticate to new UI automatically, using
query string poses a security risk since that can be seen very easily.
We validate the auth_token and then output MIDDLEWARE_TOKEN as a
javascript variable in the index.html output.

Ticket:	#40344