### PR TITLE
Allow middleware to control swap mirroring on boot disks

### DIFF
--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -603,19 +603,6 @@ partition_disks()
     return 0
 }
 
-make_swap()
-{
-    local _swapparts
-
-    # Skip the swap creation if installing into a BE (Swap already exists in that case)
-    if [ "${_upgrade_type}" != "inplace" ] ; then
-	_swapparts=$(for _disk in $*; do echo ${_disk}p3; done)
-	gmirror destroy -f swap || true
-	gmirror label -b prefer swap ${_swapparts}
-    fi
-    echo "/dev/mirror/swap.eli		none			swap		sw		0	0" > /tmp/data/data/fstab.swap
-}
-
 disk_is_freenas()
 {
     local _disk="$1"
@@ -1168,9 +1155,6 @@ menu_install()
     /usr/local/bin/freenas-install -P /.mount/${OS}/Packages -M /.mount/${OS}-MANIFEST /tmp/data
 
     rm -f /tmp/data/conf/default/etc/fstab /tmp/data/conf/base/etc/fstab
-    if is_swap_safe; then
-       make_swap ${_realdisks}
-    fi
     ln /tmp/data/etc/fstab /tmp/data/conf/base/etc/fstab || echo "Cannot link fstab"
     if [ "${_do_upgrade}" -ne 0 ]; then
 	if [ -f /tmp/hostid ]; then

--- a/src/freenas/etc/rc.conf
+++ b/src/freenas/etc/rc.conf
@@ -31,17 +31,16 @@ devfs_system_ruleset="usbrules"
 # System's run from memory disks.
 clear_tmp_X="NO"
 
-#Do not mark to autodetach otherwise ZFS get very unhappy
+# Do not mark to autodetach otherwise ZFS gets very unhappy.
 geli_autodetach="NO"
 
-# get crashdumps
-dumpdev="AUTO"
+# We set dumpdev and run savecore in middleware.  The savecore rc script
+# just errors out by the time it runs, and setting dumpdev to AUTO causes
+# the dump device to be changed from the one we actually wanted to use.
+savecore_enable="NO"
+dumpdev="NO"
 dumpdir="/data/crash"
 ix_textdump_enable="YES"
-
-# We run savecore in middleware.  The rc script
-# just errors out by the time it runs.
-savecore_enable="NO"
 
 # A set of storage supporting kernel modules, they must be loaded before ix-fstab.
 early_kld_list="geom_multipath"

--- a/src/middlewared/middlewared/plugins/disk.py
+++ b/src/middlewared/middlewared/plugins/disk.py
@@ -34,6 +34,10 @@ RE_ISDISK = re.compile(r'^(da|ada|vtbd|mfid|nvd|pmem)[0-9]+$')
 RE_MPATH_NAME = re.compile(r'[a-z]+(\d+)')
 RE_SED_RDLOCK_EN = re.compile(r'(RLKEna = Y|ReadLockEnabled:\s*1)', re.M)
 RE_SED_WRLOCK_EN = re.compile(r'(WLKEna = Y|WriteLockEnabled:\s*1)', re.M)
+RAWTYPE = {
+    'freebsd-zfs':  '516e7cba-6ecf-11d6-8ff8-00022d09712b',
+    'freebsd-swap': '516e7cb5-6ecf-11d6-8ff8-00022d09712b',
+}
 
 
 class DiskService(CRUDService):
@@ -663,8 +667,7 @@ class DiskService(CRUDService):
             for g in klass.geoms:
                 for p in g.providers:
                     if p.name == name:
-                        # freebsd-zfs partition
-                        if p.config['rawtype'] == '516e7cba-6ecf-11d6-8ff8-00022d09712b':
+                        if p.config['rawtype'] == RAWTYPE['freebsd-zfs']:
                             return f'{{uuid}}{p.config["rawuuid"]}'
 
         g = geom.geom_by_name('LABEL', name)
@@ -1215,7 +1218,7 @@ class DiskService(CRUDService):
         for g in klass.geoms:
             for p in g.providers:
                 # if swap partition
-                if p.config['rawtype'] == '516e7cb5-6ecf-11d6-8ff8-00022d09712b':
+                if p.config['rawtype'] == RAWTYPE['freebsd-swap']:
                     if p.name not in used_partitions:
                         # Try to save a core dump from that.
                         # Only try savecore if the partition is not already in use
@@ -1279,7 +1282,7 @@ class DiskService(CRUDService):
             if not partgeom:
                 continue
             for p in partgeom.providers:
-                if p.config['rawtype'] == '516e7cb5-6ecf-11d6-8ff8-00022d09712b':
+                if p.config['rawtype'] == RAWTYPE['freebsd-swap']:
                     providers[p.id] = p
                     break
 

--- a/src/middlewared/middlewared/plugins/disk.py
+++ b/src/middlewared/middlewared/plugins/disk.py
@@ -1246,7 +1246,7 @@ class DiskService(CRUDService):
                     if name is None:
                         # Which means maximum has been reached and we can stop
                         break
-                    await run('gmirror', 'create', '-b', 'prefer', name, part_a, part_b)
+                    await run('gmirror', 'create', '-F', name, part_a, part_b)
                 except Exception:
                     self.logger.warn(f'Failed to create gmirror {name}', exc_info=True)
                     continue


### PR DESCRIPTION
Middleware can manage the mirroring on its own as long as we have created the partitions. Don't label swap partitions for automatic gmirror during installation.

The swap mirrors are encrypted with a onetime key. There's nothing of value to save. Don't synchronize the swap mirrors after unclean shutdown.

Middleware manages choosing a dumpdev. Don't let the dumpon rc script interfere.

We have chosen dumpdev as a partition instead of the mirror, so there is no need to use `prefer` (which only uses one disk for reads). Instead, we can use the default `load` balancing algorithm (which can read from more than one disk at once). Don't use the `prefer` mirror balancing algorithm.

The raw identifiers for geom partition types are long and difficult do tell apart. Refer to them by name instead.