### PR TITLE
Update legacy UI log in page to match the mockup submitted in #35614:

### DIFF
--- a/gui/templates/registration/login.html
+++ b/gui/templates/registration/login.html
@@ -68,7 +68,7 @@ require(["dojo/_base/fx", "dojo/dom", "dojo/fx/easing", "dojo/_base/html", "dojo
 <input type="hidden" name="next" value="{{ next }}" />
 <img src="{{ STATIC_URL }}ix/ix_login_logo.png" border="0" alt="iXsystems, Inc." style="float:right" />
 {% if sw_name|lower == "freenas" %}
-<div style="margin-top: 9px;"><a href="/ui/">Try the Beta UI!</a></div>
+<button style="margin-top:7px;display:flex;justify-content:center" data-dojo-type="dijit.form.Button" type="button" data-dojo-props="type:'button'" onclick="location.href='/ui/'">{% trans "New Web Interface" %}</button>
 {% endif %}
 </form>
     </div>


### PR DESCRIPTION
Rework the "Beta UI" link into a button and style it according to the mockup image.
Testing on a FreeNAS system (real hardware): Button link functions properly, styleing appears correct.
Screenshot shows appearance of screen on testing system:

![legacyui-login-button-newui-update](https://user-images.githubusercontent.com/17933320/47383494-cddba400-d6d2-11e8-91e8-051b01c391f1.png)
