### PR TITLE
tkt-2: Tkt-54693: Swap being used up while memory is not used completely

### DIFF
--- a/src/freenas/boot/loader.conf
+++ b/src/freenas/boot/loader.conf
@@ -73,3 +73,9 @@ hw.usb.no_shutdown_wait=1
 # It improves NFS write throughput with ZFS sync=always.
 vfs.nfsd.fha.write=0
 vfs.nfsd.fha.max_nfsds_per_fh=32
+
+# Make pagedaemon always request kernel (primarily ZFS) to free memory
+# before even thinking about swapping.  It may be another extreme, but
+# hopefully it will be better then going out of swap, since arc_min won't
+# allow ARC to shrink too much if some application really require swap.
+vm.lowmem_period=0


### PR DESCRIPTION
Make pagedaemon always request kernel (primarily ZFS) to free memory
before even thinking about swapping.  It may be another extreme, but
hopefully it will be better then going out of swap, since arc_min won't
allow ARC to shrink too much if some application really require swap.

Ticket: #54693
(cherry picked from commit b2f44c5e727f2a20f1c7c531175c1e76106c3d78)