### PR TITLE
tkt-62574: Show Certificate validity period accurately

### DIFF
--- a/gui/system/models.py
+++ b/gui/system/models.py
@@ -935,7 +935,7 @@ class CertificateBase(Model):
         try:
             before = thingy.get_notBefore()
             t1 = dtparser.parse(before)
-            t2 = t1.astimezone(dateutil.tz.tzutc())
+            t2 = t1.astimezone(dateutil.tz.tzlocal())
             before = t2.ctime()
         except Exception:
             before = None
@@ -953,7 +953,7 @@ class CertificateBase(Model):
         try:
             after = thingy.get_notAfter()
             t1 = dtparser.parse(after)
-            t2 = t1.astimezone(dateutil.tz.tzutc())
+            t2 = t1.astimezone(dateutil.tz.tzlocal())
             after = t2.ctime()
         except Exception:
             after = None

--- a/src/middlewared/middlewared/plugins/crypto.py
+++ b/src/middlewared/middlewared/plugins/crypto.py
@@ -295,12 +295,12 @@ class CertificateService(CRUDService):
             obj = crypto.load_certificate(crypto.FILETYPE_PEM, cert['certificate'])
             notBefore = obj.get_notBefore()
             t1 = dateutil.parser.parse(notBefore)
-            t2 = t1.astimezone(dateutil.tz.tzutc())
+            t2 = t1.astimezone(dateutil.tz.tzlocal())
             cert['from'] = t2.ctime()
 
             notAfter = obj.get_notAfter()
             t1 = dateutil.parser.parse(notAfter)
-            t2 = t1.astimezone(dateutil.tz.tzutc())
+            t2 = t1.astimezone(dateutil.tz.tzlocal())
             cert['until'] = t2.ctime()
 
         if obj:


### PR DESCRIPTION
This commit fixes a bug where the certificate date was being presented as local time whereas it was in GMT resulting in misunderstanding. Now the certificate date is set in GMT and when being presented by the API, it presents it after converting to local time.
Ticket: #62574