### PR TITLE
fix(gui): sort volume/dataset names in 'Add VMware-Snapshot' form

### DIFF
--- a/gui/storage/forms.py
+++ b/gui/storage/forms.py
@@ -2617,7 +2617,7 @@ class VMWarePluginForm(MiddlewareModelForm, ModelForm):
         self.fields['filesystem'] = forms.ChoiceField(
             label=self.fields['filesystem'].label,
         )
-        self.fields['filesystem'].choices = choices.FILESYSTEM_CHOICES()
+        self.fields['filesystem'].choices = sorted(choices.FILESYSTEM_CHOICES())
         if self.instance.id:
             self.fields['oid'].initial = self.instance.id
 


### PR DESCRIPTION
volume/dataset names must be sorted to appear in the alphabetical
order instead of the creation order.

Ticket: #49750