### PR TITLE
tkt-53595: Detach geli providers after locking pool

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -1581,6 +1581,11 @@ class PoolService(CRUDService):
 
         await self.middleware.call('zfs.pool.export', pool['name'])
 
+        for ed in await self.middleware.call(
+                'datastore.query', 'storage.encrypteddisk', [('encrypted_volume', '=', pool['id'])]
+        ):
+            await self.middleware.call('disk.geli_detach_single', ed['encrypted_provider'])
+
         await self.middleware.call_hook('pool.post_lock', pool=pool)
         await self.middleware.call('service.restart', 'system_datasets')
 


### PR DESCRIPTION
This commit ensures that after we have exported our pool while locking it, we detach the relevant geli providers.
Ticket: #53595