### PR TITLE
tkt-37990: Bug fix for Menu link in Legacy UI

### DIFF
--- a/gui/freeadmin/static/lib/js/freeadmin/Menu.js
+++ b/gui/freeadmin/static/lib/js/freeadmin/Menu.js
@@ -29,7 +29,7 @@ define([
                     if(tabnet) {
                         var c2 = tabnet.getChildren();
                         for(var j=0; j<c2.length; j++){
-                            if(c2[j].domNode.getAttribute("tab") == tab)
+                            if(c2[j].domNode.getAttribute("tab").split(".").slice(1).join(".") == tab.split(".").slice(1).join("."))
                                 tabnet.selectChild(c2[j]);
                         }
                     }

--- a/gui/freeadmin/static/lib/js/freeadmin/Menu.js
+++ b/gui/freeadmin/static/lib/js/freeadmin/Menu.js
@@ -29,7 +29,7 @@ define([
                     if(tabnet) {
                         var c2 = tabnet.getChildren();
                         for(var j=0; j<c2.length; j++){
-                            if(c2[j].domNode.getAttribute("tab").split(".").slice(1).join(".") == tab.split(".").slice(1).join("."))
+                            if(c2[j].domNode.getAttribute("tab") == tab)
                                 tabnet.selectChild(c2[j]);
                         }
                     }

--- a/gui/system/hook.py
+++ b/gui/system/hook.py
@@ -121,7 +121,7 @@ class SystemHook(AppHook):
 
             tabs.insert(14, {
                 'name': 'ViewEnclosure',
-                'focus': 'storage.ViewEnclosure',
+                'focus': 'system.ViewEnclosure',
                 'verbose_name': _('View Enclosure'),
                 'url': reverse('storage_enclosure_status'),
             })


### PR DESCRIPTION
This commit fixes a bug where context was being taken into account for a menu link under System ( View Enclosure ). The value of the tab should've been 'storage.ViewEnclosure', however as it was placed under the System tree, it's value was 'system.ViewEnclosure'. This commit does a context free comparision for children of settings tree.
Ticket: #37990