### PR TITLE
Store workgroup discovered via LDAP in config db 

### DIFF
--- a/gui/common/freenasldap.py
+++ b/gui/common/freenasldap.py
@@ -1949,7 +1949,6 @@ class FreeNAS_ActiveDirectory_Base(object):
                 log.debug("Correcting value in freenas-v1.db")
                 Client().call('datastore.update', 'services.cifs', '1', {'cifs_srv_workgroup': netbios_name})
 
-
         except Exception:
             netbios_name = None
 

--- a/gui/common/freenasldap.py
+++ b/gui/common/freenasldap.py
@@ -1938,11 +1938,17 @@ class FreeNAS_ActiveDirectory_Base(object):
             basedn
 
         netbios_name = None
+        smb = Client().call('smb.config')
         results = self._search(
             self.dchandle, config, ldap.SCOPE_SUBTREE, filter
         )
         try:
             netbios_name = results[0][1]['nETBIOSName'][0].decode('utf8')
+            if netbios_name != smb['workgroup']:
+                log.debug(f"Database workgroup {smb['workgroup']} does not match LDAP value: {netbios_name}")
+                log.debug("Correcting value in freenas-v1.db")
+                Client().call('datastore.update', 'services.cifs', '1', {'cifs_srv_workgroup': netbios_name})
+
 
         except Exception:
             netbios_name = None

--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -787,6 +787,7 @@ def add_activedirectory_conf(client, smb4_conf):
 
     try:
         ad = Struct(client.call('datastore.query', 'directoryservice.ActiveDirectory', None, {'get': True}))
+        cifs = client.call('smb.config')
         ad.ds_type = 1  # FIXME: DS_TYPE_ACTIVEDIRECTORY = 1
     except Exception as e:
         return
@@ -805,7 +806,7 @@ def add_activedirectory_conf(client, smb4_conf):
         fad = Struct(client.call('notifier.directoryservice', 'AD'))
         ad_workgroup = fad.netbiosname.upper()
     except Exception as e:
-        ad_workgroup = ad.ad_domainname.upper().split(".")[0]
+        ad_workgroup = cifs['workgroup'].upper()
 
     confset2(smb4_conf, "workgroup = %s", ad_workgroup)
     confset2(smb4_conf, "realm = %s", ad.ad_domainname.upper())


### PR DESCRIPTION
In AD environment we discover the short name of domain via LDAP query. This introduces a point of failure in smb.conf generation because we need a functional service account to get this value. New behavior is to discover the value and update the 'workgroup' field in the SMB table of the config if needed.