### PR TITLE
tkt-64656: fix(middlewared/vm): process is already being kill after (by william-gr)

### DIFF
--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -422,8 +422,7 @@ class VMSupervisor(object):
             if bhyve_error:
                 self.logger.error('===> Stopping VM error: {0}'.format(bhyve_error))
         else:
-            os.kill(self.proc.pid, signal.SIGTERM)
-            self.logger.debug('===> Soft Stop VM: {0} ID: {1} BHYVE_CODE: {2}'.format(self.vm['name'], self.vm['id'], self.bhyve_error))
+            self.logger.debug('===> Soft Stop VM: {0} ID: {1}'.format(self.vm['name'], self.vm['id']))
 
         self.destroy_tap()
         return await self.kill_bhyve_pid()


### PR DESCRIPTION
Also there is no point in showing bhyve_error right after kill, odds are
process will not exit and set status so fast.

Ticket:	#64635