### PR TITLE
tkt-57555: fix(jail/do_update): Throw validation error if plugin and rename are set (by skarekrow)

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -231,6 +231,10 @@ class JailService(CRUDService):
 
         verrors = self.common_validation(verrors, options, True, jail)
 
+        if name is not None and plugin:
+            verrors.add('options.plugin',
+                        'Cannot be true while trying to rename')
+
         if verrors:
             raise verrors
 


### PR DESCRIPTION
The plugin bool for options is meant to be used only for setting plugin properties. Those exposed by the settings.json of the plugin.

Trying to rename and set those will fail as the new location does not exist. We shouldn't allow this behavior. The UI also needs a ticket to not send plugin = True when calling do_update until it implements setting plugin properties.

Ticket: #56781