### PR TITLE
Generate dhparams in ix-etc

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-etc
+++ b/src/freenas/etc/ix.rc.d/ix-etc
@@ -26,6 +26,8 @@ generate_etc()
 {
 	copy_templates
 
+	[ -s /data/dhparam.pem ] || openssl dhparam -rand - 2048 > /data/dhparam.pem
+
 	LD_LIBRARY_PATH=/usr/local/lib /usr/local/bin/midclt call etc.generate_all > /dev/null
 }
 

--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf
@@ -9,23 +9,11 @@
     if not os.path.exists('/var/log/nginx'):
         os.makedirs('/var/log/nginx')
 
-    for size in ('', 1024):
-        if not os.path.isfile(f'/data/dhparam{size}.pem'):
-            with open(f'/data/dhparam{size}.pem', 'wb') as file:
-                file.write(
-                    dh.generate_parameters(
-                        generator=2, key_size=size or 2048, backend=default_backend()
-                    ).parameter_bytes(
-                        encoding=serialization.Encoding.PEM,
-                        format=serialization.ParameterFormat('PKCS3')
-                    )
-                )
-
     general_settings = middleware.call_sync('system.general.config')
     cert = general_settings['ui_certificate']
     dojo_version = middleware.call_sync('notifier.dojango_dojo_version')
     vcenter_https = middleware.call_sync('vcenteraux.config')['enable_https']
-    dhparams_file= '/data/dhparam.pem' if not vcenter_https else '/data/dhparam1024.pem'
+    dhparams_file= '/data/dhparam.pem'
     default_ui = 'ui' if middleware.call_sync('system.is_freenas') else 'legacy'
     ip_list = [
         ip for ip in general_settings['ui_address']] + [f'[{ip}]' for ip in general_settings['ui_v6address']


### PR DESCRIPTION
Generating dhparams in middlewared took a lot of time which resulted in call timeout errors and nginx configuration file not being generated on time. This commit moves generation to ix-etc to ensure that we have dhparams before we generate nginx conf file.
Ticket: #54807