### PR TITLE
tkt-47675: SMART Temp alerts for specific disks

### DIFF
--- a/gui/storage/migrations/0011_disk_temperatures.py
+++ b/gui/storage/migrations/0011_disk_temperatures.py
@@ -1,0 +1,43 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('storage', '0010_auto_20180618_0340'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='disk',
+            name='disk_critical',
+            field=models.IntegerField(
+                blank=True, default=None,
+                help_text='Report as critical in the system log and send an email if the temperature is greater or '
+                          'equal than N degrees Celsius.',
+                null=True, verbose_name='Critical',
+                editable=False
+            ),
+        ),
+        migrations.AddField(
+            model_name='disk',
+            name='disk_difference',
+            field=models.IntegerField(
+                blank=True, default=None,
+                help_text='Report if the temperature has changed by at least N degrees Celsius since the last report.',
+                null=True, verbose_name='Difference',
+                editable=False
+            ),
+        ),
+        migrations.AddField(
+            model_name='disk',
+            name='disk_informational',
+            field=models.IntegerField(
+                blank=True, default=None,
+                help_text='Report as informational in the system log if the temperature is greater or equal than N '
+                          'degrees Celsius.',
+                null=True, verbose_name='Informational',
+                editable=False
+            ),
+        )
+    ]

--- a/gui/storage/models.py
+++ b/gui/storage/models.py
@@ -404,6 +404,41 @@ class Disk(Model):
         verbose_name=_("Password for SED"),
         blank=True
     )
+    disk_difference = models.IntegerField(
+        default=None,
+        verbose_name=_("Difference"),
+        help_text=_(
+            "Report if the temperature has changed by at least N "
+            "degrees Celsius since the last report. 0 to disable."
+        ),
+        null=True,
+        blank=True,
+        editable=False
+    )
+    disk_informational = models.IntegerField(
+        default=None,
+        verbose_name=_("Informational"),
+        help_text=_(
+            "Report as informational in the system log if the "
+            "temperature is greater or equal than N degrees Celsius. "
+            "0 to disable."
+        ),
+        null=True,
+        blank=True,
+        editable=False
+    )
+    disk_critical = models.IntegerField(
+        default=None,
+        verbose_name=_("Critical"),
+        help_text=_(
+            "Report as critical in the system log and send an "
+            "email if the temperature is greater or equal than N "
+            "degrees Celsius. 0 to disable."
+        ),
+        null=True,
+        blank=True,
+        editable=False
+    )
 
     def identifier_to_device(self):
         """

--- a/src/middlewared/middlewared/etc_files/smartd.py
+++ b/src/middlewared/middlewared/etc_files/smartd.py
@@ -43,8 +43,11 @@ async def ensure_smart_enabled(args):
 def get_smartd_config(disk):
     args = " ".join(disk["smartctl_args"])
 
-    config = f"{args} -n {disk['smart_powermode']} -W {disk['smart_difference']}," \
-             f"{disk['smart_informational']},{disk['smart_critical']}"
+    critical = disk['smart_critical'] if disk['disk_critical'] is None else disk['disk_critical']
+    difference = disk['smart_difference'] if disk['disk_difference'] is None else disk['disk_difference']
+    informational = disk['smart_informational'] if disk['disk_informational'] is None else disk['disk_informational']
+    config = f"{args} -n {disk['smart_powermode']} -W {difference}," \
+             f"{informational},{critical}"
 
     if disk['smart_email']:
         config += f" -m {disk['smart_email']}"

--- a/src/middlewared/middlewared/plugins/disk.py
+++ b/src/middlewared/middlewared/plugins/disk.py
@@ -118,7 +118,10 @@ class DiskService(CRUDService):
         if any(new[key] != old[key] for key in ['hddstandby', 'advpowermgmt', 'acousticlevel']):
             await self.middleware.call('notifier.start_ataidle', new['name'])
 
-        if any(new[key] != old[key] for key in ['togglesmart', 'smartoptions']):
+        if any(
+                new[key] != old[key]
+                for key in ['togglesmart', 'smartoptions', 'critical', 'difference', 'informational']
+        ):
 
             if new['togglesmart']:
                 await self.toggle_smart_on(new['name'])

--- a/src/middlewared/middlewared/plugins/disk.py
+++ b/src/middlewared/middlewared/plugins/disk.py
@@ -15,7 +15,7 @@ from bsd import geom, getswapinfo
 
 from middlewared.common.camcontrol import camcontrol_list
 from middlewared.common.smart.smartctl import get_smartctl_args
-from middlewared.schema import accepts, Bool, Dict, List, Str
+from middlewared.schema import accepts, Bool, Dict, Int, List, Str
 from middlewared.service import job, private, CallError, CRUDService
 from middlewared.utils import Popen, run
 from middlewared.utils.asyncio_ import asyncio_map
@@ -80,6 +80,9 @@ class DiskService(CRUDService):
             ]),
             Str('passwd', password=True),
             Str('smartoptions'),
+            Int('critical', null=True),
+            Int('difference', null=True),
+            Int('informational', null=True),
             update=True
         )
     )

--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -512,6 +512,10 @@ class ServiceService(CRUDService):
         os.environ['TZ'] = settings['stg_timezone']
         time.tzset()
 
+    async def _start_smartd(self, **kwargs):
+        await self.middleware.call("etc.generate", "smartd")
+        await self._service("smartd-daemon", "start", **kwargs)
+
     async def _reload_smartd(self, **kwargs):
         await self.middleware.call("etc.generate", "smartd")
         await self._service("smartd-daemon", "reload", **kwargs)


### PR DESCRIPTION
This commit adds a feature where an end user can directly set a temperature for a specific disk instead of having one temperature value applied to all disks. If the disk temperature value is set to NULL, then smartd service config temperature value is used for that disk.
Ticket: #47675