### PR TITLE
tkt-37990: Bug fix for Menu Link in Legacy - Master

### DIFF
--- a/gui/system/hook.py
+++ b/gui/system/hook.py
@@ -123,7 +123,7 @@ class SystemHook(AppHook):
 
             tabs.insert(15, {
                 'name': 'ViewEnclosure',
-                'focus': 'storage.ViewEnclosure',
+                'focus': 'system.ViewEnclosure',
                 'verbose_name': _('View Enclosure'),
                 'url': reverse('storage_enclosure_status'),
             })


### PR DESCRIPTION
This commit fixes a bug where view enclosure couldn't be opened from the left hand menu in legacy UI ( TrueNAS ).
Ticket: #37990