### PR TITLE
tkt-68097: fix(jail/get_activated_pool): Do not return None on all exceptions

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -355,7 +355,9 @@ class JailService(CRUDService):
         """Returns the activated pool if there is one, or None"""
         try:
             pool = ioc.IOCage(skip_jails=True).get("", pool=True)
-        except Exception:
+        except RuntimeError as e:
+            raise CallError(f'Error occurred getting activated pool: {e}')
+        except ioc_exceptions.PoolNotActivated:
             pool = None
 
         return pool


### PR DESCRIPTION
Instead we raise a CallError with the message for a RuntimeError.

TIcket: #68097