### PR TITLE
tkt-62766: fix(jail/query): Catch subprocess exception

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -76,9 +76,12 @@ class JailService(CRUDService):
                                 interface = 'epair0b'
                             ip4_cmd = ['jexec', f'ioc-{uuid}', 'ifconfig',
                                        interface, 'inet']
-                            out = su.check_output(ip4_cmd)
-                            jail['ip4_addr'] = f'{interface}|' \
-                                f'{out.splitlines()[2].split()[1].decode()}'
+                            try:
+                                out = su.check_output(ip4_cmd)
+                                out = out.splitlines()[2].split()[1].decode()
+                                jail['ip4_addr'] = f'{interface}|{out}'
+                            except (su.CalledProcessError, IndexError):
+                                jail['ip4_addr'] = f'{interface}|ERROR'
                         else:
                             jail['ip4_addr'] = 'DHCP (not running)'
                     jails.append(jail)


### PR DESCRIPTION
If the user has some interface issue, this would have halted all jails being returned.

Ticket: #62766