### PR TITLE
Don't use Malformed Certificates

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-proftpd
+++ b/src/freenas/etc/ix.rc.d/ix-proftpd
@@ -212,7 +212,10 @@ EOF
 
         if [ ${ftp_tls} -gt 0 ]; then
 
-if [ -z "${ftp_ssltls_certificate_id}" ]; then
+/usr/local/bin/midclt call certificate.certificate_ftp_health "$ftp_ssltls_certificate_id" 'ftp.ftp_ssltls_certificate_id' > /dev/null 2>&1
+certerror=$?
+
+if [ ${certerror} -gt 0 ]; then
         certname=""
         certchain=""
 else

--- a/src/middlewared/middlewared/etc_files/local/apache24/webdav_config.py
+++ b/src/middlewared/middlewared/etc_files/local/apache24/webdav_config.py
@@ -4,6 +4,8 @@ import re
 def generate_webdav_config(middleware):
     webdav_config = middleware.call_sync('webdav.config')
     if webdav_config['protocol'] in ('HTTPS', 'HTTPHTTPS'):
+        middleware.call_sync('certificate.certificate_webdav_health', webdav_config['certssl'], 'webdav.certssl')
+
         with open('/usr/local/etc/apache24/Includes/webdav.conf', 'r') as f:
             data = f.read()
 

--- a/src/middlewared/middlewared/etc_files/local/minio/certificates.py
+++ b/src/middlewared/middlewared/etc_files/local/minio/certificates.py
@@ -4,21 +4,15 @@ import pwd
 
 
 async def render(service, middleware):
-    s3 = await middleware.call('datastore.query', 'services.s3')
-    if not s3:
-        return
-    s3 = s3[0]
-    if not s3:
-        return
+    s3 = await middleware.call('s3.config')
 
-    cert = s3.get('s3_certificate')
+    cert = s3.get('certificate')
     if not cert:
         return
+    else:
+        await middleware.call('certificate.certificate_s3_health', cert, 's3.certificate')
 
-    if (
-        'cert_certificate' in cert and len(cert['cert_certificate']) > 0 and
-        'cert_privatekey' in cert and len(cert['cert_privatekey']) > 0
-    ):
+        cert = await middleware.call('certificate._get_instance', cert)
 
         minio_path = "/usr/local/etc/minio"
 
@@ -36,11 +30,11 @@ async def render(service, middleware):
         os.chown(minio_path, minio_uid, minio_gid)
 
         with open(minio_certificate, 'w') as f:
-            f.write(cert['cert_certificate'])
+            f.write(cert['certificate'])
         os.chown(minio_certificate, minio_uid, minio_gid)
         os.chmod(minio_certificate, 0o644)
 
         with open(minio_privatekey, 'w') as f:
-            f.write(cert['cert_privatekey'])
+            f.write(cert['privatekey'])
         os.chown(minio_privatekey, minio_uid, minio_gid)
         os.chmod(minio_privatekey, 0o600)

--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf
@@ -20,7 +20,7 @@
     ]
 
     # Let's verify that required SSL support in the backend is complete by middlewared
-    if not cert:
+    if not cert or middleware.call_sync('certificate.certificate_nginx_health', cert['id'], 'nginx.certificate', False):
         ssl_configuration = False
         middleware.call_sync('alert.oneshot_create', 'NginxCertificateSetupFailed', None)
     else:

--- a/src/middlewared/middlewared/plugins/s3.py
+++ b/src/middlewared/middlewared/plugins/s3.py
@@ -18,6 +18,8 @@ class S3Service(SystemServiceService):
     async def config_extend(self, s3):
         s3['storage_path'] = s3.pop('disks', None)
         s3.pop('mode', None)
+        if s3.get('certificate'):
+            s3['certificate'] = s3['certificate']['id']
         return s3
 
     @accepts(Dict(
@@ -65,6 +67,11 @@ class S3Service(SystemServiceService):
             # If the storage_path does not exist, let's create it
             if not os.path.exists(new['storage_path']):
                 os.makedirs(new['storage_path'])
+
+        if new['certificate']:
+            verrors.extend((await self.middleware.call(
+                'certificate.certificate_s3_health', new['certificate'], 's3_update.certificate', False
+            )))
 
         if verrors:
             raise verrors

--- a/src/middlewared/middlewared/plugins/webdav.py
+++ b/src/middlewared/middlewared/plugins/webdav.py
@@ -173,11 +173,10 @@ class WebDAVService(SystemServiceService):
                     f"{schema_name}.certssl",
                     'WebDAV SSL protocol specified without choosing a certificate'
                 )
-            elif not (await self.middleware.call('certificate.query', [['id', '=', cert_ssl]])):
-                verrors.add(
-                    f"{schema_name}.certssl",
-                    'Please provide a valid certificate id'
-                )
+            else:
+                verrors.extend((await self.middleware.call(
+                    'certificate.certificate_webdav_health', cert_ssl, f'{schema_name}.certssl', False
+                )))
 
         if verrors:
             raise verrors


### PR DESCRIPTION
This commit adds the following changes:
1) Make sure we don't use malformed certificates in our services.
2) Make sure we don't delete a cert being used by our services.
3) Make sure when configuration files are generated for services which use certs, they also check for cert health before proceeding.
4) Fix a bug with s3 service where update to it was broken if a certificate was once selected.
Ticket: #64755