### PR TITLE
tkt-48380: Handle a None value case for serials in certs

### DIFF
--- a/gui/system/migrations/0028_cert_serials.py
+++ b/gui/system/migrations/0028_cert_serials.py
@@ -1,0 +1,33 @@
+from django.db import migrations
+
+from OpenSSL import crypto
+
+
+def serial_update(apps, schema_editor):
+
+    certificate_model = apps.get_model('system', 'certificate')
+    for cert in certificate_model.objects.all():
+        if not cert.cert_serial and cert.cert_certificate:
+            try:
+                cert.cert_serial = crypto.load_certificate(
+                    crypto.FILETYPE_PEM, cert.cert_certificate
+                ).get_serial_number()
+            except crypto.Error:
+                # Let's pass this to ensure very old certificates which might be malformed
+                # not raise exceptions
+                pass
+            else:
+                cert.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('system', '0027_merge_20180807_0638'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            serial_update
+        )
+    ]

--- a/src/middlewared/middlewared/plugins/crypto.py
+++ b/src/middlewared/middlewared/plugins/crypto.py
@@ -728,7 +728,9 @@ class CertificateService(CRUDService):
             if not verrors:
                 new['type'] = CERT_TYPE_EXISTING
 
-                new.update(self.load_certificate(new['certificate']))
+                new.update(
+                    (await self.middleware.run_in_thread(self.load_certificate, new['certificate']))
+                )
 
                 new['chain'] = True if len(RE_CERTIFICATE.findall(new['certificate'])) > 1 else False
 
@@ -851,7 +853,7 @@ class CertificateAuthorityService(CRUDService):
 
             # There is for a case when user might have old certs in the db whose serial value
             # isn't set in the db
-            ca_signed_certs = list(filter(None.__ne__, ca_signed_certs))
+            ca_signed_certs = list(filter(None, ca_signed_certs))
 
             if not ca_signed_certs:
                 return int(

--- a/src/middlewared/middlewared/plugins/crypto.py
+++ b/src/middlewared/middlewared/plugins/crypto.py
@@ -728,6 +728,10 @@ class CertificateService(CRUDService):
             if not verrors:
                 new['type'] = CERT_TYPE_EXISTING
 
+                new.update(self.load_certificate(new['certificate']))
+
+                new['chain'] = True if len(RE_CERTIFICATE.findall(new['certificate'])) > 1 else False
+
         if new['name'] != old['name']:
 
             await validate_cert_name(self.middleware, data['name'], self._config.datastore, verrors,
@@ -845,8 +849,14 @@ class CertificateAuthorityService(CRUDService):
 
             ca_signed_certs.extend((await child_serials(ca_id)))
 
+            # There is for a case when user might have old certs in the db whose serial value
+            # isn't set in the db
+            ca_signed_certs = list(filter(None.__ne__, ca_signed_certs))
+
             if not ca_signed_certs:
-                return int((await self._get_instance(ca_id))['serial']) + 1
+                return int(
+                    (await self._get_instance(ca_id))['serial'] or 0
+                ) + 1
             else:
                 return max(ca_signed_certs) + 1
 


### PR DESCRIPTION
This commit handles a case where old certs may not have serial values set in their respective db entries.
Ticket: #48380