### PR TITLE
QA-Test tkt-51744 Adding code to get logs, exit with 1 if FreeNAS installation bhyve fails and fix stats random issue.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ webui/node_modules/
 webui/dll/
 webui/dist/
 npm-debug.log
+tests/artifacts/

--- a/tests/api2/stats.py
+++ b/tests/api2/stats.py
@@ -12,9 +12,9 @@ from functions import GET, POST
 source_list = []
 source_dict = {}
 sources = GET('/stats/get_sources/').json()
-
 for source, types in sources.items():
-    source_list.append(source)
+    if 'interface-vnet0' not in source:
+        source_list.append(source)
 
 
 def test_01_get_stats_sources():

--- a/tests/functions.py
+++ b/tests/functions.py
@@ -196,6 +196,27 @@ def send_file(file, destination, username, passwrd, host):
         return {'result': True, 'output': output}
 
 
+def get_file(file, destination, username, passwrd, host):
+    cmd = [] if passwrd is None else ["sshpass", "-p", passwrd]
+    cmd += [
+        "scp",
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "UserKnownHostsFile=/dev/null",
+        "-o",
+        "VerifyHostKeyDNS=no",
+        f"{user}@{host}:{file}",
+        destination
+    ]
+    process = run(cmd, stdout=PIPE, universal_newlines=True)
+    output = process.stdout
+    if process.returncode != 0:
+        return {'result': False, 'output': output}
+    else:
+        return {'result': True, 'output': output}
+
+
 def RC_TEST(command):
     process = run(command, shell=True)
     if process.returncode != 0:

--- a/tests/install.exp
+++ b/tests/install.exp
@@ -77,6 +77,6 @@ expect {
   "failed." {
     send_user "Bhyve installation failed."
     sleep 5
-    exit 0
+    exit 1
   }
 }

--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -12,8 +12,8 @@ import re
 
 apifolder = getcwd()
 sys.path.append(apifolder)
-
-results_xml = getcwd() + '/results/'
+workdir = getcwd()
+results_xml = f'{workdir}/results/'
 localHome = path.expanduser('~')
 dotsshPath = localHome + '/.ssh'
 keyPath = localHome + '/.ssh/test_id_rsa'
@@ -106,7 +106,7 @@ cfg_file = open("auto_config.py", 'w')
 cfg_file.writelines(cfg_content)
 cfg_file.close()
 
-from functions import setup_ssh_agent, create_key, add_ssh_key
+from functions import setup_ssh_agent, create_key, add_ssh_key, get_file
 
 # Setup ssh agent befor starting test.
 setup_ssh_agent()
@@ -161,3 +161,17 @@ elif api == "2.0":
               f"{results_xml}{i}_tests_result.xml"] + (
                   ["-k", testexpr] if testexpr else []
         ) + [f"api2/{i}.py"])
+
+# get useful logs
+artifacts = f"{workdir}/artifacts"
+logs_list = [
+    "/var/log/middlewared.log",
+    "/var/log/messages",
+    "/var/log/debug.log",
+    "/var/log/console.log"
+]
+if not path.exists(artifacts):
+    makedirs(artifacts)
+
+for log in logs_list:
+    get_file(log, artifacts, 'root', 'testing', ip)


### PR DESCRIPTION
Change freenas/tests/install.exp to exit with 1 if FreeNAS installation bhyve fails.
add get_file function to get files from FreeNAS with scp.
add code including get_file in runtest.py to get middlewared.log, messages, debug.log, and console.log from FreeNAS after all tests are finished.
remove interface-vnet0 from source_list in stats API v2 test 
