### PR TITLE
tkt-60201:  Validate AD config file during the AD start process (by anodos325)

### DIFF
--- a/src/freenas/etc/directoryservice/ActiveDirectory/ctl
+++ b/src/freenas/etc/directoryservice/ActiveDirectory/ctl
@@ -79,6 +79,12 @@ adctl_start()
 	local ad_started=0
 	touch "${start_file}"
 
+	#56751 - verify that servers in /etc/directoryservice/ActiveDirectory/config
+	#        are listening. If not, re-generate config.
+	if ! AD_validate_config
+		AD_remove_config
+	fi
+
 	if ! AD_init
 	then
 		activedirectory_set 1

--- a/src/freenas/etc/directoryservice/rc.ActiveDirectory
+++ b/src/freenas/etc/directoryservice/rc.ActiveDirectory
@@ -1069,7 +1069,7 @@ AD_generate_config()
 	fi
 	if [ ${res} = "1" ]
 	then
-		rm "${AD_CONFIG_FILE}"
+		AD_remove_config
 	fi
 
 	return ${res}

--- a/src/freenas/etc/directoryservice/rc.ActiveDirectory
+++ b/src/freenas/etc/directoryservice/rc.ActiveDirectory
@@ -1067,8 +1067,46 @@ AD_generate_config()
 		res=$?
 		/bin/chmod 600 "${AD_CONFIG_FILE}"
 	fi
+	if [ ${res} = "1" ]
+	then
+		rm "${AD_CONFIG_FILE}"
+	fi
 
 	return ${res}
+}
+
+AD_validate_config()
+{
+	if [ ! -s "${AD_CONFIG_FILE}" ]
+	then
+		return 1
+	fi
+
+	exec 3<&0
+	exec 0<"${AD_CONFIG_FILE}"
+
+	while read -r line
+	do
+		local is_dc="$(echo ${line}|grep 'ad_dcname')"
+		local is_gc="$(echo ${line}|grep 'ad_gcname')"
+		local is_krb="$(echo ${line}|grep 'ad_krbname')"
+		if [ "${is_dc}" ] || [ "${is_gc}" ] || [ "${is_krb}" ]
+		then
+			local val="$(echo ${line}|cut -f2- -d=|sed -Ee 's#^[[:space:]]+##' -e 's#[[:space:]]+$##')"
+			local server_address="$(echo ${val}|sed 's/\:/\ /')"
+			nc -vz -w 3 ${server_address} 2> /dev/null
+			res=$?
+
+			if [ ${res}  = "1" ]
+			then
+				return 1 
+			fi
+		fi
+
+	done
+	exec 0<&3
+
+	return 0
 }
 
 AD_remove_config()


### PR DESCRIPTION
Add sanity check to the AD start process. Check for stale entries in the config file (/etc/directoryservice/ActiveDirectory/config). Nuke it if we can't open a socket to the servers in it and force the config to regenerate.