### PR TITLE
De-obfuscate partitioning-related code in install.sh

### DIFF
--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -644,12 +644,9 @@ disk_is_freenas()
 	# This code is very clumsy.  There
 	# should be a way to structure it such that
 	# all of the cleanup happens as we want it to.
-	if zdb -l ${os_part} | grep "name: 'freenas-boot'" > /dev/null ; then
-	    :
-	else
-	    return 1
-	fi
+	zdb -l ${os_part} | fgrep -q "name: 'freenas-boot'" || return 1
 	zpool import -N -f freenas-boot || return 1
+
 	# Now we want to figure out which dataset to use.
 	DS=$(zpool list -H -o bootfs freenas-boot | head -n 1 | cut -d '/' -f 3)
 	if [ -z "$DS" ] ; then

--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -609,9 +609,9 @@ make_swap()
 
     # Skip the swap creation if installing into a BE (Swap already exists in that case)
     if [ "${_upgrade_type}" != "inplace" ] ; then
-      _swapparts=$(for _disk in $*; do echo ${_disk}p3; done)
-      gmirror destroy -f swap || true
-      gmirror label -b prefer swap ${_swapparts}
+	_swapparts=$(for _disk in $*; do echo ${_disk}p3; done)
+	gmirror destroy -f swap || true
+	gmirror label -b prefer swap ${_swapparts}
     fi
     echo "/dev/mirror/swap.eli		none			swap		sw		0	0" > /tmp/data/data/fstab.swap
 }
@@ -649,40 +649,35 @@ disk_is_freenas()
 
 	# Now we want to figure out which dataset to use.
 	DS=$(zpool list -H -o bootfs freenas-boot | head -n 1 | cut -d '/' -f 3)
-	if [ -z "$DS" ] ; then
+	if [ -z "$DS" ]; then
 	    zpool export freenas-boot || true
 	    return 1
-	fi
-	# There should always be a "set default=" line in a grub.cfg
-	# that we created.
-        if [ -n "${DS}" ]; then
-    	   # Okay, mount this pool
-	   if mount -t zfs freenas-boot/ROOT/"${DS}" /tmp/data_old; then
-		    # If the active dataset doesn't have a database file,
-		    # then it's not FN as far as we're concerned (the upgrade code
-		    # will go badly).
-		    # We also check for the Corral database directory.
-		    if [ ! -f /tmp/data_old/data/freenas-v1.db -o \
-			   -d /tmp/data_old/data/freenas.db ]; then
-			umount /tmp/data_old || true
-			zpool export freenas-boot || true
-			return 1
-		    fi
-		    cp -pR /tmp/data_old/data/. /tmp/data_preserved
-		    # Don't want to keep the old pkgdb around, since we're
-		    # nuking the filesystem
-		    rm -rf /tmp/data_preserved/pkgdb
-		    if [ -f /tmp/data_old/conf/base/etc/hostid ]; then
-			cp -p /tmp/data_old/conf/base/etc/hostid /tmp/
-		    fi
-		    if [ -d /tmp/data_old/root/.ssh ]; then
-			cp -pR /tmp/data_old/root/.ssh /tmp/
-		    fi
-		    if [ -d /tmp/data_old/boot/modules ]; then
-			mkdir -p /tmp/modules
-			for i in `ls /tmp/data_old/boot/modules`
+        elif mount -t zfs freenas-boot/ROOT/"${DS}" /tmp/data_old; then
+	    # If the active dataset doesn't have a database file,
+	    # then it's not FN as far as we're concerned (the upgrade code
+	    # will go badly).
+	    # We also check for the Corral database directory.
+	    if [ ! -f /tmp/data_old/data/freenas-v1.db -o \
+		   -d /tmp/data_old/data/freenas.db ]; then
+		umount /tmp/data_old || true
+		zpool export freenas-boot || true
+		return 1
+	    fi
+	    cp -pR /tmp/data_old/data/. /tmp/data_preserved
+	    # Don't want to keep the old pkgdb around, since we're
+	    # nuking the filesystem
+	    rm -rf /tmp/data_preserved/pkgdb
+	    if [ -f /tmp/data_old/conf/base/etc/hostid ]; then
+		cp -p /tmp/data_old/conf/base/etc/hostid /tmp/
+	    fi
+	    if [ -d /tmp/data_old/root/.ssh ]; then
+		cp -pR /tmp/data_old/root/.ssh /tmp/
+	    fi
+	    if [ -d /tmp/data_old/boot/modules ]; then
+		mkdir -p /tmp/modules
+		for i in `ls /tmp/data_old/boot/modules`
 		do
-	    cp -p /tmp/data_old/boot/modules/$i /tmp/modules/
+		    cp -p /tmp/data_old/boot/modules/$i /tmp/modules/
 		done
 	    fi
 	    if [ -d /tmp/data_old/usr/local/fusionio ]; then
@@ -697,9 +692,8 @@ disk_is_freenas()
 	    umount /tmp/data_old || return 1
 	    zpool export freenas-boot || return 1
 	    return 0
-        fi
-      fi
-    fi # End of if NEW upgrade style
+        fi # elif mount ...
+    fi # if [ "${upgrade_style}" = "new" ]
 
     # This is now legacy code, to support the old
     # partitioning scheme (freenas-9.2 and earlier)
@@ -709,7 +703,7 @@ disk_is_freenas()
 
     ls /tmp/data_old > /tmp/data_old.ls
     if [ -f /tmp/data_old/freenas-v1.db ]; then
-        _rv=0
+	_rv=0
     fi
     # XXX side effect, shouldn't be here!
     cp -pR /tmp/data_old/. /tmp/data_preserved

--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -278,15 +278,15 @@ get_media_description()
 	    -v GiB=${GiB}.0 \
 	    -v MiB=${MiB}.0 \
 	'{
-            capacity = $3;
-            if (capacity >= TiB) {
-                printf("%.1f TiB", capacity / TiB);
-            } else if (capacity >= GiB) {
-                printf("%.1f GiB", capacity / GiB);
-            } else if (capacity >= MiB) {
-                printf("%.1f MiB", capacity / MiB);
-            } else {
-                printf("%d Bytes", capacity);
+	    capacity = $3;
+	    if (capacity >= TiB) {
+	        printf("%.1f TiB", capacity / TiB);
+	    } else if (capacity >= GiB) {
+	        printf("%.1f GiB", capacity / GiB);
+	    } else if (capacity >= MiB) {
+	        printf("%.1f MiB", capacity / MiB);
+	    } else {
+	        printf("%d Bytes", capacity);
 	    }
 	}'`
 	VAL="${_description} -- ${_cap}"

--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -652,7 +652,7 @@ disk_is_freenas()
 	if [ -z "$DS" ]; then
 	    zpool export freenas-boot || true
 	    return 1
-        elif mount -t zfs freenas-boot/ROOT/"${DS}" /tmp/data_old; then
+	elif mount -t zfs freenas-boot/ROOT/"${DS}" /tmp/data_old; then
 	    # If the active dataset doesn't have a database file,
 	    # then it's not FN as far as we're concerned (the upgrade code
 	    # will go badly).
@@ -692,7 +692,7 @@ disk_is_freenas()
 	    umount /tmp/data_old || return 1
 	    zpool export freenas-boot || return 1
 	    return 0
-        fi # elif mount ...
+	fi # elif mount ...
     fi # if [ "${upgrade_style}" = "new" ]
 
     # This is now legacy code, to support the old

--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -130,6 +130,7 @@ pre_install_check()
     fi
     return 0
 }
+
 # Convert /etc/version* to /etc/avatar.conf
 #
 # 1 - old /etc/version* file
@@ -387,7 +388,8 @@ EOD
     return $?
 }
 
-install_loader() {
+install_loader()
+{
     local _disk _disks
     local _mnt
 
@@ -428,7 +430,8 @@ install_loader() {
     return 0
 }
 
-save_serial_settings() {
+save_serial_settings()
+{
     _mnt="$1"
 
     # If the installer was booted with serial mode enabled, we should
@@ -460,7 +463,8 @@ save_serial_settings() {
     fi
 }
 
-mount_disk() {
+mount_disk()
+{
 	local _mnt
 
 	if [ $# -ne 1 ]; then
@@ -474,7 +478,8 @@ mount_disk() {
 	return 0
 }
 
-create_partitions() {
+create_partitions()
+{
     local _disk="$1"
     local _size=""
 
@@ -509,7 +514,8 @@ create_partitions() {
     return 1
 }
 
-get_minimum_size() {
+get_minimum_size()
+{
     local _min=0
     local _disk
     local _size
@@ -546,7 +552,8 @@ get_minimum_size() {
     echo ${_min}k
 }
 
-partition_disks() {
+partition_disks()
+{
 	local _disks _disksparts
 	local _mirror
 	local _minsize
@@ -737,32 +744,33 @@ disk_is_freenas()
 	if [ -f /tmp/data_old/conf/base/etc/hostid ]; then
 	    cp -p /tmp/data_old/conf/base/etc/hostid /tmp/
 	fi
-        if [ -d /tmp/data_old/root/.ssh ]; then
-            cp -pR /tmp/data_old/root/.ssh /tmp/
-        fi
-        if [ -d /tmp/data_old/boot/modules ]; then
-            mkdir -p /tmp/modules
-            for i in `ls /tmp/data_old/boot/modules`
-            do
-                cp -p /tmp/data_old/boot/modules/$i /tmp/modules/
-            done
-        fi
-        if [ -d /tmp/data_old/usr/local/fusionio ]; then
-            cp -pR /tmp/data_old/usr/local/fusionio /tmp/
-        fi
+	if [ -d /tmp/data_old/root/.ssh ]; then
+	    cp -pR /tmp/data_old/root/.ssh /tmp/
+	fi
+	if [ -d /tmp/data_old/boot/modules ]; then
+	    mkdir -p /tmp/modules
+	    for i in `ls /tmp/data_old/boot/modules`
+	    do
+		cp -p /tmp/data_old/boot/modules/$i /tmp/modules/
+	    done
+	fi
+	if [ -d /tmp/data_old/usr/local/fusionio ]; then
+	    cp -pR /tmp/data_old/usr/local/fusionio /tmp/
+	fi
 	if [ -f /tmp/data_old/boot.config ]; then
 	    cp /tmp/data_old/boot.config /tmp/
 	fi
 	if [ -f /tmp/data_old/boot/loader.conf.local ]; then
 	    cp /tmp/data_old/boot/loader.conf.local /tmp/
 	fi
-        umount /tmp/data_old
+	umount /tmp/data_old
     fi
     rmdir /tmp/data_old
     return $_rv
 }
 
-prompt_password() {
+prompt_password()
+{
 
     local values value password="" password1 password2 _counter _tmpfile="/tmp/pwd.$$"
 
@@ -1402,7 +1410,8 @@ fi
 # The output is suitable to be used as the arguments
 # to main(), which will directl ycall menu_install().
 
-yesno() {
+yesno()
+{
     # Output "true" or "false" depending on the argument
     if [ $# -ne 1 ]; then
 	echo "false"
@@ -1415,7 +1424,8 @@ yesno() {
     return 0
 }
 
-getsize() {
+getsize()
+{
     # Given a size specifier, convert it to bytes.
     # No suffix, or a suffix of "[bBcC]", means bytes;
     # [kK] is 1024, etc.
@@ -1434,7 +1444,8 @@ getsize() {
     return 0
 }
 	
-parse_config() {
+parse_config()
+{
     local _conf="/etc/install.conf"
     local _diskList=""
     local _minSize=""

--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -118,10 +118,9 @@ get_image_name()
 # This does memory size only for now.
 pre_install_check()
 {
-    # We need at least this many GB of RAM
-    local readonly minmemgb=8
-    # subtract 1GB to allow for reserved memory
-    local readonly minmem=$(expr \( ${minmemgb} \- 1 \) \* 1024 \* 1024 \* 1024)
+    # We need at least 8 GB of RAM
+    # minus 1 GB to allow for reserved memory
+    local minmem=$((7 * GiB))
     local memsize=$(sysctl -n hw.physmem)
 
     if [ ${memsize} -lt ${minmem} ]; then
@@ -272,20 +271,25 @@ get_media_description()
 	_description=`geom disk list ${_media} 2>/dev/null \
 	    | sed -ne 's/^   descr: *//p'`
 	if [ -z "$_description" ] ; then
-		_description="Unknown Device"
+	    _description="Unknown Device"
 	fi
-        _cap=`diskinfo ${_media} | awk '{
+	_cap=`diskinfo ${_media} | awk \
+	    -v TiB=${TiB}.0 \
+	    -v GiB=${GiB}.0 \
+	    -v MiB=${MiB}.0 \
+	'{
             capacity = $3;
-            if (capacity >= 1099511627776) {
-                printf("%.1f TiB", capacity / 1099511627776.0);
-            } else if (capacity >= 1073741824) {
-                printf("%.1f GiB", capacity / 1073741824.0);
-            } else if (capacity >= 1048576) {
-                printf("%.1f MiB", capacity / 1048576.0);
+            if (capacity >= TiB) {
+                printf("%.1f TiB", capacity / TiB);
+            } else if (capacity >= GiB) {
+                printf("%.1f GiB", capacity / GiB);
+            } else if (capacity >= MiB) {
+                printf("%.1f MiB", capacity / MiB);
             } else {
                 printf("%d Bytes", capacity);
-        }}'`
-        VAL="${_description} -- ${_cap}"
+	    }
+	}'`
+	VAL="${_description} -- ${_cap}"
     fi
     export VAL
 }
@@ -481,10 +485,12 @@ mount_disk()
 create_partitions()
 {
     local _disk="$1"
-    local _size=""
+    local _size="$2"
 
-    if [ $# -eq 2 ]; then
-	_size="-s $2"
+    if [ -n "${_size}" ]; then
+	# Round ZFS partition size down to a multiple of 16 MiB (2^24),
+	# leaving units in MiB (2^20).
+	_size="-s $(( (_size >> 24) << 4 ))m"
     fi
     if gpart create -s GPT -f active ${_disk}; then
 	if [ "$BOOTMODE" = "UEFI" ] ; then
@@ -519,15 +525,6 @@ get_minimum_size()
     local _min=0
     local _disk
     local _size
-    # We use 1mbyte because the fat16 partition is 512k,
-    # and there's some header space.
-    # Now we use 8MBytes because gpart and some thumb drives
-    # misbehave.
-    local _m1=$(expr 1024 \* 1024 \* 8)
-    # If we decide we want to round it down,
-    # set this to the size (eg, 256 * 1024 * 1024)
-    local _round=0
-    local _g16=$(expr 16 \* 1024 \* 1024 \* 1024)
 
     for _disk
     do
@@ -541,67 +538,70 @@ get_minimum_size()
 	    echo "Could not do anything with ${_disk}, skipping" 1>&2
 	    continue
 	fi
-	if [ ${_round} -gt 0 ]; then
-	    _size=$(expr \( ${_size} / ${_round} \) \* ${_round})
-	fi
-	_size=$(expr ${_size} / 1024)
 	if [ ${_min} -eq 0 -o ${_size} -lt ${_min} ]; then
 	    _min=${_size}
 	fi
     done
-    echo ${_min}k
+
+    echo ${_min}
 }
+
+# Minimum required space for an installation.
+# Docs state 8 GiB is the bare minimum, but we specify 8 GB here for wiggle room.
+# That should leave enough slop for alignment, boot partition, etc.
+: ${MIN_ZFS_PARTITION_SIZE:=$((8 * GB))}; readonly MIN_ZFS_PARTITION_SIZE
 
 partition_disks()
 {
-	local _disks _disksparts
-	local _mirror
-	local _minsize
+    local _disks _disksparts
+    local _mirror
+    local _minsize
+    local _size
 
-	_disks=$*
+    _disks=$*
 
-	check_is_swap_safe ${_disks}
+    check_is_swap_safe ${_disks}
 
-	gmirror destroy -f swap || true
+    gmirror destroy -f swap || true
 
-	# Erase both typical metadata area.
-	for _disk in ${_disks}; do
-	    gpart destroy -F ${_disk} >/dev/null 2>&1 || true
-	    dd if=/dev/zero of=/dev/${_disk} bs=1m count=2 >/dev/null
-	    dd if=/dev/zero of=/dev/${_disk} bs=1m oseek=$(diskinfo /dev/${_disk} | awk '{ print int($3/(1024*1024))-2 }') >/dev/null || true
-	done
+    # Erase both typical metadata area.
+    for _disk in ${_disks}; do
+	gpart destroy -F ${_disk} >/dev/null 2>&1 || true
+	dd if=/dev/zero of=/dev/${_disk} bs=1m count=2 >/dev/null
+	_size=$(diskinfo ${_disk} | cut -f 3)
+	dd if=/dev/zero of=/dev/${_disk} bs=1m oseek=$((_size / MiB - 2)) >/dev/null || true
+    done
 
-	_minsize=$(get_minimum_size ${_disks})
+    _minsize=$(get_minimum_size ${_disks})
 
-	if [ "${_minsize}" = "0k" ]; then
-	    echo "Disk is too small to install ${AVATAR_PROJECT}" 1>&2
-	    return 1
+    if [ ${_minsize} -lt ${MIN_ZFS_PARTITION_SIZE} ]; then
+	echo "Disk is too small to install ${AVATAR_PROJECT}" 1>&2
+	return 1
+    fi
+
+    _disksparts=$(for _disk in ${_disks}; do
+	create_partitions ${_disk} ${_minsize} >&2
+	if [ "$BOOTMODE" != "UEFI" ] ; then
+	    # Make the disk active
+	    gpart set -a active ${_disk} >&2
 	fi
+	echo ${_disk}p2
+    done)
 
-	_disksparts=$(for _disk in ${_disks}; do
-	    create_partitions ${_disk} ${_minsize} >&2
-	    if [ "$BOOTMODE" != "UEFI" ] ; then
-	      # Make the disk active
-	      gpart set -a active ${_disk} >&2
-	    fi
+    if [ $# -gt 1 ]; then
+	_mirror="mirror"
+    else
+	_mirror=""
+    fi
+    zpool create -f -o cachefile=/tmp/zpool.cache -o version=28 -O mountpoint=none -O atime=off -O canmount=off freenas-boot ${_mirror} ${_disksparts}
+    zpool set feature@async_destroy=enabled freenas-boot
+    zpool set feature@empty_bpobj=enabled freenas-boot
+    zpool set feature@lz4_compress=enabled freenas-boot
+    zfs set compress=lz4 freenas-boot
+    zfs create -o canmount=off freenas-boot/ROOT
+    zfs create -o mountpoint=legacy freenas-boot/ROOT/${BENAME}
 
-	    echo ${_disk}p2
-	done)
-
-	if [ $# -gt 1 ]; then
-	    _mirror="mirror"
-	else
-	    _mirror=""
-	fi
-	zpool create -f -o cachefile=/tmp/zpool.cache -o version=28 -O mountpoint=none -O atime=off -O canmount=off freenas-boot ${_mirror} ${_disksparts}
-	zpool set feature@async_destroy=enabled freenas-boot
-	zpool set feature@empty_bpobj=enabled freenas-boot
-	zpool set feature@lz4_compress=enabled freenas-boot
-	zfs set compress=lz4 freenas-boot
-	zfs create -o canmount=off freenas-boot/ROOT
-	zfs create -o mountpoint=legacy freenas-boot/ROOT/${BENAME}
-
-	return 0
+    return 0
 }
 
 make_swap()

--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -510,13 +510,12 @@ create_partitions()
 	fi
 
 	if is_swap_safe; then
-	    gpart add -t freebsd-swap -s 16g -i 3 ${_disk}
+	    gpart add -t freebsd-swap -a 4k -s 16g -i 3 ${_disk}
 	fi
 	if gpart add -t freebsd-zfs -a 4k -i 2 ${_size} ${_disk}; then
 	    return 0
 	fi
     fi
-
     return 1
 }
 

--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -492,7 +492,7 @@ create_partitions()
 	# leaving units in MiB (2^20).
 	_size="-s $(( (_size >> 24) << 4 ))m"
     fi
-    if gpart create -s GPT -f active ${_disk}; then
+    if gpart create -s GPT ${_disk}; then
 	if [ "$BOOTMODE" = "UEFI" ] ; then
 	  # EFI Mode
 	  sysctl kern.geom.debugflags=16


### PR DESCRIPTION
Summary of changes:
* Check at least 8GB is available for install (as documented), rather than size != 0k
* Align swap partition to 4k, same as the ZFS partition
* Simplify mathematical expressions
* Replace magic numbers with symbolic constants
* Improve style consistency
* Eliminate dead code

Ticket: #51852