### PR TITLE
tkt-50335: fix(zsh): remove ^H bindkey, incompatible with some terminals

### DIFF
--- a/src/freenas/root/.zshrc
+++ b/src/freenas/root/.zshrc
@@ -8,7 +8,6 @@ setopt APPEND_HISTORY
 bindkey "^[[F" end-of-line
 bindkey "^[[H" beginning-of-line
 bindkey "^[[3~" delete-char
-bindkey '^H' backward-delete-word
 
 # Enable the builtin emacs(1) command line editor in sh(1),
 # e.g. C-a -> beginning-of-line.


### PR DESCRIPTION
Ticket:	#50233