### PR TITLE
tkt-56502: Fix 56502 master

### DIFF
--- a/gui/middleware/notifier.py
+++ b/gui/middleware/notifier.py
@@ -371,16 +371,6 @@ class notifier(metaclass=HookMetaclass):
 
         return ret
 
-    def path_to_smb_share(self, path):
-        from freenasUI.sharing.models import CIFS_Share
-
-        try:
-            share = CIFS_Share.objects.get(cifs_path=path)
-        except Exception:
-            share = None
-
-        return share
-
     def owner_to_SID(self, owner):
         if not owner:
             return None
@@ -419,35 +409,6 @@ class notifier(metaclass=HookMetaclass):
         log.debug("group_to_SID: %s -> %s", group, SID)
         return SID
 
-    def sharesec_add(self, share, owner, group):
-        if not share:
-            return False
-
-        log.debug("sharesec_add: adding '%s:%s' ACL on %s", owner, group, share)
-
-        add_args = ""
-        sharesec = "/usr/local/bin/sharesec"
-
-        owner_SID = self.owner_to_SID(owner)
-        group_SID = self.group_to_SID(group)
-
-        if owner and owner_SID:
-            add_args += ",%s:ALLOWED/0/FULL" % owner_SID
-        if group and group_SID:
-            add_args += ",%s:ALLOWED/0/FULL" % group_SID
-        add_args = add_args.lstrip(',')
-
-        ret = True
-        if add_args:
-            add_cmd = "%s %s -a '%s'" % (sharesec, share, add_args)
-            try:
-                self._pipeopen(add_cmd).communicate()
-            except Exception:
-                log.debug("sharesec_add: %s failed", add_cmd)
-                ret = False
-
-        return ret
-
     def sharesec_delete(self, share):
         if not share:
             return False
@@ -466,15 +427,6 @@ class notifier(metaclass=HookMetaclass):
 
         return ret
 
-    def sharesec_reset(self, share, owner=None, group=None):
-        if not share:
-            return False
-
-        log.debug("sharesec_reset: resetting %s to '%s:%s'", share, owner, group)
-
-        self.sharesec_delete(share)
-        return self.sharesec_add(share, owner, group)
-
     def winacl_reset(self, path, owner=None, group=None, exclude=None, recursive=True):
         if exclude is None:
             exclude = []
@@ -491,9 +443,6 @@ class notifier(metaclass=HookMetaclass):
         aclfile = os.path.join(path, ACL_WINDOWS_FILE)
         if not os.path.exists(aclfile):
             open(aclfile, 'a').close()
-
-        share = self.path_to_smb_share(path)
-        self.sharesec_reset(share, owner, group)
 
         winacl = "/usr/local/bin/winacl"
         args = "-a reset"
@@ -594,10 +543,6 @@ class notifier(metaclass=HookMetaclass):
                     self._system("/usr/sbin/chown %s :'%s' '%s'" % (flags, group, apath))
                 if mode is not None:
                     self._system("/bin/chmod %s %s '%s'" % (flags, mode, apath))
-
-        share = self.path_to_smb_share(path)
-        if share:
-            self.sharesec_reset(share, user, group)
 
     def change_upload_location(self, path):
         vardir = "/var/tmp/firmware"

--- a/gui/middleware/notifier.py
+++ b/gui/middleware/notifier.py
@@ -371,44 +371,6 @@ class notifier(metaclass=HookMetaclass):
 
         return ret
 
-    def owner_to_SID(self, owner):
-        if not owner:
-            return None
-
-        proc = self._pipeopen("/usr/local/bin/wbinfo -n '%s'" % owner)
-
-        info, err = proc.communicate()
-        if proc.returncode != 0:
-            log.debug("owner_to_SID: error %s", err)
-            return None
-
-        try:
-            SID = info.split(' ')[0].strip()
-        except Exception:
-            SID = None
-
-        log.debug("owner_to_SID: %s -> %s", owner, SID)
-        return SID
-
-    def group_to_SID(self, group):
-        if not group:
-            return None
-
-        proc = self._pipeopen("/usr/local/bin/wbinfo -n '%s'" % group)
-
-        info, err = proc.communicate()
-        if proc.returncode != 0:
-            log.debug("group_to_SID: error %s", err)
-            return None
-
-        try:
-            SID = info.split(' ')[0].strip()
-        except Exception:
-            SID = None
-
-        log.debug("group_to_SID: %s -> %s", group, SID)
-        return SID
-
     def sharesec_delete(self, share):
         if not share:
             return False


### PR DESCRIPTION
sharesec_reset sets extraneous entries into the share's ACL. This is a POLA violation and can end up effectively breaking Access Based Share Enumeration.