### PR TITLE
tkt-43932: HOSTSYNC exposed in Upsmon.conf

### DIFF
--- a/gui/freeadmin/static/lib/js/freeadmin.js
+++ b/gui/freeadmin/static/lib/js/freeadmin.js
@@ -1825,6 +1825,7 @@ require([
         var e = registry.byId("id_ups_extrausers");
         var m = registry.byId("id_ups_rmonitor");
         var o = registry.byId("id_ups_options");
+        var h = registry.byId("id_ups_hostsync");
         var trh = rh.domNode.parentNode.parentNode;
         var trp = rp.domNode.parentNode.parentNode;
         var td = d.domNode.parentNode.parentNode;
@@ -1832,6 +1833,7 @@ require([
         var te = e.domNode.parentNode.parentNode;
         var tm = m.domNode.parentNode.parentNode;
         var to = o.domNode.parentNode.parentNode;
+        var th = h.domNode.parentNode.parentNode;
         if(select.get('value') == 'master') {
             domStyle.set(trh, "display", "none");
             domStyle.set(trp, "display", "none");
@@ -1840,6 +1842,7 @@ require([
             domStyle.set(te, "display", "table-row");
             domStyle.set(tm, "display", "table-row");
             domStyle.set(to, "display", "table-row");
+            domStyle.set(th, "display", "table-row");
         } else {
             domStyle.set(trp, "display", "table-row");
             domStyle.set(trh, "display", "table-row");
@@ -1849,6 +1852,7 @@ require([
             domStyle.set(te, "display", "none");
             domStyle.set(tm, "display", "none");
             domStyle.set(to, "display", "none");
+            domStyle.set(th, "display", "none");
         }
 
     }

--- a/gui/services/migrations/0021_add_ups_hostsync_field.py
+++ b/gui/services/migrations/0021_add_ups_hostsync_field.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('services', '0020_make_lunid_non_null'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='ups',
+            name='ups_hostsync',
+            field=models.IntegerField(
+                default=15,
+                verbose_name='Host Sync',
+                help_text='Upsmon will wait up to this many seconds in master '
+                          'mode for the slaves to disconnect during a shutdown situation'
+            ),
+        )
+    ]

--- a/gui/services/models.py
+++ b/gui/services/models.py
@@ -1305,6 +1305,14 @@ class UPS(Model):
         help_text=_("Signal the UPS to power off after FreeNAS shuts down."),
         default=True,
     )
+    ups_hostsync = models.IntegerField(
+        default=15,
+        verbose_name=_("Host Sync"),
+        help_text=_(
+            "Upsmon will wait up to this many seconds in master mode "
+            "for the slaves to disconnect during a shutdown situation"
+        )
+    )
 
     def __init__(self, *args, **kwargs):
         super(UPS, self).__init__(*args, **kwargs)

--- a/src/freenas/etc/ix.rc.d/ix-ups
+++ b/src/freenas/etc/ix.rc.d/ix-ups
@@ -45,7 +45,7 @@ EOF
 generate_upsmon()
 {
     local IFS="|"
-    local f="ups_mode ups_remotehost ups_remoteport ups_monuser ups_monpwd ups_identifier ups_shutdown ups_shutdowntimer ups_shutdowncmd ups_nocommwarntime ups_emailnotify ups_toemail ups_subject ups_powerdown"
+    local f="ups_mode ups_remotehost ups_remoteport ups_monuser ups_monpwd ups_identifier ups_shutdown ups_shutdowntimer ups_shutdowncmd ups_nocommwarntime ups_emailnotify ups_toemail ups_subject ups_powerdown ups_hostsync"
     eval local $f
     local sf=$(var_to_sf $f)
     local user passwd ident powerdown
@@ -85,6 +85,7 @@ NOTIFYFLAG FSD SYSLOG+EXEC
 NOTIFYFLAG SHUTDOWN SYSLOG+EXEC
 SHUTDOWNCMD "${ups_shutdowncmd}"
 POWERDOWNFLAG ${powerdown}
+HOSTSYNC ${ups_hostsync}
 EOF
 
 		if [ -n "${ups_nocommwarntime}" ]; then

--- a/src/middlewared/middlewared/plugins/ups.py
+++ b/src/middlewared/middlewared/plugins/ups.py
@@ -6,7 +6,7 @@ import re
 
 from middlewared.schema import accepts, Bool, Dict, Int, List, Str
 from middlewared.service import private, SystemServiceService, ValidationErrors
-from middlewared.validators import Email
+from middlewared.validators import Email, Range
 
 
 DRIVER_BIN_DIR = '/usr/local/libexec/nut'
@@ -123,9 +123,10 @@ class UPSService(SystemServiceService):
             Bool('emailnotify'),
             Bool('powerdown'),
             Bool('rmonitor'),
-            Int('nocommwarntime'),
+            Int('nocommwarntime', null=True),
             Int('remoteport'),
             Int('shutdowntimer'),
+            Int('hostsync', validators=[Range(min=0)]),
             Str('description'),
             Str('driver'),
             Str('extrausers'),
@@ -141,7 +142,6 @@ class UPSService(SystemServiceService):
             Str('shutdowncmd'),
             Str('subject'),
             List('toemail', items=[Str('email', validators=[Email()])]),
-            update=True
         )
     )
     async def do_update(self, data):

--- a/src/middlewared/middlewared/plugins/ups.py
+++ b/src/middlewared/middlewared/plugins/ups.py
@@ -142,6 +142,7 @@ class UPSService(SystemServiceService):
             Str('shutdowncmd'),
             Str('subject'),
             List('toemail', items=[Str('email', validators=[Email()])]),
+            update=True
         )
     )
     async def do_update(self, data):


### PR DESCRIPTION
This commit exposes the variable 'HOSTSYNC' in upsmon.conf file. It makes sure that the option is exposed in legacy UI as well and is configurable in ups service configuration.
Ticket: #43932