### PR TITLE
tkt-51006: fix(smart): Fix smart config not being regenerated when reloading smartd (by bugclerk)

### DIFF
--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -512,6 +512,10 @@ class ServiceService(CRUDService):
         os.environ['TZ'] = settings['stg_timezone']
         time.tzset()
 
+    async def _reload_smartd(self, **kwargs):
+        await self._service("ix-smartd", "start", quiet=True, **kwargs)
+        await self._service("smartd-daemon", "reload", **kwargs)
+
     async def _restart_smartd(self, **kwargs):
         await self.middleware.call("etc.generate", "smartd")
         await self._service("smartd-daemon", "stop", force=True, **kwargs)


### PR DESCRIPTION
Ticket: #43196