### PR TITLE
tkt-46997: fix(middlewared): lazy import freenasOS to avoid double logging config

### DIFF
--- a/src/middlewared/middlewared/utils/__init__.py
+++ b/src/middlewared/middlewared/utils/__init__.py
@@ -12,9 +12,9 @@ from functools import wraps
 from threading import Lock
 
 
+# For freenasOS
 if '/usr/local/lib' not in sys.path:
     sys.path.append('/usr/local/lib')
-from freenasOS import Configuration
 
 BUILDTIME = None
 VERSION = None
@@ -185,6 +185,8 @@ def filter_list(_list, filters=None, options=None):
 
 
 def sw_buildtime():
+    # Lazy import to avoid freenasOS configure logging for us
+    from freenasOS import Configuration
     global BUILDTIME
     if BUILDTIME is None:
         conf = Configuration.Configuration()
@@ -195,6 +197,8 @@ def sw_buildtime():
 
 
 def sw_version():
+    # Lazy import to avoid freenasOS configure logging for us
+    from freenasOS import Configuration
     global VERSION
     if VERSION is None:
         conf = Configuration.Configuration()
@@ -205,6 +209,8 @@ def sw_version():
 
 
 def sw_version_is_stable():
+    # Lazy import to avoid freenasOS configure logging for us
+    from freenasOS import Configuration
     conf = Configuration.Configuration()
     train = conf.CurrentTrain()
     if train and 'stable' in train.lower():


### PR DESCRIPTION
freenasOS init will configure logging on its own if no handlers are
found. Lazy importing it will avoid that issue since at that point
middlewared logging will be configured already.