### PR TITLE
tkt-40548: fix(jails/fstab): Don't allow adding mount to a running jail

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -446,10 +446,13 @@ class JailService(CRUDService):
             Int("index", default=None),
         ))
     def fstab(self, jail, options):
-        """
-        Adds an fstab mount to the jail, mounts if the jail is running.
-        """
-        _, _, iocage = self.check_jail_existence(jail, skip=False)
+        """Adds an fstab mount to the jail"""
+        uuid, _, iocage = self.check_jail_existence(jail, skip=False)
+        status, jid = IOCList.list_get_jid(uuid)
+
+        if status:
+            raise CallError(
+                f'{jail} should not be running when adding a mountpoint')
 
         action = options["action"].lower()
         source = options["source"]


### PR DESCRIPTION
This can be reevaluated later.

Ticket: #40548