### PR TITLE
tkt-46403: Update wording in legacy UI when downloading updates

### DIFF
--- a/gui/templates/system/update_check.html
+++ b/gui/templates/system/update_check.html
@@ -1,6 +1,5 @@
 {% extends "freeadmin/generic_form.html" %}
 {% block onSubmit %}
-getDialog(this).set('title', 'Update Status');
 
 doSubmit({
     form: this,
@@ -16,6 +15,12 @@ doSubmit({
       fileUpload: false
     }
 });
+
+dlg = getDialog(this);
+if(dlg != null){
+    dlg.set('title', 'Update Status');
+}
+
 {% endblock %}
 {% block form %}
 <tr>

--- a/gui/templates/system/update_check.html
+++ b/gui/templates/system/update_check.html
@@ -1,5 +1,7 @@
 {% extends "freeadmin/generic_form.html" %}
 {% block onSubmit %}
+getDialog(this).set('title', 'Update Status');
+
 doSubmit({
     form: this,
     event: e,


### PR DESCRIPTION
This commit updates the title of the dialog when downloading an update to reflect the current state of the dialog.
Ticket: #46403