### PR TITLE
tkt-43767: rm(pbi): pbi daemon is no longer used

### DIFF
--- a/src/freenas/etc/rc.conf.local
+++ b/src/freenas/etc/rc.conf.local
@@ -807,8 +807,6 @@ _gen_conf()
 
 	if is_freenas; then
 		echo "ataidle_enable=\"YES\""
-		# Needed to use pbi repositories
-		echo "pbid_enable=\"YES\""
 		# Bug #7337 -- blacklist AMD systems for now
 		if /sbin/sysctl hw.model | grep -q AMD; then
 			echo "watchdogd_enable=\"NO\""


### PR DESCRIPTION
Old plugins no longer available for installation so thats not necessary
anymore.