### PR TITLE
tkt-59121:  Store workgroup discovered via LDAP in config db 

### DIFF
--- a/gui/common/freenasldap.py
+++ b/gui/common/freenasldap.py
@@ -1904,7 +1904,6 @@ class FreeNAS_ActiveDirectory_Base(object):
                 log.debug("Correcting value in freenas-v1.db")
                 Client().call('datastore.update', 'services.cifs', '1', {'cifs_srv_workgroup': netbios_name})
 
-
         except Exception:
             netbios_name = None
 

--- a/gui/common/freenasldap.py
+++ b/gui/common/freenasldap.py
@@ -65,7 +65,7 @@ from freenasUI.common.freenascache import (
     FLAGS_CACHE_WRITE_GROUP
 )
 
-from middlewared.client import Client
+from freenasUI.middleware.client import client
 
 log = logging.getLogger('common.freenasldap')
 
@@ -1796,15 +1796,18 @@ class FreeNAS_ActiveDirectory_Base(object):
                             break
 
         if ipv4_site and ipv6_site and ipv4_site == ipv6_site:
-            Client().call('datastore.update', 'directoryservice.activedirectory', '1', {'ad_site': ipv4_site})
+            with client as c:
+                c.call('datastore.update', 'directoryservice.activedirectory', '1', {'ad_site': ipv4_site})
             return ipv4_site
 
         if not ipv6_site and ipv4_site:
-            Client().call('datastore.update', 'directoryservice.activedirectory', '1', {'ad_site': ipv4_site})
+            with client as c:
+                c.call('datastore.update', 'directoryservice.activedirectory', '1', {'ad_site': ipv4_site})
             return ipv4_site
 
         if not ipv4_site and ipv6_site:
-            Client().call('datastore.update', 'directoryservice.activedirectory', '1', {'ad_site': ipv6_site})
+            with client as c:
+                c.call('datastore.update', 'directoryservice.activedirectory', '1', {'ad_site': ipv6_site})
             return ipv6_site
 
         return None
@@ -1893,7 +1896,8 @@ class FreeNAS_ActiveDirectory_Base(object):
             basedn
 
         netbios_name = None
-        smb = Client().call('smb.config')
+        with client as c:
+            smb = c.call('smb.config')
         results = self._search(
             self.dchandle, config, ldap.SCOPE_SUBTREE, filter
         )
@@ -1902,7 +1906,8 @@ class FreeNAS_ActiveDirectory_Base(object):
             if netbios_name != smb['workgroup']:
                 log.debug(f"Database workgroup {smb['workgroup']} does not match LDAP value: {netbios_name}")
                 log.debug("Correcting value in freenas-v1.db")
-                Client().call('datastore.update', 'services.cifs', '1', {'cifs_srv_workgroup': netbios_name})
+                with client as c:
+                    c.call('datastore.update', 'services.cifs', '1', {'cifs_srv_workgroup': netbios_name})
 
         except Exception:
             netbios_name = None

--- a/gui/common/freenasldap.py
+++ b/gui/common/freenasldap.py
@@ -1893,11 +1893,17 @@ class FreeNAS_ActiveDirectory_Base(object):
             basedn
 
         netbios_name = None
+        smb = Client().call('smb.config')
         results = self._search(
             self.dchandle, config, ldap.SCOPE_SUBTREE, filter
         )
         try:
             netbios_name = results[0][1]['nETBIOSName'][0].decode('utf8')
+            if netbios_name != smb['workgroup']:
+                log.debug(f"Database workgroup {smb['workgroup']} does not match LDAP value: {netbios_name}")
+                log.debug("Correcting value in freenas-v1.db")
+                Client().call('datastore.update', 'services.cifs', '1', {'cifs_srv_workgroup': netbios_name})
+
 
         except Exception:
             netbios_name = None

--- a/src/middlewared/middlewared/etc_files/local/smb4.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf
@@ -107,7 +107,7 @@
         def add_rolebased_params(pc, db):
             if db['role'] == "ad_member":
                 pc.update({'server role': 'member server'})
-                pc.update({'workgroup': db['ad']['ad_domainname'].upper().split(".")[0]})
+                pc.update({'workgroup': db['cifs']['workgroup'].upper()})
                 pc.update({'realm': db['ad']['ad_domainname'].upper()})
                 pc.update({'security': 'ADS'})
                 pc.update({'client use spnego': 'Yes'})


### PR DESCRIPTION
In AD environment we discover the short name of domain via LDAP query. This introduces a point of failure in smb.conf generation because we need a functional service account to get this value. New behavior is to discover the value and update the 'workgroup' field in the SMB table of the config if needed.