### PR TITLE
tkt-51006: Fix smart config not being regenerated when reloading smartd (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -513,7 +513,7 @@ class ServiceService(CRUDService):
         time.tzset()
 
     async def _reload_smartd(self, **kwargs):
-        await self._service("ix-smartd", "start", quiet=True, **kwargs)
+        await self.middleware.call("etc.generate", "smartd")
         await self._service("smartd-daemon", "reload", **kwargs)
 
     async def _restart_smartd(self, **kwargs):


### PR DESCRIPTION
This was backported incorrectly from 11.1