### PR TITLE
tkt-54954: Add enable_smb1 checkbox

### DIFF
--- a/gui/api/test_services.py
+++ b/gui/api/test_services.py
@@ -121,6 +121,7 @@ class CIFSResourceTest(APITestCase):
             'cifs_srv_description': '',
             'cifs_srv_dirmask': '',
             'cifs_srv_domain_logons': False,
+            'cifs_srv_enable_smb1': False,
             'cifs_srv_doscharset': 'CP437',
             'cifs_srv_filemask': '',
             'cifs_srv_guest': 'nobody',

--- a/gui/services/forms.py
+++ b/gui/services/forms.py
@@ -161,12 +161,6 @@ class CIFSForm(ModelForm):
         else:
             self.fields['cifs_srv_bindip'].initial = ('')
 
-        # Disable UNIX extensions if not using SMB1 - We can probably disable other things too
-        proto = _fs().services.smb.config.server_min_protocol
-        if re.match('SMB[23]+', proto):
-            self.initial['cifs_srv_unixext'] = False
-            self.fields['cifs_srv_unixext'].widget.attrs['disabled'] = 'disabled'
-
         if activedirectory_enabled():
             self.initial['cifs_srv_localmaster'] = False
             self.fields['cifs_srv_localmaster'].widget.attrs['disabled'] = 'disabled'

--- a/gui/services/migrations/0020_add_enable_smb1.py
+++ b/gui/services/migrations/0020_add_enable_smb1.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('services', '0019_add_asigra_model'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='cifs',
+            name='cifs_srv_enable_smb1',
+            field=models.BooleanField(default=False,
+                help_text=(
+                    'Use this option to allow legacy SMB clients to connect to the '
+                    'server. Note that SMB1 is being deprecated and it is advised '
+                    'to upgrade clients to operating system versions that support '
+                    'modern versions of the SMB protocol.'
+                ),
+                verbose_name='Enable SMB1'
+        ),
+    ]
+

--- a/gui/services/migrations/0020_add_enable_smb1.py
+++ b/gui/services/migrations/0020_add_enable_smb1.py
@@ -3,7 +3,7 @@ from django.db import migrations, models
 
 def move_sysctl_min_protocol(apps, schemaeditor):
     tunables = apps.get_model('system', 'tunable')
-    smb1_sysctl = tunables.objects.filter(tun_type='SYSCTL',
+    smb1_sysctl = tunables.objects.filter(tun_type='sysctl',
                                           tun_var='freenas.services.smb.config.server_min_protocol',
                                           tun_value='NT1')
 

--- a/gui/services/migrations/0020_add_enable_smb1.py
+++ b/gui/services/migrations/0020_add_enable_smb1.py
@@ -1,6 +1,18 @@
 from django.db import migrations, models
 
 
+def move_sysctl_min_protocol(apps, schemaeditor):
+    tunables = apps.get_model('system', 'tunable')
+    smb1_sysctl = tunables.filter(tun_type='SYSCTL',
+                                  tun_var='freenas.services.smb.config.server_min_protocol',
+                                  tun_value='NT1')
+
+    if smb1_sysctl.exists():
+        cifs.cifs_srv_enable_smb1 = True
+        cifs.save
+        smb1_sysctl.delete()
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -19,6 +31,10 @@ class Migration(migrations.Migration):
                     'modern versions of the SMB protocol.'
                 ),
                 verbose_name='Enable SMB1'
+            ),
+        ),
+        migrations.RunPython(
+            move_sysctl_min_protocol
         ),
     ]
 

--- a/gui/services/migrations/0020_add_enable_smb1.py
+++ b/gui/services/migrations/0020_add_enable_smb1.py
@@ -3,9 +3,9 @@ from django.db import migrations, models
 
 def move_sysctl_min_protocol(apps, schemaeditor):
     tunables = apps.get_model('system', 'tunable')
-    smb1_sysctl = tunables.filter(tun_type='SYSCTL',
-                                  tun_var='freenas.services.smb.config.server_min_protocol',
-                                  tun_value='NT1')
+    smb1_sysctl = tunables.objects.filter(tun_type='SYSCTL',
+                                          tun_var='freenas.services.smb.config.server_min_protocol',
+                                          tun_value='NT1')
 
     cifs = apps.get_model('services', 'cifs').objects.order_by('-id')[0]
 

--- a/gui/services/migrations/0020_add_enable_smb1.py
+++ b/gui/services/migrations/0020_add_enable_smb1.py
@@ -7,9 +7,11 @@ def move_sysctl_min_protocol(apps, schemaeditor):
                                   tun_var='freenas.services.smb.config.server_min_protocol',
                                   tun_value='NT1')
 
+    cifs = apps.get_model('services', 'cifs').objects.order_by('-id')[0]
+
     if smb1_sysctl.exists():
         cifs.cifs_srv_enable_smb1 = True
-        cifs.save
+        cifs.save()
         smb1_sysctl.delete()
 
 

--- a/gui/services/models.py
+++ b/gui/services/models.py
@@ -102,6 +102,16 @@ class CIFS(Model):
         blank=True,
         help_text=_("Server description. This can usually be left blank."),
     )
+    cifs_srv_enable_smb1 = models.BooleanField(
+        verbose_name=_("Enable SMB1 support"),
+        default=False,
+        help_text=_(
+            "Use this option to allow legacy SMB clients to connect to the "
+            "server. Note that SMB1 is being deprecated and it is advised "
+            "to upgrade clients to operating system versions that support "
+            "modern versions of the SMB protocol."
+        ),
+    )
     cifs_srv_doscharset = models.CharField(
         max_length=120,
         choices=choices.CHARSET(choices.DOSCHARSET_CHOICES),

--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -952,9 +952,17 @@ def generate_smb4_conf(client, smb4_conf, role):
     if os.path.exists("/usr/local/etc/smbusers"):
         confset1(smb4_conf, "username map = /usr/local/etc/smbusers")
 
-    server_min_protocol = fs().services.smb.config.server_min_protocol
-    if server_min_protocol != 'NONE':
-        confset2(smb4_conf, "server min protocol = %s", server_min_protocol)
+    sysctl_server_min_protocol = fs().services.smb.config.server_min_protocol
+
+    # Migrate to the enable_smb1_checkbox
+    if sysctl_server_min_protocol == 'NT1':
+        client.call('datastore.update', 'services.cifs', cifs.id, {'cifs_srv_enable_smb1': true})
+        confset2(smb4_conf, "server min protocol = NT1")
+    else:
+        if not cifs.enable_smb1:
+            confset2(smb4_conf, "server min protocol = SMB2_02")
+        else:
+            confset2(smb4_conf, "server min protocol = NT1")
 
     server_max_protocol = fs().services.smb.config.server_max_protocol
     if server_max_protocol != 'NONE':

--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -952,17 +952,8 @@ def generate_smb4_conf(client, smb4_conf, role):
     if os.path.exists("/usr/local/etc/smbusers"):
         confset1(smb4_conf, "username map = /usr/local/etc/smbusers")
 
-    sysctl_server_min_protocol = fs().services.smb.config.server_min_protocol
-
-    # Migrate to the enable_smb1_checkbox
-    if not cifs.enable_smb1 and sysctl_server_min_protocol == 'NT1':
-        client.call('datastore.update', 'services.cifs', cifs.id, {'cifs_srv_enable_smb1': true})
-        confset2(smb4_conf, "server min protocol = NT1")
-    else:
-        if cifs.enable_smb1:
-            confset2(smb4_conf, "server min protocol = NT1")
-        else:
-            confset2(smb4_conf, "server min protocol = SMB2_02")
+    if not cifs.enable_smb1:
+        confset2(smb4_conf, "server min protocol = SMB2_02")
 
     server_max_protocol = fs().services.smb.config.server_max_protocol
     if server_max_protocol != 'NONE':

--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -953,9 +953,9 @@ def generate_smb4_conf(client, smb4_conf, role):
         confset1(smb4_conf, "username map = /usr/local/etc/smbusers")
 
     if not cifs.enable_smb1:
-        confset2(smb4_conf, "server min protocol = SMB2_02")
+        confset1(smb4_conf, "server min protocol = SMB2_02")
     else:
-        confset2(smb4_conf, "server min protocol = NT1")
+        confset1(smb4_conf, "server min protocol = NT1")
 
     server_max_protocol = fs().services.smb.config.server_max_protocol
     if server_max_protocol != 'NONE':

--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -955,14 +955,14 @@ def generate_smb4_conf(client, smb4_conf, role):
     sysctl_server_min_protocol = fs().services.smb.config.server_min_protocol
 
     # Migrate to the enable_smb1_checkbox
-    if sysctl_server_min_protocol == 'NT1':
+    if not cifs.enable_smb1 and sysctl_server_min_protocol == 'NT1':
         client.call('datastore.update', 'services.cifs', cifs.id, {'cifs_srv_enable_smb1': true})
         confset2(smb4_conf, "server min protocol = NT1")
     else:
-        if not cifs.enable_smb1:
-            confset2(smb4_conf, "server min protocol = SMB2_02")
-        else:
+        if cifs.enable_smb1:
             confset2(smb4_conf, "server min protocol = NT1")
+        else:
+            confset2(smb4_conf, "server min protocol = SMB2_02")
 
     server_max_protocol = fs().services.smb.config.server_max_protocol
     if server_max_protocol != 'NONE':

--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -954,6 +954,8 @@ def generate_smb4_conf(client, smb4_conf, role):
 
     if not cifs.enable_smb1:
         confset2(smb4_conf, "server min protocol = SMB2_02")
+    else:
+        confset2(smb4_conf, "server min protocol = NT1")
 
     server_max_protocol = fs().services.smb.config.server_max_protocol
     if server_max_protocol != 'NONE':


### PR DESCRIPTION
tkt: 54954 
- add checkbox to enable_smb1
- remove UI change where we were hiding "unix extensions" based on value of server min protocol sysctl
- if sysctl is set to enable NT1, then check the "enable smb1" box when we generate the smb4.conf file.