### PR TITLE
tkt-45761: fix(plugins): Return N/A for version if the database doesn't exist

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -793,7 +793,7 @@ class JailService(CRUDService):
                 if primary_pkg == row[1] or primary_pkg == row[2]:
                     version = [row[3], '1']
                     break
-        except KeyError:
+        except (KeyError, sqlite3.OperationalError):
             version = ['N/A', 'N/A']
 
         return version


### PR DESCRIPTION
This shouldn't happen, *knock on wood* but since it sometimes does, let's not make it fatal.