### PR TITLE
tkt-32793: Report actual physical (compressed) L2ARC size

### DIFF
--- a/gui/tools/arc_summary.py
+++ b/gui/tools/arc_summary.py
@@ -795,6 +795,7 @@ def get_l2arc_summary(Kstat):
     l2_misses = Kstat["kstat.zfs.misc.arcstats.l2_misses"]
     l2_rw_clash = Kstat["kstat.zfs.misc.arcstats.l2_rw_clash"]
     l2_size = Kstat["kstat.zfs.misc.arcstats.l2_size"]
+    l2_asize = Kstat["kstat.zfs.misc.arcstats.l2_asize"]
     l2_write_buffer_bytes_scanned = Kstat["kstat.zfs.misc.arcstats.l2_write_buffer_bytes_scanned"]
     l2_write_buffer_iter = Kstat["kstat.zfs.misc.arcstats.l2_write_buffer_iter"]
     l2_write_buffer_list_iter = Kstat["kstat.zfs.misc.arcstats.l2_write_buffer_list_iter"]
@@ -818,6 +819,7 @@ def get_l2arc_summary(Kstat):
 
     output['l2_access_total'] = l2_access_total
     output['l2_size'] = l2_size
+    output['l2_asize'] = l2_asize
 
     if l2_size > 0 and l2_access_total > 0:
 
@@ -839,6 +841,10 @@ def get_l2arc_summary(Kstat):
 
         output["l2_arc_size"] = {}
         output["l2_arc_size"]["adative"] = fBytes(l2_size)
+        output["l2_arc_size"]["actual"] = {
+            'per': fPerc(l2_asize, l2_size),
+            'num': fBytes(l2_asize),
+        }
         output["l2_arc_size"]["head_size"] = {
             'per': fPerc(l2_hdr_size, l2_size),
             'num': fBytes(l2_hdr_size),
@@ -917,6 +923,10 @@ def _l2arc_summary(Kstat):
         sys.stdout.write("\n")
 
         sys.stdout.write("L2 ARC Size: (Adaptive)\t\t\t\t%s\n" % arc["l2_arc_size"]["adative"])
+        sys.stdout.write("\tCompressed:\t\t\t%s\t%s\n" % (
+            arc["l2_arc_size"]["actual"]["per"],
+            arc["l2_arc_size"]["actual"]["num"],
+        ))
         sys.stdout.write("\tHeader Size:\t\t\t%s\t%s\n" % (
             arc["l2_arc_size"]["head_size"]["per"],
             arc["l2_arc_size"]["head_size"]["num"],

--- a/gui/tools/arc_summary.py
+++ b/gui/tools/arc_summary.py
@@ -840,7 +840,7 @@ def get_l2arc_summary(Kstat):
         output["spa_mismatch"] = fHits(l2_write_spa_mismatch)
 
         output["l2_arc_size"] = {}
-        output["l2_arc_size"]["adative"] = fBytes(l2_size)
+        output["l2_arc_size"]["adaptive"] = fBytes(l2_size)
         output["l2_arc_size"]["actual"] = {
             'per': fPerc(l2_asize, l2_size),
             'num': fBytes(l2_asize),
@@ -922,7 +922,7 @@ def _l2arc_summary(Kstat):
         sys.stdout.write("\tSPA Mismatch:\t\t\t\t%s\n" % arc['spa_mismatch'])
         sys.stdout.write("\n")
 
-        sys.stdout.write("L2 ARC Size: (Adaptive)\t\t\t\t%s\n" % arc["l2_arc_size"]["adative"])
+        sys.stdout.write("L2 ARC Size: (Adaptive)\t\t\t\t%s\n" % arc["l2_arc_size"]["adaptive"])
         sys.stdout.write("\tCompressed:\t\t\t%s\t%s\n" % (
             arc["l2_arc_size"]["actual"]["per"],
             arc["l2_arc_size"]["actual"]["num"],

--- a/src/freenas/usr/local/bin/snmp-agent.py
+++ b/src/freenas/usr/local/bin/snmp-agent.py
@@ -324,7 +324,7 @@ if __name__ == "__main__":
             zfs_l2arc_misses.update(int(kstat["kstat.zfs.misc.arcstats.l2_misses"] % 2 ** 32))
             zfs_l2arc_read.update(int(kstat["kstat.zfs.misc.arcstats.l2_read_bytes"] / 1024 % 2 ** 32))
             zfs_l2arc_write.update(int(kstat["kstat.zfs.misc.arcstats.l2_write_bytes"] / 1024 % 2 ** 32))
-            zfs_l2arc_size.update(int(kstat["kstat.zfs.misc.arcstats.l2_size"] / 1024))
+            zfs_l2arc_size.update(int(kstat["kstat.zfs.misc.arcstats.l2_asize"] / 1024))
 
             zfs_zilstat_ops1.update(zilstat_1_thread.value["ops"])
             zfs_zilstat_ops5.update(zilstat_5_thread.value["ops"])


### PR DESCRIPTION
`l2_size` gives the logical (uncompressed) L2ARC size, but we are more
interested in the physical (compressed) size, so use `l2_asize` instead.

`l2_asize` is added to the output of arc_summary.py as was done in ZoL

Ticket: #32793