### PR TITLE
tkt-63108: Improve krb5.conf generation and fix some bugs for edge cases (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/krb5.conf
+++ b/src/middlewared/middlewared/etc_files/krb5.conf
@@ -69,9 +69,10 @@
             return section_conf
 
         db = {}
+        db_realms = []
+        environment_is_kerberized = False
         db['ad'] = middleware.call_sync('datastore.query', 'directoryservice.activedirectory', None, {'get': True})
         db['ldap'] = middleware.call_sync('datastore.query', 'directoryservice.ldap', None, {'get': True})
-        db['cifs'] = middleware.call_sync('datastore.query', 'services.cifs', None, {'get': True})
         db['krb_aux'] = middleware.call_sync('datastore.query', 'directoryservice.kerberossettings', None, {'get': True})
         db_realms = middleware.call_sync('datastore.query', 'directoryservice.kerberosrealm')
         appdefaults = {'pam': {'forwardable': 'true', 'ticket_lifetime': '86400', 'renew_lifetime': '86400'}}
@@ -82,16 +83,43 @@
                                       'dns_lookup_kdc': 'true',
                                       'ticket_lifetime': '24h',
                                       'clockskew': '300',
-                                      'forwadable': 'yes'
+                                      'forwardable': 'yes'
                                      }
                        }
 
-        if db['ad']['ad_enable'] and db['ad']['ad_kerberos_realm']['krb_realm']:
+        """
+            Active Directory environments are always kerberized. This means
+            we make best effort to make a valid krb5.conf and update set correct
+            values in the configuration database.
+
+            On the other hand, not all LDAP environments are kerberized so we cannot guess the correct
+            realm in this case.
+        """
+        if db['ad']['ad_enable'] and db['ad']['ad_kerberos_realm']:
+            environment_is_kerberized = True
             krb_default_realm = db['ad']['ad_kerberos_realm']['krb_realm']
         elif db['ad']['ad_enable']:
+            environment_is_kerberized = True
             krb_default_realm = db['ad']['ad_domainname']
+            db_realm_entry = next((item for item in db_realms if item['krb_realm'] == krb_default_realm), None)
+            if db_realm_entry:
+                middleware.call_sync(
+                    'datastore.update',
+                    'directoryservice.activedirectory', '1',
+                    {'ad_kerberos_realm_id': db_realm_entry['id']}
+                )
+                db_realms.append({f"{db_realm_entry}['realm']": db_realm_entry})
+            else:
+                middleware.call_sync(
+                    'datastore.insert', 
+                    'directoryservice.kerberosrealm', 
+                    {'krb_realm': krb_default_realm}
+                )
+                db_realms.append({f"{krb_default_realm}['realm']": krb_default_realm})
+
         elif db['ldap']['ldap_enable'] and db['ldap']['ldap_kerberos_realm']:
-            krb_default_realm = db['ldap']['ldap_kerberos_realm']
+            environment_is_kerberized = True
+            krb_default_realm = db['ldap']['ldap_kerberos_realm']['krb_realm']
         else:
             krb_default_realm = None
 
@@ -100,10 +128,10 @@
 
         parsed_appdefaults = parse_defaults("appdefault", appdefaults, db_def=db['krb_aux']['ks_appdefaults_aux'])
         parsed_libdefaults = parse_defaults("libdefault", libdefaults, db_def=db['krb_aux']['ks_libdefaults_aux'])
-        db_realms = middleware.call_sync('datastore.query', 'directoryservice.kerberosrealm')
 
 %>
-[app_defaults]
+% if environment_is_kerberized:
+[appdefaults]
 % for section_name, section in parsed_appdefaults.items():
             % if section_name == "krb5_main":
             % for binding, value in section.items():
@@ -118,7 +146,7 @@
             % endif
 % endfor
 
-[lib_defaults]
+[libdefaults]
 % for section_name, section in parsed_libdefaults.items():
             % for binding, value in section.items():
             ${binding} = ${value}
@@ -151,3 +179,4 @@
 
 [logging]
             default = SYSLOG:INFO:LOCAL7
+% endif


### PR DESCRIPTION
- Remove unnecessary datastore queries
- Recover from situations where kerberos realm isn't configured correctly in AD enviornment
- Only fill out contents in kerberized environments
- fix typos