### PR TITLE
tkt-60219: Allow middleware to control swap mirroring on boot disks

### DIFF
--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -523,19 +523,6 @@ partition_disk() {
 	return 0
 }
 
-make_swap()
-{
-    local _swapparts
-
-    # Skip the swap creation if installing into a BE (Swap already exists in that case)
-    if [ "${_upgrade_type}" != "inplace" ] ; then
-      _swapparts=$(for _disk in $*; do echo ${_disk}p3; done)
-      gmirror destroy -f swap || true
-      gmirror label -b prefer swap ${_swapparts}
-    fi
-    echo "/dev/mirror/swap.eli		none			swap		sw		0	0" > /tmp/data/data/fstab.swap
-}
-
 disk_is_freenas()
 {
     local _disk="$1"
@@ -1096,9 +1083,6 @@ menu_install()
     /usr/local/bin/freenas-install -P /.mount/${OS}/Packages -M /.mount/${OS}-MANIFEST /tmp/data
 
     rm -f /tmp/data/conf/default/etc/fstab /tmp/data/conf/base/etc/fstab
-    if is_truenas; then
-       make_swap ${_realdisks}
-    fi
     ln /tmp/data/etc/fstab /tmp/data/conf/base/etc/fstab || echo "Cannot link fstab"
     if [ "${_do_upgrade}" -ne 0 ]; then
 	if [ -f /tmp/hostid ]; then

--- a/src/freenas/etc/rc.conf
+++ b/src/freenas/etc/rc.conf
@@ -31,17 +31,16 @@ devfs_system_ruleset="usbrules"
 # System's run from memory disks.
 clear_tmp_X="NO"
 
-#Do not mark to autodetach otherwise ZFS get very unhappy
+# Do not mark to autodetach otherwise ZFS gets very unhappy.
 geli_autodetach="NO"
 
-# get crashdumps
-dumpdev="AUTO"
+# We set dumpdev and run savecore in middleware.  The savecore rc script
+# just errors out by the time it runs, and setting dumpdev to AUTO causes
+# the dump device to be changed from the one we actually wanted to use.
+savecore_enable="NO"
+dumpdev="NO"
 dumpdir="/data/crash"
 ix_textdump_enable="YES"
-
-# We run savecore in middleware.  The rc script
-# just errors out by the time it runs.
-savecore_enable="NO"
 
 # A set of storage supporting kernel modules, they must be loaded before ix-fstab.
 early_kld_list="geom_multipath"

--- a/src/middlewared/middlewared/plugins/disk.py
+++ b/src/middlewared/middlewared/plugins/disk.py
@@ -937,7 +937,7 @@ class DiskService(CRUDService):
                     if name is None:
                         # Which means maximum has been reached and we can stop
                         break
-                    await run('gmirror', 'create', '-b', 'prefer', name, part_a, part_b)
+                    await run('gmirror', 'create', name, part_a, part_b)
                 except Exception:
                     self.logger.warn(f'Failed to create gmirror {name}', exc_info=True)
                     continue

--- a/src/middlewared/middlewared/plugins/disk.py
+++ b/src/middlewared/middlewared/plugins/disk.py
@@ -36,6 +36,10 @@ RE_ISDISK = re.compile(r'^(da|ada|vtbd|mfid|nvd|pmem)[0-9]+$')
 RE_MPATH_NAME = re.compile(r'[a-z]+(\d+)')
 RE_SED_RDLOCK_EN = re.compile(r'(RLKEna = Y|ReadLockEnabled:\s*1)', re.M)
 RE_SED_WRLOCK_EN = re.compile(r'(WLKEna = Y|WriteLockEnabled:\s*1)', re.M)
+RAWTYPE = {
+    'freebsd-zfs': '516e7cba-6ecf-11d6-8ff8-00022d09712b',
+    'freebsd-swap': '516e7cb5-6ecf-11d6-8ff8-00022d09712b',
+}
 
 
 class DiskService(CRUDService):
@@ -364,8 +368,7 @@ class DiskService(CRUDService):
             for g in klass.geoms:
                 for p in g.providers:
                     if p.name == name:
-                        # freebsd-zfs partition
-                        if p.config['rawtype'] == '516e7cba-6ecf-11d6-8ff8-00022d09712b':
+                        if p.config['rawtype'] == RAWTYPE['freebsd-zfs']:
                             return f'{{uuid}}{p.config["rawuuid"]}'
 
         g = geom.geom_by_name('LABEL', name)
@@ -906,7 +909,7 @@ class DiskService(CRUDService):
         for g in klass.geoms:
             for p in g.providers:
                 # if swap partition
-                if p.config['rawtype'] == '516e7cb5-6ecf-11d6-8ff8-00022d09712b':
+                if p.config['rawtype'] == RAWTYPE['freebsd-swap']:
                     if p.name not in used_partitions:
                         # Try to save a core dump from that.
                         # Only try savecore if the partition is not already in use
@@ -970,7 +973,7 @@ class DiskService(CRUDService):
             if not partgeom:
                 continue
             for p in partgeom.providers:
-                if p.config['rawtype'] == '516e7cb5-6ecf-11d6-8ff8-00022d09712b':
+                if p.config['rawtype'] == RAWTYPE['freebsd-swap']:
                     providers[p.id] = p
                     break
 


### PR DESCRIPTION
(11.2 version of of #2278)

Prevents needless synchronization of swap mirror on unclean boot.

Ticket: #60219