### PR TITLE
tkt-41060: Bug fix for validation in jail plugin

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -426,21 +426,17 @@ class JailService(CRUDService):
         destination = options.get('destination')
         if destination:
             destination = f'/{destination}' if destination[0] != '/' else destination
-            dst = f'{self.get_iocroot()}/jails/{jail}/root{destination}'
-            if 'mnt' in destination:
-                verrors.add(
-                    'destination',
-                    'Destination should not include the jail path. '
-                    'e.g "/mnt/iocage/jails/btsync/root/" Path should be specified'
-                    'after /'
-                )
-            elif os.path.exists(dst):
-                if not os.path.isdir(dst):
+            dst = f'{self.get_iocroot()}/jails/{jail}/root'
+            if not dst in destination:
+                destination = f'{dst}{destination}'
+
+            if os.path.exists(destination):
+                if not os.path.isdir(destination):
                     verrors.add(
                         'destination',
                         'Destination is not a directory, please provide a valid destination'
                     )
-                elif os.listdir(dst):
+                elif os.listdir(destination):
                     verrors.add(
                         'destination',
                         'Destination directory should be empty'
@@ -460,16 +456,17 @@ class JailService(CRUDService):
         _pass = options.get('pass')
         index = options.get('index')
 
+        if action == 'replace' and index is None:
+            verrors.add(
+                'index',
+                'Index must not be None when replacing fstab entry'
+            )
+
         if verrors:
             raise verrors
 
-        if action == 'replace' and index is None:
-            raise ValueError(
-                "Index must not be None when replacing fstab entry"
-            )
-
         _list = iocage.fstab(action, source, destination, fstype, fsoptions,
-                             dump, _pass, index=index, add_path=True)
+                             dump, _pass, index=index)
 
         if action == "list":
             split_list = {}

--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -427,7 +427,7 @@ class JailService(CRUDService):
         if destination:
             destination = f'/{destination}' if destination[0] != '/' else destination
             dst = f'{self.get_iocroot()}/jails/{jail}/root'
-            if not dst in destination:
+            if dst not in destination:
                 destination = f'{dst}{destination}'
 
             if os.path.exists(destination):

--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -419,7 +419,7 @@ class JailService(CRUDService):
         if source:
             if not os.path.exists(source):
                 verrors.add(
-                    'source',
+                    'options.source',
                     'Provided path for source does not exist'
                 )
 
@@ -433,12 +433,12 @@ class JailService(CRUDService):
             if os.path.exists(destination):
                 if not os.path.isdir(destination):
                     verrors.add(
-                        'destination',
+                        'options.destination',
                         'Destination is not a directory, please provide a valid destination'
                     )
                 elif os.listdir(destination):
                     verrors.add(
-                        'destination',
+                        'options.destination',
                         'Destination directory should be empty'
                     )
 
@@ -446,7 +446,7 @@ class JailService(CRUDService):
             for f in options:
                 if not options.get(f) and f not in ('index',):
                     verrors.add(
-                        f,
+                        f'options.{f}',
                         'This field is required'
                     )
 
@@ -458,7 +458,7 @@ class JailService(CRUDService):
 
         if action == 'replace' and index is None:
             verrors.add(
-                'index',
+                'options.index',
                 'Index must not be None when replacing fstab entry'
             )
 


### PR DESCRIPTION
This commit fixes a bug which prevented valid destination paths to be rejected on validation while updating fstab of a jail.
Ticket: #41060