### PR TITLE
tkt-56430: Fix collectd df reporting

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-collectd
+++ b/src/freenas/etc/ix.rc.d/ix-collectd
@@ -298,6 +298,7 @@ cat << EOF >> $cfg
     FSType "devfs"
     FSType "fdescfs"
     ignoreSelected true
+    LogOnce true
 </Plugin>
 
 <Plugin python>

--- a/src/freenas/etc/ix.rc.d/ix-collectd
+++ b/src/freenas/etc/ix.rc.d/ix-collectd
@@ -289,10 +289,15 @@ cat << EOF >> $cfg
 </Plugin>
 
 <Plugin "df">
-    Mountpoint "/"
-    Mountpoint "/^\/mnt\//"
-    FSType "zfs"
-    LogOnce true
+    Mountpoint "/^\/boot/"
+    Mountpoint "/\.zfs\/snapshot/"
+    Mountpoint "/\.system/"
+    Mountpoint "/\.warden/"
+    FSType "tmpfs"
+    FSType "nullfs"
+    FSType "devfs"
+    FSType "fdescfs"
+    ignoreSelected true
 </Plugin>
 
 <Plugin python>


### PR DESCRIPTION
- Switch to using ignoreSelected. This makes it easier to exclude certain paths
- Exclude .zfs/snapshot and .warden paths from reporting output.