### PR TITLE
tkt-53415: fix(gui): restart smartd on background

### DIFF
--- a/gui/storage/forms.py
+++ b/gui/storage/forms.py
@@ -331,7 +331,10 @@ class VolumeManagerForm(VolumeMixin, Form):
 
         # restart smartd to enable monitoring for any new drives added
         if (services.objects.get(srv_service='smartd').srv_enable):
-            notifier().restart("smartd")
+            with client as c:
+                # Restart in the background as it may take a long time
+                # depending on the number of disks.
+                c.call('core.bulk', 'service.restart', [['smartd']])
 
         # ModelForm compatibility layer for API framework
         self.instance = volume


### PR DESCRIPTION
This should not happen on 11.2+ because it does scanning on parallel.

Ticket:	#53415