### PR TITLE
tkt-41220: Leave temporary keytabs in place

### DIFF
--- a/src/middlewared/middlewared/etc_files/krb5.keytab.py
+++ b/src/middlewared/middlewared/etc_files/krb5.keytab.py
@@ -25,8 +25,6 @@ async def write_keytab(db_keytabname, db_keytabfile):
     if ktutil_errs:
         logger.debug(f'Keytab generation failed with error: {ktutil_errs}')
 
-    os.remove(temp_keytab)
-
 
 async def render(service, middleware):
     keytabs = await middleware.call("datastore.query", "directoryservice.kerberoskeytab")


### PR DESCRIPTION
Some directory service code still references temporary keytabs rather than using the default system one. Leave temporary ones in place until we've cleaned up other parts of kerberos code.