### PR TITLE
tkt-62883: Disallow certs with keysize less then 1024

### DIFF
--- a/gui/system/migrations/0034_cert_key_lengths.py
+++ b/gui/system/migrations/0034_cert_key_lengths.py
@@ -1,0 +1,36 @@
+from django.db import migrations
+
+from OpenSSL import crypto
+import itertools
+
+
+def normalize_key_length(apps, schema_editor):
+    # TODO: Talk to William, Perhaps let's remove all the attributes which can be obtained from parsing cert/privatekey
+
+    ca_model = apps.get_model('system', 'certificateauthority')
+    certificate_model = apps.get_model('system', 'certificate')
+    for cert in itertools.chain(certificate_model.objects.all(), ca_model.objects.all()):
+        if cert.cert_privatekey:
+            try:
+                cert.cert_key_length = crypto.load_privatekey(
+                    crypto.FILETYPE_PEM, cert.cert_privatekey
+                ).bits()
+            except crypto.Error:
+                # Let's pass this to ensure very old private keys which might be malformed
+                # not raise exceptions
+                pass
+            else:
+                cert.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('system', '0033_acme_models'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            normalize_key_length
+        )
+    ]

--- a/gui/system/models.py
+++ b/gui/system/models.py
@@ -64,7 +64,10 @@ class Settings(Model):
     stg_guicertificate = models.ForeignKey(
         "Certificate",
         verbose_name=_("Certificate for HTTPS"),
-        limit_choices_to={'cert_type__in': [CERT_TYPE_EXISTING, CERT_TYPE_INTERNAL]},
+        limit_choices_to={
+            'cert_type__in': [CERT_TYPE_EXISTING, CERT_TYPE_INTERNAL],
+            'cert_key_length__in': [1024, 2048, 4096]
+        },
         on_delete=models.SET_NULL,
         blank=True,
         null=True

--- a/src/middlewared/middlewared/plugins/crypto.py
+++ b/src/middlewared/middlewared/plugins/crypto.py
@@ -138,18 +138,18 @@ async def _validate_common_attributes(middleware, data, verrors, schema_name):
     private_key = data.get('privatekey')
     passphrase = data.get('passphrase')
     if private_key:
-        if not load_private_key(private_key, passphrase):
+        private_key_obj = load_private_key(private_key, passphrase)
+        if not private_key_obj:
             verrors.add(
                 f'{schema_name}.privatekey',
                 'Please provide a valid private key with matching passphrase ( if any )'
             )
-
-    key_length = data.get('key_length')
-    if key_length:
-        if key_length not in [1024, 2048, 4096]:
+        elif 'create' in schema_name and private_key_obj.bits() < 1024:
+            # When a cert/ca is being created, we disallow keys with size less then 1024
+            # Update is allowed for now for keeping compatibility with very old cert/keys
             verrors.add(
-                f'{schema_name}.key_length',
-                'Key length must be a valid value ( 1024, 2048, 4096 )'
+                f'{schema_name}.privatekey',
+                'Please provide a key with size greater then or equal to 1024'
             )
 
     signedby = data.get('signedby')
@@ -411,14 +411,6 @@ class CertificateService(CRUDService):
             return self.get_x509_subject(csr)
 
     @private
-    async def get_fingerprint_of_cert(self, certificate_id):
-        cert = await self._get_instance(certificate_id)
-        return await self.middleware.run_in_thread(
-            self.fingerprint,
-            cert['certificate']
-        )
-
-    @private
     @accepts(
         Str('cert_certificate', required=True)
     )
@@ -452,7 +444,7 @@ class CertificateService(CRUDService):
     @accepts(
         Dict(
             'certificate_cert_info',
-            Int('key_length'),
+            Int('key_length', enum=[1024, 2048, 4096]),
             Int('serial', required=False, null=True),
             Int('lifetime', required=True),
             Str('country', required=True),
@@ -774,7 +766,7 @@ class CertificateService(CRUDService):
             Dict('dns_mapping', additional_attrs=True),
             Int('csr_id'),
             Int('signedby'),
-            Int('key_length'),
+            Int('key_length', enum=[1024, 2048, 4096]),
             Int('renew_days'),
             Int('type'),
             Int('lifetime'),


### PR DESCRIPTION
This commit introduces 3 changes:
1) Disallow importing of certificates/CSR which have key size less then 1024
2) Normalize key length values wrt their certificate/CSR's so that they reflect the certficate state accurately
3) Make sure nginx configuration does not use a certificate with key length less then 1024
Ticket: #62883