### PR TITLE
tkt-42581: Fix for failed ip validation

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -274,7 +274,7 @@ class JailService(CRUDService):
             exclude_ips = [
                 ip.split('|')[1].split('/')[0] if '|' in ip else ip.split('/')[0]
                 for f in ('ip4_addr', 'ip6_addr') for ip in jail[f].split(',')
-                if ip != 'none'
+                if ip not in ('none', 'DHCP (not running)')
             ]
 
             self.validate_ips(

--- a/src/middlewared/middlewared/validators.py
+++ b/src/middlewared/middlewared/validators.py
@@ -124,8 +124,9 @@ class IpInUse:
         # ip is valid
         if ip not in self.exclude:
             ips = [
-                v.split('|')[1].split('/')[0] for jail in self.middleware.call_sync('jail.query')
-                for j_ip in [jail['ip4_addr'], jail['ip6_addr']] for v in j_ip.split(',') if j_ip != 'none'
+                v.split('|')[1].split('/')[0] if '|' in v else 'none'
+                for jail in self.middleware.call_sync('jail.query')
+                for j_ip in [jail['ip4_addr'], jail['ip6_addr']] for v in j_ip.split(',')
             ] + [
                 d['address'] for d in self.middleware.call_sync('interfaces.ip_in_use')
             ]


### PR DESCRIPTION
This commit fixes a bug which when a jail was off with dhcp=on, raised a traceback when ip_in_use validator was used.
Ticket: #42581