### PR TITLE
tkt-52757: fix(middlewared/network): skip interface on OSError

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -291,7 +291,10 @@ class InterfacesService(CRUDService):
         for name, iface in netif.list_interfaces().items():
             if iface.cloned and name not in configs:
                 continue
-            data[name] = self.iface_extend(iface.__getstate__(), configs)
+            try:
+                data[name] = self.iface_extend(iface.__getstate__(), configs)
+            except OSError:
+                self.logger.warn('Failed to get interface state for %s', name, exc_info=True)
         for name, config in filter(lambda x: x[0] not in data, configs.items()):
             data[name] = self.iface_extend({
                 'name': config['int_interface'],


### PR DESCRIPTION
Interface state may raise OSError on certain situations (Device not
configured). Skip them instead of failing the call.

Ticket:	#52757