### PR TITLE
tkt-23359: Add time machine over SMB

### DIFF
--- a/gui/sharing/admin.py
+++ b/gui/sharing/admin.py
@@ -58,7 +58,6 @@ class CIFSShareFAdmin(BaseFreeAdmin):
         'cifs_ro',
         'cifs_showhiddenfiles',
         'cifs_vfsobjects',
-        'cifs_vuid',
         'cifs_storage_task',
     )
     fields = (

--- a/gui/sharing/admin.py
+++ b/gui/sharing/admin.py
@@ -58,6 +58,7 @@ class CIFSShareFAdmin(BaseFreeAdmin):
         'cifs_ro',
         'cifs_showhiddenfiles',
         'cifs_vfsobjects',
+        'cifs_vuid',
         'cifs_storage_task',
     )
     fields = (

--- a/gui/sharing/migrations/0014_add_smb_timemachine.py
+++ b/gui/sharing/migrations/0014_add_smb_timemachine.py
@@ -1,0 +1,23 @@
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sharing', '0013_remove_cifs_default_permissions'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='cifs_share',
+            name='cifs_timemachine',
+            field=models.BooleanField(default=False, verbose_name='Time Machine over SMB'),
+        ),
+        migrations.AddField(
+            model_name='cifs_share',
+            name='cifs_vuid',
+            field=models.CharField(blank=True, help_text='Volume UUID for _adisk._tcp. mDNS advertisment', max_length=36, verbose_name='Volume UUID')
+        ),
+    ]

--- a/gui/sharing/models.py
+++ b/gui/sharing/models.py
@@ -43,6 +43,13 @@ class CIFS_Share(Model):
         verbose_name=_('Use as home share'),
         default=False,
     )
+    cifs_timemachine = models.BooleanField(
+        verbose_name=_('Time Machine'),
+        help_text=_(
+            'Enable Time Machine backups on this share.'
+        ),
+        default=False,
+    )
     cifs_name = models.CharField(
         max_length=120,
         verbose_name=_("Name")
@@ -52,7 +59,6 @@ class CIFS_Share(Model):
         verbose_name=_("Comment"),
         blank=True,
     )
-
     cifs_ro = models.BooleanField(
         verbose_name=_('Export Read Only'),
         default=False,
@@ -126,6 +132,16 @@ class CIFS_Share(Model):
         on_delete=models.SET_NULL,
         blank=True,
         null=True
+    )
+    cifs_vuid = models.CharField(
+        max_length=36,
+        verbose_name=_('vuid for Time Machine'),
+        blank=True,
+        help_text=_(
+            'Volume UUID that will be advertized for time machine. '
+            'This value will be automatically generated when the share '
+            'is configured for time machine.'
+        ),
     )
     cifs_auxsmbconf = models.TextField(
         verbose_name=_("Auxiliary Parameters"),

--- a/gui/sharing/models.py
+++ b/gui/sharing/models.py
@@ -142,6 +142,7 @@ class CIFS_Share(Model):
             'This value will be automatically generated when the share '
             'is configured for time machine.'
         ),
+        editable=False,
     )
     cifs_auxsmbconf = models.TextField(
         verbose_name=_("Auxiliary Parameters"),

--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -1216,7 +1216,7 @@ def generate_smb4_shares(client, smb4_shares):
            the filesystem with ad files.
         """
         if fruit_enabled:
-            if not "fruit" in share.cifs_vfsobjects:
+            if "fruit" not in share.cifs_vfsobjects:
                 vfs_objects.append('fruit')
             confset1(smb4_shares, "fruit:metadata = stream")
             confset1(smb4_shares, "fruit:resource = stream")

--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -1140,6 +1140,11 @@ def generate_smb4_shares(client, smb4_shares):
     if len(shares) == 0:
         return
 
+    fruit_enabled = False
+    for share in shares:
+        if "fruit" in share['cifs_vfsobjects'] or share['cifs_timemachine']:
+            fruit_enabled = True
+
     for share in shares:
         share = Struct(share)
         if (not share.cifs_home and
@@ -1198,6 +1203,28 @@ def generate_smb4_shares(client, smb4_shares):
         vfs_objects = []
         if task:
             vfs_objects.append('shadow_copy2')
+
+        """
+           vfs_fruit must be enabled on _all_ shares if it is enabled on any of
+           them. This is because support for aapl SMB extensions is negotiated/
+           discovered on the first SMB tree connect.
+
+           We also take this opportunity to set parameters to store AFP Resource
+           and AFP Info alternate data streams as xattrs. Default behavior in fruit
+           is to store as apple double files due in part to size limits for xattrs
+           in Linux. FreeBSD doesn't have this limitation, and so we can avoid littering
+           the filesystem with ad files.
+        """
+        if fruit_enabled:
+            if not "fruit" in share.cifs_vfsobjects:
+                vfs_objects.append('fruit')
+            confset1(smb4_shares, "fruit:metadata = stream")
+            confset1(smb4_shares, "fruit:resource = stream")
+
+        if share.cifs_timemachine:
+            confset1(smb4_shares, "fruit:time machine = yes")
+            confset2(smb4_shares, "fruit:volume_uuid = %s", share.cifs_vuid)
+
         extend_vfs_objects_for_zfs(share.cifs_path, vfs_objects)
         vfs_objects.extend(share.cifs_vfsobjects)
 

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -391,8 +391,6 @@ class SharingSMBService(CRUDService):
 
     @private
     async def generate_vuid(self, timemachine, vuid):
-        self.logger.debug(f"tm: ({timemachine}), vuid: ({vuid})")
-
         try:
             if timemachine:
                 uuid.UUID(vuid, version=4)

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -232,7 +232,6 @@ class SharingSMBService(CRUDService):
         data['id'] = await self.middleware.call(
             'datastore.insert', self._config.datastore, data,
             {'prefix': self._config.datastore_prefix})
-        self.logger.debug("We got past datastore insert")
         await self.extend(data)  # We should do this in the insert call ?
 
         await self.middleware.call('service.reload', 'cifs')
@@ -393,7 +392,7 @@ class SharingSMBService(CRUDService):
     @private
     async def generate_vuid(self, timemachine, vuid=""):
         try:
-            if timemachine:
+            if timemachine and vuid:
                 uuid.UUID(vuid, version=4)
         except ValueError:
             self.logger.debug(f"Time machine VUID string ({vuid}) is invalid. Regenerating.")


### PR DESCRIPTION
- Add heckbox to enable time machine
- Add field to store VUID for shares. This will be automatically populated, but the user given the option to change it if needed.
- Detect whether fruit or timemachine is enabled on any shares. If so, enable fruit on all shares.
- If time machine is enabled on a share, set appropriate parameters.
- If fruit is enabled on a share, then also set parameters to store Mac metadata as alternate datastreams.