### PR TITLE
tkt-65565: Warning for manual setup of Volume creation

### DIFF
--- a/gui/templates/storage/zfswizard.html
+++ b/gui/templates/storage/zfswizard.html
@@ -145,6 +145,14 @@
                 </table>
             </td>
         </tr>
+        <tr>
+            <td>
+                <b style="color: red">{% trans "WARNING" %}</b>
+            </td>
+            <td style="width:250px;">
+                {% trans "Please make sure that the disks are correctly setup by verifying the selected Member Disks field choices and ZFS Extra field choices before proceeding" %}
+            </td>
+        </tr>
     </table>
         <button data-dojo-type="dijit.form.Button" type="submit" data-dojo-props="type:'submit'" class="submitform">
     <script type="dojo/method">


### PR DESCRIPTION
This commit adds a warning which will help users be more careful when using manual setup for configuring their pools so that they don't accidentally setup different choices while creating it.
Ticket: #65565