### PR TITLE
tkt-43811: fix(middlewared): deadlock on thread pool

### DIFF
--- a/src/middlewared/middlewared/async_validators.py
+++ b/src/middlewared/middlewared/async_validators.py
@@ -26,7 +26,7 @@ async def resolve_hostname(middleware, verrors, name, hostname):
         except Exception:
             return False
 
-    result_future = middleware.run_in_io_thread(resolve_host_name_thread, hostname)
+    result_future = middleware.run_in_thread(resolve_host_name_thread, hostname)
     try:
         result = await asyncio.wait_for(result_future, 5, loop=asyncio.get_event_loop())
     except asyncio.futures.TimeoutError:

--- a/src/middlewared/middlewared/job.py
+++ b/src/middlewared/middlewared/job.py
@@ -389,7 +389,7 @@ class Job(object):
 
                 return excerpt
 
-            self.logs_excerpt = await self.middleware.run_in_io_thread(get_logs_excerpt)
+            self.logs_excerpt = await self.middleware.run_in_thread(get_logs_excerpt)
 
     async def __close_pipes(self):
         def close_pipes():
@@ -398,7 +398,7 @@ class Job(object):
             if self.pipes.output:
                 self.pipes.output.w.close()
 
-        await self.middleware.run_in_io_thread(close_pipes)
+        await self.middleware.run_in_thread(close_pipes)
 
     def __encode__(self):
         return {

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -190,7 +190,7 @@ class Application(object):
         else:
             async with self.middleware.crash_reporting_semaphore:
                 extra_log_files = (('/var/log/middlewared.log', 'middlewared_log'),)
-                await self.middleware.run_in_io_thread(
+                await self.middleware.run_in_thread(
                     self.middleware.crash_reporting.report,
                     exc_info,
                     None,
@@ -405,7 +405,7 @@ class FileApplication(object):
                 asyncio.run_coroutine_threadsafe(resp.write(read), loop=self.loop).result()
 
         try:
-            await self.middleware.run_in_io_thread(do_copy)
+            await self.middleware.run_in_thread(do_copy)
         finally:
             await self._cleanup_job(job_id)
 
@@ -486,9 +486,9 @@ class FileApplication(object):
             job = await self.middleware.call(data['method'], *(data.get('params') or []),
                                              pipes=Pipes(input=self.middleware.pipe()))
             try:
-                await self.middleware.run_in_io_thread(copy)
+                await self.middleware.run_in_thread(copy)
             finally:
-                await self.middleware.run_in_io_thread(job.pipes.input.w.close)
+                await self.middleware.run_in_thread(job.pipes.input.w.close)
         except CallError as e:
             if e.errno == CallError.ENOMETHOD:
                 status_code = 422
@@ -912,13 +912,22 @@ class Middleware(object):
         loop = asyncio.get_event_loop()
         return await loop.run_in_executor(pool, functools.partial(method, *args, **kwargs))
 
-    async def run_in_thread(self, method, *args, **kwargs):
+    async def _run_in_conn_threadpool(self, method, *args, **kwargs):
+        """
+        Threads to handle websocket connection are gated on `__threadpool`.
+        Any other calls should use `run_in_thread` as that launches its own thread
+        and does not cause deadlock waiting another thread to finish in the pool
+        (which could happen on the stack call, e.g.
+           service.foo calls something in using the thread pool and something also
+           uses the thread pool. If service.foo is called many times before each thread
+           finishes we will have a deadlock)
+        """
         return await self.run_in_executor(self.__threadpool, method, *args, **kwargs)
 
     async def run_in_proc(self, method, *args, **kwargs):
         return await self.run_in_executor(self.__procpool, method, *args, **kwargs)
 
-    async def run_in_io_thread(self, method, *args, **kwargs):
+    async def run_in_thread(self, method, *args, **kwargs):
         executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
         try:
             return await self.loop.run_in_executor(executor, functools.partial(method, *args, **kwargs))
@@ -928,7 +937,7 @@ class Middleware(object):
     def pipe(self):
         return Pipe(self)
 
-    async def _call(self, name, serviceobj, methodobj, params=None, app=None, pipes=None, io_thread=False):
+    async def _call(self, name, serviceobj, methodobj, params=None, app=None, pipes=None, io_thread=True):
 
         args = []
         if hasattr(methodobj, '_pass_app'):
@@ -972,9 +981,9 @@ class Middleware(object):
                 return await self.run_in_executor(tpool, methodobj, *args)
 
             if io_thread:
-                run_method = self.run_in_io_thread
-            else:
                 run_method = self.run_in_thread
+            else:
+                run_method = self._run_in_conn_threadpool
             return await run_method(methodobj, *args)
 
     async def _call_worker(self, serviceobj, name, *args, job=None):

--- a/src/middlewared/middlewared/pipe.py
+++ b/src/middlewared/middlewared/pipe.py
@@ -27,5 +27,5 @@ class Pipe:
         self.w = os.fdopen(w, "wb")
 
     async def close(self):
-        await self.middleware.run_in_io_thread(self.r.close)
-        await self.middleware.run_in_io_thread(self.w.close)
+        await self.middleware.run_in_thread(self.r.close)
+        await self.middleware.run_in_thread(self.w.close)

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -317,7 +317,7 @@ class UserService(CRUDService):
                     self.logger.warn(f"Failed to copy homedir: {e}")
                 set_home_mode()
 
-            asyncio.ensure_future(self.middleware.run_in_io_thread(do_home_copy))
+            asyncio.ensure_future(self.middleware.run_in_thread(do_home_copy))
         else:
             set_home_mode()
 

--- a/src/middlewared/middlewared/plugins/config.py
+++ b/src/middlewared/middlewared/plugins/config.py
@@ -35,7 +35,7 @@ class ConfigService(Service):
                 tar.add('/data/pwenc_secret', arcname='pwenc_secret')
 
         with open(filename, 'rb') as f:
-            await self.middleware.run_in_io_thread(shutil.copyfileobj, f, job.pipes.output.w)
+            await self.middleware.run_in_thread(shutil.copyfileobj, f, job.pipes.output.w)
 
         if bundle:
             os.remove(filename)
@@ -60,7 +60,7 @@ class ConfigService(Service):
                     if nreads > 10240:
                         # FIXME: transfer to a file on disk
                         raise ValueError('File is bigger than 10MiB')
-        await self.middleware.run_in_io_thread(read_write)
+        await self.middleware.run_in_thread(read_write)
         rv = await self.middleware.call('notifier.config_upload', filename)
         if not rv[0]:
             raise ValueError(rv[1])

--- a/src/middlewared/middlewared/plugins/crypto.py
+++ b/src/middlewared/middlewared/plugins/crypto.py
@@ -179,7 +179,7 @@ async def _validate_common_attributes(middleware, data, verrors, schema_name):
                 'Please provide a valid signing authority'
             )
 
-    await middleware.run_in_io_thread(
+    await middleware.run_in_thread(
         _validate_certificate_with_key, certificate, private_key, schema_name, verrors
     )
 
@@ -380,7 +380,7 @@ class CertificateService(CRUDService):
         if len(certificate_list) == 0:
             return None
         else:
-            return await self.middleware.run_in_io_thread(
+            return await self.middleware.run_in_thread(
                 self.fingerprint,
                 certificate_list[0]['certificate']
             )
@@ -560,7 +560,7 @@ class CertificateService(CRUDService):
         if verrors:
             raise verrors
 
-        data = await self.middleware.run_in_io_thread(
+        data = await self.middleware.run_in_thread(
             self.map_functions[data.pop('create_type')],
             data
         )
@@ -895,7 +895,7 @@ class CertificateAuthorityService(CRUDService):
         if verrors:
             raise verrors
 
-        data = await self.middleware.run_in_io_thread(
+        data = await self.middleware.run_in_thread(
             self.map_create_functions[data.pop('create_type')],
             data
         )
@@ -1123,7 +1123,7 @@ class CertificateAuthorityService(CRUDService):
 
         if data.pop('create_type', '') == 'CA_SIGN_CSR':
             data['ca_id'] = id
-            return await self.middleware.run_in_io_thread(
+            return await self.middleware.run_in_thread(
                 self.__ca_sign_csr,
                 data,
                 'certificate_authority_update'

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -175,7 +175,7 @@ class FilesystemService(Service):
             raise CallError(f'{path} is not a file')
 
         with open(path, 'rb') as f:
-            await self.middleware.run_in_io_thread(shutil.copyfileobj, f, job.pipes.output.w)
+            await self.middleware.run_in_thread(shutil.copyfileobj, f, job.pipes.output.w)
 
     @accepts(
         Str('path'),
@@ -200,7 +200,7 @@ class FilesystemService(Service):
             openmode = 'wb+'
 
         with open(path, openmode) as f:
-            await self.middleware.run_in_io_thread(shutil.copyfileobj, job.pipes.input.r, f)
+            await self.middleware.run_in_thread(shutil.copyfileobj, job.pipes.input.r, f)
 
         mode = options.get('mode')
         if mode:

--- a/src/middlewared/middlewared/plugins/ntp.py
+++ b/src/middlewared/middlewared/plugins/ntp.py
@@ -84,7 +84,7 @@ class NTPServerService(CRUDService):
         maxpoll = data['maxpoll']
         minpoll = data['minpoll']
         force = data.pop('force', False)
-        usable = True if await self.middleware.run_in_io_thread(
+        usable = True if await self.middleware.run_in_thread(
             self.test_ntp_server, data['address']) else False
 
         if not force and not usable:

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -289,7 +289,7 @@ class PoolService(CRUDService):
             filters.append(('id', '=', oid))
         for pool in await self.query(filters):
             if pool['is_decrypted']:
-                async for i in await self.middleware.call('zfs.pool.get_disks', pool['name']):
+                for i in await self.middleware.call('zfs.pool.get_disks', pool['name']):
                     yield i
             else:
                 for encrypted_disk in await self.middleware.call('datastore.query', 'storage.encrypteddisk',

--- a/src/middlewared/middlewared/plugins/support.py
+++ b/src/middlewared/middlewared/plugins/support.py
@@ -189,8 +189,8 @@ class SupportService(Service):
             tjob = await self.middleware.call('support.attach_ticket', t, pipes=Pipes(input=self.middleware.pipe()))
 
             with open(debug_file, 'rb') as f:
-                await self.middleware.run_in_io_thread(shutil.copyfileobj, f, tjob.pipes.input.w)
-                await self.middleware.run_in_io_thread(tjob.pipes.input.w.close)
+                await self.middleware.run_in_thread(shutil.copyfileobj, f, tjob.pipes.input.w)
+                await self.middleware.run_in_thread(tjob.pipes.input.w.close)
 
             await tjob.wait()
         else:
@@ -222,7 +222,7 @@ class SupportService(Service):
         filename = data.pop('filename')
 
         try:
-            r = await self.middleware.run_in_io_thread(lambda: requests.post(
+            r = await self.middleware.run_in_thread(lambda: requests.post(
                 f'https://{ADDRESS}/{sw_name}/api/v1.0/ticket/attachment',
                 data=data,
                 timeout=10,

--- a/src/middlewared/middlewared/plugins/update.py
+++ b/src/middlewared/middlewared/plugins/update.py
@@ -475,7 +475,7 @@ Changelog:
         try:
             job.set_progress(10, 'Writing uploaded file to disk')
             with open(destfile, 'wb') as f:
-                await self.middleware.run_in_io_thread(
+                await self.middleware.run_in_thread(
                     shutil.copyfileobj, job.pipes.input.r, f, 1048576,
                 )
 
@@ -488,7 +488,7 @@ Changelog:
                 except Exception as e:
                     raise CallError(str(e))
 
-            await self.middleware.run_in_io_thread(do_update)
+            await self.middleware.run_in_thread(do_update)
 
             job.set_progress(95, 'Cleaning up')
 

--- a/src/middlewared/middlewared/plugins/vcenter.py
+++ b/src/middlewared/middlewared/plugins/vcenter.py
@@ -91,7 +91,7 @@ class VCenterService(ConfigService):
             'certificate.get_host_certificates_thumbprint',
             new['management_ip'], new['port']
         )
-        plugin_file_name = await self.middleware.run_in_io_thread(
+        plugin_file_name = await self.middleware.run_in_thread(
             self.get_plugin_file_name
         )
         # TODO: URL will change once the plugin file's location is shifted
@@ -126,14 +126,14 @@ class VCenterService(ConfigService):
                     raise verrors
 
                 try:
-                    await self.middleware.run_in_io_thread(
+                    await self.middleware.run_in_thread(
                         self.__install_vcenter_plugin,
                         install_dict
                     )
                 except ValidationError as e:
                     verrors.add_validation_error(e)
                 else:
-                    new['version'] = await self.middleware.run_in_io_thread(self.get_plugin_version)
+                    new['version'] = await self.middleware.run_in_thread(self.get_plugin_version)
                     new['installed'] = True
 
         elif action == 'REPAIR':
@@ -153,7 +153,7 @@ class VCenterService(ConfigService):
                     credential_dict.pop('management_ip')
                     credential_dict.pop('fingerprint')
 
-                    found_plugin = await self.middleware.run_in_io_thread(
+                    found_plugin = await self.middleware.run_in_thread(
                         self._find_plugin,
                         credential_dict
                     )
@@ -172,7 +172,7 @@ class VCenterService(ConfigService):
                     try:
                         repair_dict = install_dict.copy()
                         repair_dict['install_mode'] = 'REPAIR'
-                        await self.middleware.run_in_io_thread(
+                        await self.middleware.run_in_thread(
                             self.__install_vcenter_plugin,
                             repair_dict
                         )
@@ -192,7 +192,7 @@ class VCenterService(ConfigService):
                     uninstall_dict = install_dict.copy()
                     uninstall_dict.pop('management_ip')
                     uninstall_dict.pop('fingerprint')
-                    await self.middleware.run_in_io_thread(
+                    await self.middleware.run_in_thread(
                         self.__uninstall_vcenter_plugin,
                         uninstall_dict
                     )
@@ -221,14 +221,14 @@ class VCenterService(ConfigService):
             else:
 
                 try:
-                    await self.middleware.run_in_io_thread(
+                    await self.middleware.run_in_thread(
                         self.__upgrade_vcenter_plugin,
                         install_dict
                     )
                 except ValidationError as e:
                     verrors.add_validation_error(e)
                 else:
-                    new['version'] = await self.middleware.run_in_io_thread(self.get_plugin_version)
+                    new['version'] = await self.middleware.run_in_thread(self.get_plugin_version)
 
         if verrors:
             raise verrors
@@ -247,7 +247,7 @@ class VCenterService(ConfigService):
 
     @private
     async def is_update_available(self):
-        latest_version = await self.middleware.run_in_io_thread(self.get_plugin_version)
+        latest_version = await self.middleware.run_in_thread(self.get_plugin_version)
         current_version = (await self.config())['version']
         return latest_version if current_version and \
                                  parse_version(latest_version) > parse_version(current_version) else None

--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -1177,25 +1177,25 @@ class VMService(CRUDService):
 
     @accepts(Str('vmOS'), Bool('force', default=False))
     @job(lock='container')
-    async def fetch_image(self, job, vmOS, force=False):
+    def fetch_image(self, job, vmOS, force=False):
         """Download a pre-built image for bhyve"""
         vm_os = CONTAINER_IMAGES.get(vmOS)
         url = vm_os['URL']
 
         self.logger.debug('==> IMAGE: {0}'.format(vm_os))
 
-        sharefs = await self.middleware.call('vm.get_sharefs')
+        sharefs = self.middleware.call_sync('vm.get_sharefs')
         vm_os_file = vm_os['GZIPFILE']
         iso_path = sharefs + '/iso_files/'
         file_path = iso_path + vm_os_file
 
         if os.path.exists(file_path) is False and force is False:
             logger.debug('===> Downloading: %s' % (url))
-            await self.middleware.run_in_thread(lambda: urlretrieve(
+            urlretrieve(
                 url,
                 file_path,
                 lambda nb, bs, fs, job=job: self.fetch_hookreport(nb, bs, fs, job, file_path)
-            ))
+            )
 
     @accepts()
     async def list_images(self):

--- a/src/middlewared/middlewared/plugins/vmware.py
+++ b/src/middlewared/middlewared/plugins/vmware.py
@@ -38,7 +38,7 @@ class VMWareService(CRUDService):
 
         datastore = data.get('datastore')
         try:
-            ds = await self.middleware.run_in_io_thread(
+            ds = await self.middleware.run_in_thread(
                 self.get_datastores,
                 {
                     'hostname': data.get('hostname'),

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -62,14 +62,14 @@ class ZFSPoolService(Service):
         return filter_list(pools, filters, options)
 
     @accepts(Str('pool'))
-    async def get_disks(self, name):
+    def get_disks(self, name):
         try:
             with libzfs.ZFS() as zfs:
                 disks = list(zfs.get(name).disks)
         except libzfs.ZFSException as e:
             raise CallError(str(e), errno.ENOENT)
 
-        await self.middleware.run_in_thread(geom.scan)
+        geom.scan()
         labelclass = geom.class_by_name('LABEL')
         for absdev in disks:
             dev = absdev.replace('/dev/', '').replace('.eli', '')

--- a/src/middlewared/middlewared/rclone/remote/s3.py
+++ b/src/middlewared/middlewared/rclone/remote/s3.py
@@ -34,8 +34,9 @@ class S3RcloneRemote(BaseRcloneRemote):
         if task["attributes"]["encryption"] not in (None, "", "AES256"):
             verrors.add("encryption", 'Encryption should be null or "AES256"')
 
-        response = await self.middleware.run_in_io_thread(self._get_client(credentials).get_bucket_location,
-                                                          Bucket=task["attributes"]["bucket"])
+        response = await self.middleware.run_in_thread(
+            self._get_client(credentials).get_bucket_location, Bucket=task["attributes"]["bucket"]
+        )
         task["attributes"]["region"] = response["LocationConstraint"] or "us-east-1"
 
     def get_remote_extra(self, task):

--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -265,7 +265,7 @@ class CRUDService(ServiceChangeMixin, Service):
             result = await self.middleware.call(
                 'datastore.query', self._config.datastore, [], datastore_options
             )
-            return await self.middleware.run_in_io_thread(
+            return await self.middleware.run_in_thread(
                 filter_list, result, filters, options
             )
         else:

--- a/src/middlewared/middlewared/utils/__init__.py
+++ b/src/middlewared/middlewared/utils/__init__.py
@@ -20,7 +20,7 @@ BUILDTIME = None
 VERSION = None
 
 
-async def django_modelobj_serialize(middleware, obj, extend=None, field_prefix=None):
+def django_modelobj_serialize(middleware, obj, extend=None, field_prefix=None):
     from django.db.models.fields.related import ForeignKey, ManyToManyField
     from freenasUI.contrib.IPAddressField import (
         IPAddressField, IP4AddressField, IP6AddressField
@@ -43,15 +43,15 @@ async def django_modelobj_serialize(middleware, obj, extend=None, field_prefix=N
         )):
             data[name] = str(value)
         elif isinstance(field, ForeignKey):
-            data[name] = await django_modelobj_serialize(middleware, value) if value is not None else value
+            data[name] = django_modelobj_serialize(middleware, value) if value is not None else value
         elif isinstance(field, ManyToManyField):
             data[name] = []
             for o in value.all():
-                data[name].append((await django_modelobj_serialize(middleware, o)))
+                data[name].append(django_modelobj_serialize(middleware, o))
         else:
             data[name] = value
     if extend:
-        data = await middleware.call(extend, data)
+        data = middleware.call_sync(extend, data)
     return data
 
 


### PR DESCRIPTION
Threads to handle websocket connection are gated on `__threadpool`.
Any other calls should use `run_in_io_thread` as that launches its own thread
and does not cause deadlock waiting another thread to finish in the pool
(which could happen on the stack call, e.g.
   service.foo calls something in using the thread pool and something also
   uses the thread pool. If service.foo is called many times before each thread
   finishes we will have a deadlock)

Ticket:	#43811