### PR TITLE
tkt-55734 (master) fix freenas-debug hang

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/nfs/nfs.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/nfs/nfs.sh
@@ -70,10 +70,6 @@ nfs_func()
 	sc /etc/exports
 	section_footer
 
-	section_header "showmount -e"
-	showmount -e
-	section_footer
-
 	section_header "rpcinfo -p"
 	rpcinfo -p
 	section_footer


### PR DESCRIPTION
showmount -e hangs for awhile on freeBSD if the rpcbind service isn't running.

This causes standby controller debugs to fail with CallTimeout exception.

Spoke with @amotin about this and the quick solution is to remove this command for now.

Another ticket will be opened up to understand why showmount is hanging and hopefully get a fix upstream.