### PR TITLE
[install.sh] Make sure swap mirror is destroyed

### DIFF
--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -454,7 +454,8 @@ get_minimum_size() {
     do
 	_size=""
 	if create_partitions ${_disk} 1>&2; then
-	    _size=$(diskinfo /dev/${_disk}p2 | cut -f 3)
+	    _size=$(diskinfo ${_disk}p2 | cut -f 3)
+	    gmirror destroy -f swap || true
 	    gpart destroy -F ${_disk} 1>&2
 	fi
 	if [ -z "${_size}" ]; then


### PR DESCRIPTION
Fixes an edge case when installing to disks that previously had a swap
mirror set up but the partition table was destroyed without destroying
the swap mirror.

(Cherry-picked from a5b512bbf18b2436c07174b1c276ed2a426a861a)

Ticket: #28142