### PR TITLE
Bug fix for alert file

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-nginx
+++ b/src/freenas/etc/ix.rc.d/ix-nginx
@@ -263,6 +263,11 @@ __EOF__
 		fi
 	fi
 
+	if [ "${proto}" = "http" -a -f /tmp/alert_invalid_ssl_nginx ]; then
+	# Let's remove ssl invalid nginx alert file if protocol is http
+		rm /tmp/alert_invalid_ssl_nginx
+	fi
+
 	if [ ! ${working_ssl} -o "${proto}" = "http" -o "${proto}" = "httphttps" ]; then
 		echo "        listen       ${addr}:${port};"
 		echo "        listen       [${addr6}]:${port};"


### PR DESCRIPTION
This commit fixes a bug when protocol for system was set to HTTP and nginx did not remove a ssl invalid alert file which was created when the protocol was either http or httphttps.
Ticket: #62478