### PR TITLE
fix(gui): sort volume/dataset names in 'Replication Tasks' form

### DIFF
--- a/gui/storage/forms.py
+++ b/gui/storage/forms.py
@@ -2109,10 +2109,10 @@ class ReplicationForm(MiddlewareModelForm, ModelForm):
                 "This field will be empty if you have not "
                 "setup a periodic snapshot task"),
         )
-        fs = list(set([
+        fs = sorted(list(set([
             (task.task_filesystem, task.task_filesystem)
             for task in models.Task.objects.all()
-        ]))
+        ])))
         self.fields['repl_filesystem'].choices = fs
 
         if not self.instance.id:


### PR DESCRIPTION
volume/dataset names must be sorted to appear in the
alphabetical order instead of the creation order.
Ticket: #49739