### PR TITLE
tkt-45512: Disallow global as a share name in smb

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -309,6 +309,12 @@ class SharingSMBService(CRUDService):
                 verrors, self.middleware, f"{schema_name}.path", data['path']
             )
 
+        if data.get('name') and data['name'] == 'global':
+            verrors.add(
+                f'{schema_name}.name',
+                'Global is a reserved section name, please select another one'
+            )
+
     @private
     async def home_exists(self, home, schema_name, verrors, old=None):
         home_filters = [('home', '=', True)]


### PR DESCRIPTION
This commit introduces improved validation for smb share names disallowing creating shares named global as it is a reserved section name.
Ticket: #45512