### PR TITLE
tkt-51997: fix(logging): Use log_handler arg for worker logging

### DIFF
--- a/src/middlewared/middlewared/logger.py
+++ b/src/middlewared/middlewared/logger.py
@@ -1,6 +1,7 @@
-import os
 import logging
 import logging.handlers
+import os
+import sys
 
 from logging.config import dictConfig
 from .utils import sw_version, sw_version_is_stable
@@ -260,3 +261,18 @@ class Logger(object):
             self._set_output_file()
 
         logging.root.setLevel(getattr(logging, self.debug_level))
+
+
+def setup_logging(name, debug_level, log_handler):
+    _logger = Logger(name, debug_level)
+    _logger.getLogger()
+
+    if 'file' in log_handler:
+        _logger.configure_logging('file')
+        stream = _logger.stream()
+        if stream is not None:
+            sys.stdout = sys.stderr = stream
+    elif 'console' in log_handler:
+        _logger.configure_logging('console')
+    else:
+        _logger.configure_logging('file')

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -729,7 +729,10 @@ class Middleware(object):
 
     CONSOLE_ONCE_PATH = '/tmp/.middlewared-console-once'
 
-    def __init__(self, loop_debug=False, loop_monitor=True, overlay_dirs=None, debug_level=None):
+    def __init__(
+        self, loop_debug=False, loop_monitor=True, overlay_dirs=None, debug_level=None,
+        log_handler=None,
+    ):
         self.logger = logger.Logger('middlewared', debug_level).getLogger()
         self.crash_reporting = logger.CrashReporting()
         self.crash_reporting_semaphore = asyncio.Semaphore(value=2)
@@ -742,7 +745,7 @@ class Middleware(object):
         multiprocessing.set_start_method('spawn')
         self.__procpool = concurrent.futures.ProcessPoolExecutor(
             max_workers=2,
-            initializer=worker_init,
+            initializer=functools.partial(worker_init, debug_level, log_handler),
         )
         self.__threadpool = concurrent.futures.ThreadPoolExecutor(
             initializer=lambda: set_thread_name('threadpool_ws'),
@@ -1305,9 +1308,6 @@ def main():
     ], default='console')
     args = parser.parse_args()
 
-    _logger = logger.Logger('middleware', args.debug_level)
-    _logger.getLogger()
-
     pidpath = '/var/run/middlewared.pid'
 
     if args.restart:
@@ -1320,15 +1320,7 @@ def main():
                 if e.errno != errno.ESRCH:
                     raise
 
-    if 'file' in args.log_handler:
-        _logger.configure_logging('file')
-        stream = _logger.stream()
-        if stream is not None:
-            sys.stdout = sys.stderr = stream
-    elif 'console' in args.log_handler:
-        _logger.configure_logging('console')
-    else:
-        _logger.configure_logging('file')
+    logger.setup_logging('middleware', args.debug_level, args.log_handler)
 
     setproctitle.setproctitle('middlewared')
     # Workaround to tell django to not set up logging on its own
@@ -1343,6 +1335,7 @@ def main():
         loop_monitor=not args.disable_loop_monitor,
         overlay_dirs=args.overlay_dirs,
         debug_level=args.debug_level,
+        log_handler=args.log_handler,
     ).run()
 
 

--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -315,9 +315,7 @@ class JailService(CRUDService):
     @accepts(Str("jail"))
     def do_delete(self, jail):
         """Takes a jail and destroys it."""
-        # Jails cannot have whitespace, but this is so a user can destroy a
-        # corrupt jail
-        _, _, iocage = self.check_jail_existence(jail.split()[0])
+        _, _, iocage = self.check_jail_existence(jail)
 
         # TODO: Port children checking, release destroying.
         iocage.destroy_jail()

--- a/src/middlewared/middlewared/worker.py
+++ b/src/middlewared/middlewared/worker.py
@@ -129,8 +129,9 @@ def watch_parent():
     os._exit(1)
 
 
-def worker_init():
+def worker_init(debug_level, log_handler):
     global MIDDLEWARE
     MIDDLEWARE = FakeMiddleware()
     setproctitle.setproctitle('middlewared (worker)')
     threading.Thread(target=watch_parent, daemon=True).start()
+    logger.setup_logging('worker', debug_level, log_handler)


### PR DESCRIPTION
This fixes the previously merged behavior that defaulted to console and had a split for the jail.


- Drop defaulting to console, use file like main middlewared
- Simplify odd if/elif/else clause in main.py
- Remove unneeded split

Ticket: #51997