### PR TITLE
tkt-68293: Fix 56502 master (by anodos325)

### DIFF
--- a/gui/middleware/notifier.py
+++ b/gui/middleware/notifier.py
@@ -1247,45 +1247,6 @@ class notifier(metaclass=HookMetaclass):
 
         return ret
 
-    def owner_to_SID(self, owner):
-        if not owner:
-            return None
-
-        proc = self._pipeopen("/usr/local/bin/wbinfo -n '%s'" % owner)
-
-        info, err = proc.communicate()
-        if proc.returncode != 0:
-            log.debug("owner_to_SID: error %s", err)
-            return None
-
-        try:
-            SID = info.split(' ')[0].strip()
-        except:
-            SID = None
-
-        log.debug("owner_to_SID: %s -> %s", owner, SID)
-        return SID
-
-    def group_to_SID(self, group):
-        if not group:
-            return None
-
-        proc = self._pipeopen("/usr/local/bin/wbinfo -n '%s'" % group)
-
-        info, err = proc.communicate()
-        if proc.returncode != 0:
-            log.debug("group_to_SID: error %s", err)
-            return None
-
-        try:
-            SID = info.split(' ')[0].strip()
-        except:
-            SID = None
-
-        log.debug("group_to_SID: %s -> %s", group, SID)
-        return SID
-
-
     def sharesec_delete(self, share):
         if not share:
             return False


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick edafab29e7f2bc00318fc927abb822719ce5cc12
    git cherry-pick 2bfe25cd9e5cc6055a65d82e3999cb34f82cb7c7

sharesec_reset sets extraneous entries into the share's ACL. This is a POLA violation and can end up effectively breaking Access Based Share Enumeration.