### PR TITLE
tkt-58581: fix(jail/exec): Use Str instead of RuntimeError instance for message

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -739,7 +739,7 @@ class JailService(CRUDService):
         try:
             msg = iocage.exec(command, host_user, jail_user, msg_return=True)
         except RuntimeError as e:
-            raise CallError(e)
+            raise CallError(str(e))
 
         return '\n'.join(msg)
 


### PR DESCRIPTION
Ticket: #58581