### PR TITLE
tkt-40768: Revert "fix(snmp/zilstat) dtrace was triggering off zil_lwb_write_sta…

### DIFF
--- a/src/freenas/usr/local/bin/zilstat
+++ b/src/freenas/usr/local/bin/zilstat
@@ -170,7 +170,7 @@ fi
  /*
   * collect info when zil_lwb_write_start fires
   */
-fbt::zil_lwb_write_issue:entry
+fbt::zil_lwb_write_start:entry
 /OPT_pool == 0 || POOL == args[0]->zl_dmu_pool->dp_spa->spa_name/
 {
      nused += args[1]->lwb_nused;


### PR DESCRIPTION
…rt, which has been removed."

This reverts commit 3bda775e16b8d276245d40741f926804f09afa6b.

There is no zil_lwb_write_start() function in FreeNAS 11.1 ZFS.
This commit should be limited to 11.2 only.

Ticket:	#40768