### PR TITLE
tkt-46854: Fix system.ready never being true if middleware restarts

### DIFF
--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -178,4 +178,8 @@ async def _event_system_ready(middleware, event_type, args):
 
 
 def setup(middleware):
+    global SYSTEM_READY
+    if os.path.exists("/tmp/.bootready"):
+        SYSTEM_READY = True
+
     middleware.event_subscribe('system', _event_system_ready)


### PR DESCRIPTION
(cherry picked from commit fcb9929053767e40b02113660792efcb447e05a4)