### PR TITLE
tkt-62892: Disallow certs with keysize less then 1024

### DIFF
--- a/gui/system/migrations/0029_cert_key_lengths.py
+++ b/gui/system/migrations/0029_cert_key_lengths.py
@@ -1,0 +1,38 @@
+from django.db import migrations
+
+from OpenSSL import crypto
+import itertools
+
+# FIXME: Talk to william about the best way to handle migrations in different branches
+
+
+def normalize_key_length(apps, schema_editor):
+    # TODO: Talk to William, Perhaps let's remove all the attributes which can be obtained from parsing cert/privatekey
+
+    ca_model = apps.get_model('system', 'certificateauthority')
+    certificate_model = apps.get_model('system', 'certificate')
+    for cert in itertools.chain(certificate_model.objects.all(), ca_model.objects.all()):
+        if cert.cert_privatekey:
+            try:
+                cert.cert_key_length = crypto.load_privatekey(
+                    crypto.FILETYPE_PEM, cert.cert_privatekey
+                ).bits()
+            except crypto.Error:
+                # Let's pass this to ensure very old private keys which might be malformed
+                # not raise exceptions
+                pass
+            else:
+                cert.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('system', '0028_cert_serials'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            normalize_key_length
+        )
+    ]

--- a/gui/system/models.py
+++ b/gui/system/models.py
@@ -70,7 +70,10 @@ class Settings(Model):
     stg_guicertificate = models.ForeignKey(
         "Certificate",
         verbose_name=_("Certificate"),
-        limit_choices_to={'cert_type__in': [CERT_TYPE_EXISTING, CERT_TYPE_INTERNAL]},
+        limit_choices_to={
+            'cert_type__in': [CERT_TYPE_EXISTING, CERT_TYPE_INTERNAL],
+            'cert_key_length__in': [1024, 2048, 4096]
+        },
         on_delete=models.SET_NULL,
         blank=True,
         null=True


### PR DESCRIPTION
This commit introduces 3 changes:
1) Disallow importing of certificates/CSR which have key size less then 1024
2) Normalize key length values wrt their certificate/CSR's so that they reflect the certficate state accurately
3) Make sure nginx configuration does not use a certificate with key length less then 1024
Ticket: #62892