### PR TITLE
fix(master) remove f_not_consul program filter from syslog-ng.conf

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-syslogd
+++ b/src/freenas/etc/ix.rc.d/ix-syslogd
@@ -97,7 +97,7 @@ destination(other_controller_file);
 destination other_controller_file { file("$controller_file"); };
 destination other_controller { udp("$controller_other_ip" port($controller_port)); };
 
-log { source(src); filter(f_not_mdnsresponder); filter(f_not_nginx); filter(f_not_consul); destination(other_controller); };
+log { source(src); filter(f_not_mdnsresponder); filter(f_not_nginx); destination(other_controller); };
 _EOF_
 } >> /etc/local/syslog-ng.conf
 


### PR DESCRIPTION
commit d333dcc7f368035f3c9a239274edd4e1dd333287 removed the consul alerting service from syslog-ng.

commit e7a7ab8333add24d81cc7a08c8267bcf3ee8b36f added the ability to use syslog-ng to log across the heartbeat interface on TrueNAS HA appliances. I added the "f_not_consul" filter to that change.

Simply remove that program filter altogether since the consul facility was removed altogether.

#47096