### PR TITLE
tkt-42257 - keep AD in configured state even if service start fails

### DIFF
--- a/src/freenas/etc/directoryservice/ActiveDirectory/ctl
+++ b/src/freenas/etc/directoryservice/ActiveDirectory/ctl
@@ -81,7 +81,7 @@ adctl_start()
 
 	if ! AD_init
 	then
-		activedirectory_set 1 
+		activedirectory_set 1
 	        srv_set cifs 1
 	        rm "${start_file}"
 		return 1

--- a/src/freenas/etc/directoryservice/ActiveDirectory/ctl
+++ b/src/freenas/etc/directoryservice/ActiveDirectory/ctl
@@ -81,7 +81,8 @@ adctl_start()
 
 	if ! AD_init
 	then
-		activedirectory_set 0
+		activedirectory_set 1 
+	        srv_set cifs 1
 	        rm "${start_file}"
 		return 1
 	fi
@@ -111,7 +112,6 @@ adctl_start()
 	adctl_cmd ${service} ix-kinit quietstart
 	if ! adctl_cmd ${service} ix-kinit status
 	then
-		activedirectory_set 0
 	        rm "${start_file}"
 		return 1
 	fi
@@ -131,13 +131,11 @@ adctl_start()
 
 	if ! adctl_cmd ${service} ix-activedirectory quietstart
 	then
-		activedirectory_set 0
 	        rm "${start_file}"
 		return 1
 	fi
 	if ! adctl_cmd ${service} ix-activedirectory status
 	then
-		activedirectory_set 0
 	        rm "${start_file}"
 		return 1
 	fi

--- a/src/freenas/etc/ix.rc.d/ix-activedirectory
+++ b/src/freenas/etc/ix.rc.d/ix-activedirectory
@@ -192,7 +192,6 @@ activedirectory_start()
 			AD_log "activedirectory_start: trying to join domain"
 			if ! AD_join_domain
 			then
-				/etc/directoryservice/ActiveDirectory/ctl stop
 				touch /tmp/.adalert
 				return 1
 			else

--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -798,11 +798,14 @@ def add_activedirectory_conf(client, smb4_conf):
         pass
 
     ad_workgroup = None
+
+    # First try to get the workgroup from LDAP. If that fails, automatically generate based on ad_domainname
+    # This is to allow us to generate a functional config even if a DC isn't available when we're generating the config
     try:
         fad = Struct(client.call('notifier.directoryservice', 'AD'))
         ad_workgroup = fad.netbiosname.upper()
     except Exception as e:
-        return
+        ad_workgroup = ad.ad_domainname.upper().split(".")[0]
 
     confset2(smb4_conf, "workgroup = %s", ad_workgroup)
     confset2(smb4_conf, "realm = %s", ad.ad_domainname.upper())


### PR DESCRIPTION
Improve stability of AD service by not getting in the way of winbind connection manager. If we come up in a configured state with Samba running (even if domain status is offline), there is a good chance that service will be restored fairly promptly once the domain comes online.