### PR TITLE
Rename "Automatically check for updates" on System/Update page:

### DIFF
--- a/gui/freeadmin/static/lib/js/freeadmin/Update.js
+++ b/gui/freeadmin/static/lib/js/freeadmin/Update.js
@@ -85,7 +85,7 @@ define([
       me.dapUpdateTrainInfoLink.innerHTML = gettext('Train Descriptions');
 
       me.dapCurrentTrain.innerHTML = gettext( me.currentTrain ? me.currentTrain : 'Loading');
-      me.dapAutoCheckText.innerHTML = gettext('Automatically check for updates');
+      me.dapAutoCheckText.innerHTML = gettext('Check for Updates Daily and Download if Available');
       me.dapCurrentTrainText.innerHTML = gettext('Current Train');
       me.dapUpdateServerText.innerHTML = gettext('Update Server');
       me.dapUpdateGridText.innerHTML = gettext('Pending Updates');


### PR DESCRIPTION
- Renamed to better reflect actual system behavior when option is set.
- Tested with a local hot patch on a FreeNAS system (real hardware): no issues.