### PR TITLE
tkt-55923: Make s3 disks field required

### DIFF
--- a/gui/services/forms.py
+++ b/gui/services/forms.py
@@ -2007,6 +2007,16 @@ class S3Form(ModelForm):
             )
         return s3_secret_key2
 
+    def clean_s3_disks(self):
+        s3_disks = self.cleaned_data.get("s3_disks")
+        if len(s3_disks.replace('/', ' ').split()) < 3:
+            raise forms.ValidationError(
+                _("Top level datasets are not allowed. i.e /mnt/tank/dataset is allowed")
+            )
+        if not os.path.exists(s3_disks):
+            os.makedirs(s3_disks)
+        return s3_disks
+
     def clean(self):
         cdata = self.cleaned_data
         if not cdata.get("s3_secret_key"):

--- a/gui/services/forms.py
+++ b/gui/services/forms.py
@@ -2009,12 +2009,16 @@ class S3Form(ModelForm):
 
     def clean_s3_disks(self):
         s3_disks = self.cleaned_data.get("s3_disks")
-        if len(s3_disks.replace('/', ' ').split()) < 3:
+        if s3_disks.rstrip('/').count('/') < 3:
             raise forms.ValidationError(
                 _("Top level datasets are not allowed. i.e /mnt/tank/dataset is allowed")
             )
         if not os.path.exists(s3_disks):
             os.makedirs(s3_disks)
+        elif not os.path.isdir(s3_disks):
+            raise forms.ValidationError(
+                _("Specified path is not a directory")
+            )
         return s3_disks
 
     def clean(self):

--- a/gui/services/migrations/0002_add_s3_service.py
+++ b/gui/services/migrations/0002_add_s3_service.py
@@ -44,7 +44,7 @@ class Migration(migrations.Migration):
                 ('s3_secret_key', models.CharField(blank=True, help_text='S3 password', max_length=128, null=True, verbose_name='Secret Key')),
                 ('s3_browser', models.BooleanField(default=False, help_text='This will enable the web UI for the S3 service.', verbose_name='Enable Browser')),
                 ('s3_mode', models.CharField(choices=[(b'local', 'local'), (b'distributed', 'distributed')], default=b'local', max_length=120, verbose_name='Mode')),
-                ('s3_disks', models.CharField(blank=True, help_text='S3 filesystem disk(s)', max_length=8192, null=True, verbose_name='Disks')),
+                ('s3_disks', models.CharField(blank=False, help_text='S3 filesystem disk(s)', max_length=8192, null=True, verbose_name='Disks')),
             ],
             options={
                 'verbose_name': 'S3',

--- a/gui/services/models.py
+++ b/gui/services/models.py
@@ -2328,7 +2328,7 @@ class S3(Model):
     s3_disks = PathField(
         verbose_name=_("Disks"),
         max_length=8192,
-        blank=True,
+        blank=False,
         null=True,
         help_text=_("S3 filesystem directory")
     )


### PR DESCRIPTION
This commit makes s3 disks field in s3 service required for editing it's configuration and ensures that top level datasets aren't selectable by the end user.
Ticket: #55923