### PR TITLE
Validate AD config file before trying to configure kerberos

### DIFF
--- a/src/freenas/etc/directoryservice/ActiveDirectory/ctl
+++ b/src/freenas/etc/directoryservice/ActiveDirectory/ctl
@@ -79,6 +79,12 @@ adctl_start()
 	local ad_started=0
 	touch "${start_file}"
 
+	#56751 - verify that servers in /etc/directoryservice/ActiveDirectory/config
+	#        are listening. If not, re-generate config.
+	if ! AD_validate_config
+		AD_remove_config
+	fi
+
 	if ! AD_init
 	then
 		activedirectory_set 1

--- a/src/freenas/etc/directoryservice/rc.ActiveDirectory
+++ b/src/freenas/etc/directoryservice/rc.ActiveDirectory
@@ -1069,7 +1069,7 @@ AD_generate_config()
 	fi
 	if [ ${res} = "1" ]
 	then
-		rm "${AD_CONFIG_FILE}"
+		AD_remove_config
 	fi
 
 	return ${res}

--- a/src/freenas/etc/directoryservice/rc.ActiveDirectory
+++ b/src/freenas/etc/directoryservice/rc.ActiveDirectory
@@ -1067,8 +1067,46 @@ AD_generate_config()
 		res=$?
 		/bin/chmod 600 "${AD_CONFIG_FILE}"
 	fi
+	if [ ${res} = "1" ]
+	then
+		rm "${AD_CONFIG_FILE}"
+	fi
 
 	return ${res}
+}
+
+AD_validate_config()
+{
+	if [ ! -s "${AD_CONFIG_FILE}" ]
+	then
+		return 1
+	fi
+
+	exec 3<&0
+	exec 0<"${AD_CONFIG_FILE}"
+
+	while read -r line
+	do
+		local is_dc="$(echo ${line}|grep 'ad_dcname')"
+		local is_gc="$(echo ${line}|grep 'ad_gcname')"
+		local is_krb="$(echo ${line}|grep 'ad_krbname')"
+		if [ "${is_dc}" ] || [ "${is_gc}" ] || [ "${is_krb}" ]
+		then
+			local val="$(echo ${line}|cut -f2- -d=|sed -Ee 's#^[[:space:]]+##' -e 's#[[:space:]]+$##')"
+			local server_address="$(echo ${val}|sed 's/\:/\ /')"
+			nc -vz -w 3 ${server_address} 2> /dev/null
+			res=$?
+
+			if [ ${res}  = "1" ]
+			then
+				return 1 
+			fi
+		fi
+
+	done
+	exec 0<&3
+
+	return 0
 }
 
 AD_remove_config()

--- a/src/freenas/etc/ix.rc.d/ix-kerberos
+++ b/src/freenas/etc/ix.rc.d/ix-kerberos
@@ -43,8 +43,16 @@ generate_kerberos_files()
 
 	if [ $# -eq 0 ] && activedirectory_enabled
 	then
-		AD_init
-		generate_krb5_conf default "$(AD_get ad_krb_realm)"
+		if ! AD_validate_config
+		then
+			AD_remove_config
+		fi
+		if ! AD_init
+		then
+			generate_krb5_conf
+		else
+			generate_krb5_conf default "$(AD_get ad_krb_realm)"
+		fi
 	else
 		generate_krb5_conf $*
 	fi

--- a/src/freenas/usr/local/libexec/nas/generate_krb5_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_krb5_conf.py
@@ -476,8 +476,17 @@ def main():
 
     ad_objects = client.call('datastore.query', 'directoryservice.ActiveDirectory')
     if ad_objects and ad_objects[0]['ad_enable']:
-        ad = Struct(client.call('notifier.directoryservice', 'AD',
-            timeout=fs().directoryservice.kerberos.timeout.start))
+        """
+        We first try to find the best kerberos server to speak to. If this fails
+        (for instance, due to stale entries in /etc/directoryservice/ActiveDirectory/config)
+        then we fall back to relying on DNS SRV records. Although this isn't perfect, it's
+        better than going production down.
+        """
+        try:
+            ad = Struct(client.call('notifier.directoryservice', 'AD',
+                timeout=fs().directoryservice.kerberos.timeout.start))
+        except:
+            pass
 
     for kr in realms:
         kr = Struct(kr)


### PR DESCRIPTION
- Add function to validate contents of /etc/directoryservice/ActiveDirectory/config and remove it if it fails checks
- Configure minimal functional krb5.conf even if AD_init fails. 