### PR TITLE
tkt-50222: Correctly register SFTP with mdns

### DIFF
--- a/src/middlewared/middlewared/plugins/mdns.py
+++ b/src/middlewared/middlewared/plugins/mdns.py
@@ -729,7 +729,7 @@ class mDNSServiceSFTPThread(mDNSServiceThread):
             response = self.middleware.call_sync('datastore.query', 'services.ssh', [], {'get': True})
             if response:
                 self.port = response['ssh_tcpport']
-                self.regtype = "_sftp._tcp."
+                self.regtype = "_sftp-ssh._tcp."
 
 
 class mDNSServiceHTTPThread(mDNSServiceThread):


### PR DESCRIPTION
This commit fixes a bug where we were registering Simple file transfer protocol as secure file transfer protocol over ssh.
Ticket: #50222