### PR TITLE
tkt-48600: Replace disk bug fix api v1

### DIFF
--- a/docs/api/resources/storage.rst
+++ b/docs/api/resources/storage.rst
@@ -700,7 +700,8 @@ Replace disk
         {
                 "label": "gptid/7c4dd4f1-1a1f-11e3-9786-080027c5e4f4",
                 "replace_disk": "ada4",
-                "force": true
+                "force": true,
+                "pass": "abcd"
         }
 
    **Example response**:
@@ -715,6 +716,7 @@ Replace disk
 
    :json string label: zfs label of the device
    :json string replace_disk: name of the new disk
+   :json string pass: passphrase for a protected pool ( optional - as required )
    :json bool force: force replacement of the new disk
    :resheader Content-Type: content type of the response
    :statuscode 200: no error

--- a/gui/api/resources.py
+++ b/gui/api/resources.py
@@ -844,13 +844,13 @@ class VolumeResourceMixin(NestedMixin):
             request.body,
             format=request.META.get('CONTENT_TYPE', 'application/json'),
         )
+        deserialized['force'] = deserialized.get('force', False)
+        if deserialized.get('pass') and not deserialized.get('pass2'):
+            deserialized['pass2'] = deserialized.get('pass')
         form = ZFSDiskReplacementForm(
             volume=obj,
             label=deserialized.get('label'),
-            data={
-                'replace_disk': deserialized.get('replace_disk'),
-                'force': deserialized.get('force', False),
-            },
+            data=deserialized,
         )
         if not form.is_valid():
             raise ImmediateHttpResponse(


### PR DESCRIPTION
This commit fixes a bug where replace disk call for protected volumes didn't work as api v1 didn't accept passphrase param.
Ticket: #48600