### PR TITLE
tkt-43712: drop server min protocol to SMB2_02

### DIFF
--- a/src/freenas-sysctl/services.c
+++ b/src/freenas-sysctl/services.c
@@ -327,7 +327,7 @@ services_init(void)
 		FAILRET("Failed to add smb timeout node.\n", -1);
 	}
 
-	g_services->smb.config.server_min_protocol = SMB2;
+	g_services->smb.config.server_min_protocol = SMB2_02;
 	g_services->smb.config.server_max_protocol = SMB3;
 	g_services->smb.config.server_multi_channel = 0;
 


### PR DESCRIPTION
Server 2008 SP2 is still under extended support from MS until 1/14/2020. Adjust min protocol accordingly.