### PR TITLE
fix(syslog): use latest syslog-ng version

### DIFF
--- a/src/freenas/usr/local/etc/syslog-ng.conf.freenas
+++ b/src/freenas/usr/local/etc/syslog-ng.conf.freenas
@@ -1,4 +1,4 @@
-@version:3.17
+@version:3.18
 
 #
 # options


### PR DESCRIPTION
This will silence the following message:

WARNING: Configuration file format is too old, syslog-ng is running in
compatibility mode. Please update it to use the syslog-ng 3.18 format at your time of convenience. To upgrade the configuration, please review the warnings about incompatible changes printed by syslog-ng, and once completed change the @version header at the top of the configuration file.;