### PR TITLE
tkt-61659: fix(jail/rc_action): RESTART now works as intended

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -541,9 +541,7 @@ class JailService(CRUDService):
         elif action == "STOP":
             iocage.stop()
         else:
-            iocage.stop()
-            time.sleep(0.5)
-            iocage.start()
+            iocage.restart()
 
         return True
 

--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import time
 import subprocess as su
 
 import iocage_lib.iocage as ioc


### PR DESCRIPTION
Previous behavior would have the same cached list and that would cause issues with start. This instantiates a new instance for both actions.

Ticket: #61659