### PR TITLE
tkt-45343: Enhance mountpoints operation in jails plugin

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -524,6 +524,8 @@ class JailService(CRUDService):
                         'options.destination',
                         'Destination directory should be empty'
                     )
+            else:
+                os.makedirs(destination)
 
             # fstab hates spaces ;)
             destination = destination.replace(' ', r'\040')


### PR DESCRIPTION
This commit makes sure that if a path doesn't exist when adding a mount point, middlewared creates it and it is ensured that the destination path exists when a mount point is finally added by iocage.
Ticket: #45343