### PR TITLE
tkt-56430: Fix collectd df reporting

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-collectd
+++ b/src/freenas/etc/ix.rc.d/ix-collectd
@@ -280,9 +280,15 @@ LoadPlugin zfs_arc_v2
 </Plugin>
 
 <Plugin "df">
-    Mountpoint "/"
-    Mountpoint "^\/mnt(?:(?!\.zfs\/snapshot).)*$"
-    FSType "zfs"
+    Mountpoint "/^\/boot/"
+    Mountpoint "/\.zfs\/snapshot/"
+    Mountpoint "/\.system/"
+    Mountpoint "/\.warden/"
+    FSType "tmpfs"
+    FSType "nullfs"
+    FSType "devfs"
+    FSType "fdescfs"
+    ignoreSelected true
 </Plugin>
 EOF
 


### PR DESCRIPTION
- Switch to using ignoreSelected. This makes it easier to exclude certain paths
- Exclude .zfs/snapshot and .warden paths from reporting output.