### PR TITLE
tkt-42048: Rsync bug fix

### DIFF
--- a/src/middlewared/middlewared/plugins/rsync.py
+++ b/src/middlewared/middlewared/plugins/rsync.py
@@ -445,7 +445,8 @@ class RsyncTaskService(CRUDService):
                             remote_host,
                             port=remote_port,
                             username=remote_username,
-                            client_keys=key_files
+                            client_keys=key_files,
+                            known_hosts=None
                     ), timeout=5)) as conn:
 
                         await conn.run(f'test -d {remote_path}', check=True)


### PR DESCRIPTION
This commit fixes a bug in rsync plugin which made the validation for rsync fail. The issue stemmed from a probable asyncssh version upgrade which started checking for known hosts file via an environment variable which wasn't set when middlewared was running in daemon mode.
Ticket: #42048