### PR TITLE
tkt-43415: fix(middlewared): race condition on send_event

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -1063,7 +1063,7 @@ class Middleware(object):
 
         self.logger.trace(f'Sending event "{event_type}":{kwargs}')
 
-        for sessionid, wsclient in self.__wsclients.items():
+        for sessionid, wsclient in list(self.__wsclients.items()):
             try:
                 wsclient.send_event(name, event_type, **kwargs)
             except Exception:


### PR DESCRIPTION
send_event may traceback if its running between websocket open/close
connections.

Ticket:	#43415