### PR TITLE
tkt-40976: Ip usage validator added in middlewared

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -166,7 +166,7 @@ class JailService(CRUDService):
         return True
 
     @private
-    def validate_ips(self, verrors, options):
+    def validate_ips(self, verrors, options, schema='options.props'):
         for item in options['props']:
             for f in ('ip4_addr', 'ip6_addr'):
                 if f in item:
@@ -175,7 +175,7 @@ class JailService(CRUDService):
                             IpInUse(self.middleware)(ip.split('|')[1].split('/')[0])
                         except ShouldBe as e:
                             verrors.add(
-                                f'fetch.props.{f}',
+                                f'{schema}.{f}',
                                 str(e)
                             )
 
@@ -196,7 +196,7 @@ class JailService(CRUDService):
 
         verrors = ValidationErrors()
 
-        self.validate_ips(verrors, {'props': [f'{k}={v}' for k, v in options.items()]})
+        self.validate_ips(verrors, {'props': [f'{k}={v}' for k, v in options.items()]}, 'options')
 
         for prop, val in options.items():
             p = f"{prop}={val}"

--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -15,11 +15,14 @@ from iocage_lib.ioc_json import IOCJson
 # iocage's imports are per command, these are just general facilities
 from iocage_lib.ioc_list import IOCList
 from iocage_lib.ioc_upgrade import IOCUpgrade
+
+from middlewared.client import ClientException
 from middlewared.schema import Bool, Dict, Int, List, Str, accepts
 from middlewared.service import CRUDService, job, private
-from middlewared.service_exception import CallError
+from middlewared.service_exception import CallError, ValidationErrors
 from middlewared.utils import filter_list
-from middlewared.client import ClientException
+from middlewared.validators import IpInUse, ShouldBe
+
 
 SHUTDOWN_LOCK = asyncio.Lock()
 
@@ -120,6 +123,11 @@ class JailService(CRUDService):
              List("props", default=[])))
     @job()
     def create_job(self, job, options):
+
+        verrors = ValidationErrors()
+
+        self.validate_ips(verrors, options)
+
         iocage = ioc.IOCage(skip_jails=True)
 
         release = options["release"]
@@ -157,6 +165,23 @@ class JailService(CRUDService):
 
         return True
 
+    @private
+    def validate_ips(self, verrors, options):
+        for item in options['props']:
+            for f in ('ip4_addr', 'ip6_addr'):
+                if f in item:
+                    for ip in item.split('=')[1].split(','):
+                        try:
+                            IpInUse(self.middleware)(ip.split('|')[1].split('/')[0])
+                        except ShouldBe as e:
+                            verrors.add(
+                                f'fetch.props.{f}',
+                                str(e)
+                            )
+
+        if verrors:
+            raise verrors
+
     @accepts(Str("jail"), Dict(
              "options",
              Bool("plugin", default=False),
@@ -168,6 +193,10 @@ class JailService(CRUDService):
         _, _, iocage = self.check_jail_existence(jail)
 
         name = options.pop("name", None)
+
+        verrors = ValidationErrors()
+
+        self.validate_ips(verrors, {'props': [f'{k}={v}' for k, v in options.items()]})
 
         for prop, val in options.items():
             p = f"{prop}={val}"
@@ -238,6 +267,10 @@ class JailService(CRUDService):
     def fetch(self, job, options):
         """Fetches a release or plugin."""
         fetch_output = {'error': False, 'install_notes': []}
+
+        verrors = ValidationErrors()
+
+        self.validate_ips(verrors, options)
 
         def progress_callback(content):
             level = content['level']

--- a/src/middlewared/middlewared/validators.py
+++ b/src/middlewared/middlewared/validators.py
@@ -130,5 +130,5 @@ class IpInUse:
 
         if ip in ips:
             raise ShouldBe(
-                f'{ip} is already being used by the FreeNAS system. Please select another IP'
+                f'{ip} is already being used by the system. Please select another IP'
             )

--- a/src/middlewared/middlewared/validators.py
+++ b/src/middlewared/middlewared/validators.py
@@ -111,3 +111,24 @@ class Port:
     def __call__(self, value):
         range_validator = Range(min=1, max=65535)
         range_validator(value)
+
+
+class IpInUse:
+    def __init__(self, middleware):
+        self.middleware = middleware
+
+    def __call__(self, ip):
+        IpAddress()(ip)
+
+        # ip is valid
+        ips = [
+            v.split('|')[1].split('/')[0] for jail in self.middleware.call_sync('jail.query')
+            for j_ip in [jail['ip4_addr'], jail['ip6_addr']] for v in j_ip.split(',') if j_ip != 'none'
+        ] + [
+            d['address'] for d in self.middleware.call_sync('interfaces.ip_in_use')
+        ]
+
+        if ip in ips:
+            raise ShouldBe(
+                f'{ip} is already being used by the FreeNAS system. Please select another IP'
+            )

--- a/src/middlewared/middlewared/validators.py
+++ b/src/middlewared/middlewared/validators.py
@@ -114,21 +114,23 @@ class Port:
 
 
 class IpInUse:
-    def __init__(self, middleware):
+    def __init__(self, middleware, exclude=None):
         self.middleware = middleware
+        self.exclude = exclude or []
 
     def __call__(self, ip):
         IpAddress()(ip)
 
         # ip is valid
-        ips = [
-            v.split('|')[1].split('/')[0] for jail in self.middleware.call_sync('jail.query')
-            for j_ip in [jail['ip4_addr'], jail['ip6_addr']] for v in j_ip.split(',') if j_ip != 'none'
-        ] + [
-            d['address'] for d in self.middleware.call_sync('interfaces.ip_in_use')
-        ]
+        if ip not in self.exclude:
+            ips = [
+                v.split('|')[1].split('/')[0] for jail in self.middleware.call_sync('jail.query')
+                for j_ip in [jail['ip4_addr'], jail['ip6_addr']] for v in j_ip.split(',') if j_ip != 'none'
+            ] + [
+                d['address'] for d in self.middleware.call_sync('interfaces.ip_in_use')
+            ]
 
-        if ip in ips:
-            raise ShouldBe(
-                f'{ip} is already being used by the system. Please select another IP'
-            )
+            if ip in ips:
+                raise ShouldBe(
+                    f'{ip} is already being used by the system. Please select another IP'
+                )


### PR DESCRIPTION
This commit ensures that when a jail/plugin is created/updated, the ip defined is not in use by any other service in the FreeNAS system.
Ticket: #40976