### PR TITLE
tkt-52787: remove unnecessary extension from krb5.keytab.py name

### DIFF
--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -65,7 +65,7 @@ class EtcService(Service):
         #
         'kerberos': [
             {'type': 'mako', 'path': 'krb5.conf'},
-            {'type': 'py', 'path': 'krb5.keytab.py'},
+            {'type': 'py', 'path': 'krb5.keytab'},
         ],
 
         'ldap': [


### PR DESCRIPTION
extra py is only good when you can eat it.