### PR TITLE
tkt-47096: fix(master) remove f_not_consul program filter from syslog-ng.conf

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-syslogd
+++ b/src/freenas/etc/ix.rc.d/ix-syslogd
@@ -97,7 +97,7 @@ destination(other_controller_file);
 destination other_controller_file { file("$controller_file"); };
 destination other_controller { udp("$controller_other_ip" port($controller_port)); };
 
-log { source(src); filter(f_not_mdnsresponder); filter(f_not_nginx); filter(f_not_consul); destination(other_controller); };
+log { source(src); filter(f_not_mdnsresponder); filter(f_not_nginx); destination(other_controller); };
 _EOF_
 } >> /etc/local/syslog-ng.conf
 


### PR DESCRIPTION
(cherry picked from commit d3368187363efd95dfa238687e4af1c11f9a3f35)