### PR TITLE
tkt-45875: Bug fix for validating paths

### DIFF
--- a/src/middlewared/middlewared/async_validators.py
+++ b/src/middlewared/middlewared/async_validators.py
@@ -9,7 +9,9 @@ from middlewared.validators import ShouldBe, IpAddress
 async def check_path_resides_within_volume(verrors, middleware, name, path):
     vol_names = [vol["vol_name"] for vol in await middleware.call("datastore.query", "storage.volume")]
     vol_paths = [os.path.join("/mnt", vol_name) for vol_name in vol_names]
-    if not any(os.path.commonpath([parent]) == os.path.commonpath([parent, path]) for parent in vol_paths):
+    if not path.startswith("/mnt/") or not any(
+            os.path.commonpath([parent]) == os.path.commonpath([parent, path]) for parent in vol_paths
+    ):
         verrors.add(name, "The path must reside within a volume mount point")
 
 

--- a/src/middlewared/middlewared/plugins/iscsi.py
+++ b/src/middlewared/middlewared/plugins/iscsi.py
@@ -582,8 +582,9 @@ class iSCSITargetExtentService(CRUDService):
                 verrors.add(f'{schema_name}.path',
                             'You need to specify a filepath not a directory')
 
-            await check_path_resides_within_volume(verrors, self.middleware,
-                                                   schema_name, path)
+            await check_path_resides_within_volume(
+                verrors, self.middleware, f'{schema_name}.path', path
+            )
 
         return data
 


### PR DESCRIPTION
This commit fixes a bug which resulted in a traceback when an incorrect path was specified to check_path_resides_within_volume async validator. An incorrect path is defined as a path which didn't start off with /mnt/.
Ticket: #45875