### PR TITLE
tkt-53119: fix(middlewared/network): skip interface on OSError (by william-gr)

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -279,7 +279,10 @@ class InterfacesService(Service):
         for name, iface in netif.list_interfaces().items():
             if name in ('lo0', 'pfsync0', 'pflog0'):
                 continue
-            data.append(self.iface_extend(iface.__getstate__()))
+            try:
+                data.append(self.iface_extend(iface.__getstate__()))
+            except OSError:
+                self.logger.warn('Failed to get interface state for %s', name, exc_info=True)
         return filter_list(data, filters, options)
 
     @private


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick 979a0eca6071fcae7876dfd0c7df4fa084475d09

Interface state may raise OSError on certain situations (Device not
configured). Skip them instead of failing the call.

Ticket:	#52757