### PR TITLE
tkt-65544: Bug fix for s3

### DIFF
--- a/src/freenas/etc/rc.conf.local
+++ b/src/freenas/etc/rc.conf.local
@@ -451,7 +451,9 @@ _s3_config()
 		LEFT OUTER JOIN
 			services_services
 		ON
-			(srv_service = 's3' AND srv_enable = '1')
+			srv_service = 's3'
+		WHERE
+			srv_enable = '1'
 		ORDER BY
 			-services_s3.id
 		LIMIT 1


### PR DESCRIPTION
This commit fixes a bug where we started s3 service automatically on boot even if it wasn't configured to do so.
Ticket: #65544