### PR TITLE
tkt-40460: Adjust destination path in mountpoints for jails

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -422,7 +422,7 @@ class JailService(CRUDService):
             )
 
         _list = iocage.fstab(action, source, destination, fstype, fsoptions,
-                             dump, _pass, index=index)
+                             dump, _pass, index=index, add_path=True)
 
         if action == "list":
             split_list = {}


### PR DESCRIPTION
This commits adds functionality which automatically adjusts the destination path wrt jails root directory. It prepends the system path's till jails root directory meaning that the end user will only specify the path starting from root directory of jail.
Ticket: #40460