### PR TITLE
tkt-27236: fix(migrate_warden): Fixes lots of behavior in the migration

### DIFF
--- a/src/freenas/usr/local/sbin/migrate_warden.py
+++ b/src/freenas/usr/local/sbin/migrate_warden.py
@@ -36,6 +36,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 import libzfs
 import shutil
+import pathlib
 from middlewared.client import Client, ClientException
 
 
@@ -161,15 +162,18 @@ class Migrate(object):
 
     async def migrate_jail(self):
         files = {
-            "name":        "host",
-            "ip4_addr":    "ipv4",
-            "ip6_addr":    "ipv6",
-            "mac":         "mac",
+            "name": "host",
+            "ip4_addr": "ipv4",
+            "ip6_addr": "ipv6",
+            "mac": "mac",
             "allow_props": "jail-flags",
-            "warden_id":   "id",
-            "vnet":        "vnet",
-            "boot":        "autostart",
-            "nat":         "nat"
+            "warden_id": "id",
+            "vnet": "vnet",
+            "boot": "autostart",
+            "nat": "nat",
+            "release": "jailtype",
+            "defaultrouter4": "defaultrouter-ipv4",
+            "defaultrouter6": "defaultrouter-ipv6"
         }
 
         pool_exists = self.ZFS.pool_exists()
@@ -186,6 +190,7 @@ class Migrate(object):
                   " first.")
             return
 
+        iocroot = self.zfs.get_dataset(f"{self.pool}/iocage").mountpoint
         props = {}
 
         for ioc_prop, warden_prop in files.items():
@@ -207,7 +212,7 @@ class Migrate(object):
             print(f"  {self.jail} is running, please stop it first.")
             return
 
-        self.create_jail(props)
+        self.create_jail(props, iocroot)
 
         await asyncio.gather(
             asyncio.ensure_future(self.loop.run_in_executor(
@@ -230,7 +235,9 @@ class Migrate(object):
         )
 
         self.warden_dataset.destroy_snapshot(f"WardenMigration_{self.date}")
-        self.copy_fstab()
+
+        self.copy_fstab(iocroot)
+        self.fixup_fstab(iocroot)
 
     def is_jail_running(self):
         """
@@ -279,36 +286,59 @@ class Migrate(object):
     def activate_pool(self):
         su.check_call(["iocage", "activate", self.pool], stdout=su.PIPE)
 
-    def create_jail(self, props):
+    def create_jail(self, props, iocroot):
         name = props["name"]
         ip4 = props.get("ip4_addr", "none")
         ip6 = props.get("ip6_addr", "none")
-        mac = props.get("mac", "none")
+        mac = props.get("mac", "none").replace(':', '')
         vnet = props.get("vnet", "off")
         warden_id = props.get("warden_id", "none")
         boot = props.get("boot", "off")
         sysctls = props.get("allow_props", "")
+        release = props['release']
+        defaultrouter4 = props.get('defaultrouter4', "none")
+        defaultrouter6 = props.get('defaultrouter6', "none")
 
         cmd = ["iocage", "create", "-n", name, "-e",
                f"notes=warden_id={warden_id}"] + sysctls.split()
 
         if vnet == "on":
-            # Warden only uses one mac, we use two for iocage.
-            cmd += ["vnet=on", f"ip4_addr=vnet0|{ip4}", f"ip6_addr=vnet0|{ip6}",
-                    f"vnet0_mac={mac},{mac}"]
+            ip6_addr = f'vnet0|{ip6}' if ip6 != 'none' else 'none'
+            ip4_addr = f'vnet0|{ip4}' if ip4 != 'none' else 'none'
+
+            if mac != 'none':
+                # Warden only uses one mac, we use two for iocage.
+                mac_a = int(mac, 16)
+                mac_b = mac_a + 1
+                vnet0_mac = f'{mac_a:012x},{mac_b:012x}'
+            else:
+                vnet0_mac = 'none'
+
+            cmd += ['vnet=on', f'ip4_addr={ip4_addr}', f'ip6_addr={ip6_addr}',
+                    f'vnet0_mac={vnet0_mac}',
+                    f'defaultrouter={defaultrouter4}',
+                    f'defaultrouter6={defaultrouter6}']
         else:
             # iocage allows non-interface only for non-vnet
-            cmd += [f"ip4_addr={ip4}", f"ip6_addr={ip6}"]
+            cmd += [f'ip4_addr={ip4}', f'ip6_addr={ip6}']
 
         su.check_call(cmd, stdout=su.PIPE)
+
+        with open(f'{iocroot}/jails/{name}/config.json', 'r') as config:
+            config = json.load(config)
 
         # If we don't do this after, iocage will try to start the 'nonexistent'
         # jail.
         if boot == "on":
-            su.check_call(["iocage", "set", "boot=on", name], stdout=su.PIPE)
+            config['boot'] = 'on'
 
-    def copy_fstab(self):
-        iocroot = self.zfs.get_dataset(f"{self.pool}/iocage").mountpoint
+        config['release'] = release
+
+        with open(f'{iocroot}/jails/{name}/config.json', 'w') as out:
+            json.dump(config, out, sort_keys=True, indent=4,
+                      ensure_ascii=False)
+
+    def copy_fstab(self, iocroot):
         try:
             os.remove(f"{iocroot}/jails/{self.jail}/fstab")
         except FileNotFoundError:
@@ -316,6 +346,22 @@ class Migrate(object):
             pass
 
         shutil.copy(f"{self.meta}/fstab", f"{iocroot}/jails/{self.jail}/fstab")
+
+    def fixup_fstab(self, iocroot):
+        with open(f"{self.meta}/fstab", 'r') as _fstab:
+            with open(f"{iocroot}/jails/{self.jail}/fstab", 'w') as fstab:
+                for line in _fstab:
+                    line = line.replace(f'{self.dataset}/',
+                                        f'{iocroot}/jails/{self.jail}/root')
+                    # This needs to exist now
+                    fstab_dest = line.rsplit(f'{iocroot}/jails/{self.jail}',
+                                             1)[-1].split()[0]
+                    destination = f'{iocroot}/jails/' \
+                        f'{self.jail}/root{fstab_dest}'
+                    pathlib.Path(
+                        destination).mkdir(parents=True, exist_ok=True)
+
+                    fstab.write(line)
 
 
 async def main(argv, loop):


### PR DESCRIPTION
- Don't use EMPTY for jail RELEASE
- Fix destinations in fstab and create destination directories if they don't exist
- Migrate defaultrouter for ipv4 and ipv6
- Create proper mac addresses for migration and correctly iterate onto the next one for the second address that iocage uses
- Do not add vnet0|none for VNET IP variants that don't have an IP address
- Optimize setting boot=on

Requires iocage ticket #46245 as migrated shared IP jails without an interface currently will not have working network.

Ticket: #27236