### PR TITLE
tkt-50830: Add process tree information to debug output

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/system/system.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/system/system.sh
@@ -48,8 +48,8 @@ system_func()
 	ntpq -pwn
 	section_footer
 
-	section_header "ps -auxww"
-	ps -auxww
+	section_header "ps -auxwwd"
+	ps -auxwwd
 	section_footer
 
 	section_header "mount"


### PR DESCRIPTION
*Acceptance Criteria*

Debug file `ixdiagnose/fndebug/System/dump.txt` should contain process list as tree under *ps -auxww -d* header