### PR TITLE
tkt-58218: Clean Middlewared log

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/apache24/Includes/webdav.conf
+++ b/src/middlewared/middlewared/etc_files/local/apache24/Includes/webdav.conf
@@ -1,10 +1,8 @@
 <%
 	import crypt
-	import grp
 	import hashlib
 	import itertools
 	import os
-	import pwd
 	import random
 	import subprocess
 
@@ -16,12 +14,16 @@
 	if not os.path.isdir(oscmd):
 		os.mkdir(oscmd, 0o774)
 
-	# Changing permissions for all directories and files in oscmd
-	uid = pwd.getpwnam('webdav').pw_uid
-	gid = grp.getgrnam('webdav').gr_gid
+	# Changing ownership for all directories and files in oscmd
+	webdav_user = middleware.call_sync('user.query', [['username', '=', 'webdav']])
+	if not webdav_user:
+		uid, gid = 0, 0
+	else:
+		uid, gid = webdav_user[0]['uid'], webdav_user[0]['group']['bsdgrp_gid']
+
 	for root, dirs, files in os.walk(oscmd):
 		for o in list(itertools.chain(dirs, files)):
-			os.chmod(os.path.join(root, o), uid, gid)
+			os.chown(os.path.join(root, o), uid, gid)
 
 	webdav_config = middleware.call_sync('webdav.config')
 	auth_type = webdav_config['htauth'].lower()

--- a/src/middlewared/middlewared/plugins/webdav.py
+++ b/src/middlewared/middlewared/plugins/webdav.py
@@ -127,9 +127,6 @@ class WebDAVService(SystemServiceService):
     async def do_update(self, data):
         old = await self.config()
 
-        if old['certssl']:
-            old['certssl'] = old['certssl']['id']
-
         new = old.copy()
         new.update(data)
 


### PR DESCRIPTION
This commit fixes a bug which referenced webdav user while it didn't exist i.e on first boot.
Ticket: #58218