### PR TITLE
Fallback to HTTP if HTTPS cannot be configured

### DIFF
--- a/src/freenas/usr/local/etc/rc.d/django
+++ b/src/freenas/usr/local/etc/rc.d/django
@@ -63,7 +63,7 @@ start_command()
         # changed ">>" below to ">" as I want it to write a new file each time
         echo "SECRET_KEY = '${new_string}'" > ${django_config}
         local webguiproto=$(${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} "SELECT stg_guihttpsredirect from system_settings")
-        if [ "${webguiproto}" = "1" -a ! -f /tmp/alert_invalid_ssl_nginx ]; then
+        if [ "${webguiproto}" = "1" -a ! -f /tmp/alert_invalid_ssl_nginx -a ! -f /tmp/alert_invalid_ssl_conf ]; then
             echo "SESSION_COOKIE_SECURE = True" >> ${django_config}
             echo "CSRF_COOKIE_SECURE = True" >> ${django_config}
         fi

--- a/src/middlewared/middlewared/alert/source/httpd_ssl.py
+++ b/src/middlewared/middlewared/alert/source/httpd_ssl.py
@@ -17,9 +17,14 @@ class HTTPD_SSL_AlertSource(AlertSource):
 
         if os.path.exists("/tmp/alert_invalid_ssl_nginx"):
             alerts.append(Alert(
-                "FreeNAS does not support certificates with keys shorter than 1024 bits. "
+                "System does not support certificates with keys shorter than 1024 bits. "
                 "HTTPS will not be enabled until a certificate having at least 1024 bit "
                 "keylength is provided",
+            ))
+
+        if os.path.exists("/tmp/alert_invalid_ssl_conf"):
+            alerts.append(Alert(
+                "Certificate setup failed for HTTPS to be enabled"
             ))
 
         for cert_name in glob.glob("/var/tmp/alert_invalidcert_*"):

--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf
@@ -19,6 +19,17 @@
         ip for ip in general_settings['ui_address']] + [f'[{ip}]' for ip in general_settings['ui_v6address']
     ]
 
+    # Let's verify that required SSL support in the backend is complete by middlewared
+    if not cert:
+        ssl_configuration = False
+        open('/tmp/alert_invalid_ssl_conf', 'w').close()
+    else:
+        ssl_configuration = True
+        try:
+            os.remove('/tmp/alert_invalid_ssl_conf')
+        except FileNotFoundError:
+            pass
+
 %>
 #
 #    FreeNAS nginx configuration file
@@ -66,9 +77,10 @@ http {
 
     server {
         server_name  localhost;
-% for ip in ip_list:
+% if ssl_configuration:
+    % for ip in ip_list:
         listen                 ${ip}:${general_settings['ui_httpsport']} default_server ssl http2;
-% endfor
+    % endfor
 
         ssl_certificate        "${cert['certificate_path']}";
         ssl_certificate_key    "${cert['privatekey_path']}";
@@ -87,8 +99,9 @@ http {
         #ssl_stapling_verify on;
         #resolver ;
         #ssl_trusted_certificate ;
+% endif
 
-% if not general_settings['ui_httpsredirect']:
+% if not general_settings['ui_httpsredirect'] or not ssl_configuration:
     % for ip in ip_list:
         listen       ${ip}:${general_settings['ui_port']};
     % endfor
@@ -242,7 +255,7 @@ http {
 
         #include plugins.conf;
     }
-% if general_settings['ui_httpsredirect']:
+% if general_settings['ui_httpsredirect'] and ssl_configuration:
     server {
     % for ip in ip_list:
         listen    ${ip}:80;


### PR DESCRIPTION
This commit makes sure that if middlewared is unable to setup required backend support for HTTPS, nginx still works and falls back to HTTP.
Ticket: #54960