### PR TITLE
tkt-65949: Only set "map to guest = Bad user" if guest shares enabled

### DIFF
--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -943,9 +943,8 @@ def generate_smb4_conf(client, smb4_conf, role, shares):
 
     guest_enabled = False
 
-    for share in shares:
-        if share['cifs_guestok']:
-            guest_enabled = True
+    if any(filter(lambda x: x['cifs_guestok'], shares)):
+        guest_enabled = True
 
     if not cifs.guest:
         cifs.guest = 'ftp'
@@ -1150,6 +1149,7 @@ def generate_smb4_shares(client, smb4_shares, shares):
     for share in shares:
         if "fruit" in share['cifs_vfsobjects'] or share['cifs_timemachine']:
             fruit_enabled = True
+            break
 
     for share in shares:
         share = Struct(share)


### PR DESCRIPTION
- Setting 'map to guest' will cause default installs of Windows 10 and Server 2019 to fail a security check and not attempt an SMB tree connect. The cause of the failure is not immediately visible to the end user (logged in Event Viewer).
- If we leave this at the default value in samba "map to guest = never", then the user will be presented with a password prompt.
- New behavior: only add "map to guest = Bad user" if one of the SMB shares has "Allow Guest Access" checked.