### PR TITLE
tkt-43558: [loader.conf] Raise max TCP segment queue length

### DIFF
--- a/src/freenas/boot/loader.conf
+++ b/src/freenas/boot/loader.conf
@@ -43,6 +43,10 @@ module_path="/boot/kernel;/boot/modules;/usr/local/modules"
 # if IPv6 is configured for the interface later on in boot.
 net.inet6.ip6.auto_linklocal="0"
 
+# Relax the TCP reassembly queue length limit to improve performance
+# in the event of packet loss or reordering.
+net.inet.tcp.reass.maxqueuelen=1448
+
 # Switch ZVOLs into "dev" mode, skipping GEOM.
 vfs.zfs.vol.mode=2
 

--- a/src/freenas/etc/sysctl.conf
+++ b/src/freenas/etc/sysctl.conf
@@ -16,6 +16,3 @@ net.link.lagg.lacp.default_strict_mode=0
 
 # Force minimal 4KB ashift for new top level ZFS VDEVs.
 vfs.zfs.min_auto_ashift=12
-
-# Set a more reasonable max segment queue length for TCP reassembly.
-net.inet.tcp.reass.maxqueuelen=1448

--- a/src/freenas/etc/sysctl.conf
+++ b/src/freenas/etc/sysctl.conf
@@ -16,3 +16,6 @@ net.link.lagg.lacp.default_strict_mode=0
 
 # Force minimal 4KB ashift for new top level ZFS VDEVs.
 vfs.zfs.min_auto_ashift=12
+
+# Set a more reasonable max segment queue length for TCP reassembly.
+net.inet.tcp.reass.maxqueuelen=1448


### PR DESCRIPTION
Out-of-order TCP segments are queued in the reassembly queue until the missing in-sequence segments arrive.  As a DoS mitigation, the length of this queue is limited, with a default of 100.  Since TCP allows a whole window to be in-flight at once, there can be up to 1448 to 11586 segments arriving before the sender expects an ACK, depending on the configured max receive buffer size and negotiated window size.  The limit of 100 is not usually an issue in wired networks, because segments seldom arrive out of order.  However, reordering and/or losses are more frequent with wireless networks, so the low default limit can cause a lot of segments to be discarded.

Raise the limit to 1448, which allows a full window to be queued in the default configuration, and also improves the behavior while retaining some sensible mitigation against DoS when the max receive buffer length has been raised to 16 MiB (for example by the autotune script).

Ticket: #43558