### PR TITLE
tkt-48548: Allow showing fstab mounts while jail is running, add type to new dict

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -566,14 +566,14 @@ class JailService(CRUDService):
         """Adds an fstab mount to the jail"""
         uuid, _, iocage = self.check_jail_existence(jail, skip=False)
         status, jid = IOCList.list_get_jid(uuid)
+        action = options['action'].lower()
 
-        if status:
+        if status and action != 'list':
             raise CallError(
                 f'{jail} should not be running when adding a mountpoint')
 
         verrors = ValidationErrors()
 
-        action = options['action'].lower()
         source = options.get('source')
         if source:
             if not os.path.exists(source):
@@ -636,8 +636,20 @@ class JailService(CRUDService):
 
         if action == "list":
             split_list = {}
+            system_mounts = (
+                '/root/bin', '/root/boot', '/root/lib', '/root/libexec',
+                '/root/rescue', '/root/sbin', '/root/usr/bin',
+                '/root/usr/include', '/root/usr/lib', '/root/usr/libexec',
+                '/root/usr/sbin', '/root/usr/share', '/root/usr/libdata',
+                '/root/usr/lib32'
+            )
+
             for i in _list:
-                split_list[i[0]] = i[1].split()
+                fstab_entry = i[1].split()
+                _fstab_type = 'SYSTEM' if fstab_entry[0].endswith(
+                    system_mounts) else 'USER'
+
+                split_list[i[0]] = {'entry': fstab_entry, 'type': _fstab_type}
 
             return split_list
 


### PR DESCRIPTION
This call now returns "INDEX": {"entry": FSTAB_ENTRY, "type": SYSTEM|USER}

Which allows the UI to filter based on mounts for showing the user.

Ticket: #48548