### PR TITLE
tkt-67762: Bug fix for rsync validation

### DIFF
--- a/src/middlewared/middlewared/plugins/rsync.py
+++ b/src/middlewared/middlewared/plugins/rsync.py
@@ -436,7 +436,7 @@ class RsyncTaskService(CRUDService):
                 remote_port
             ):
                 if '@' in remote_host:
-                    remote_username, remote_host = remote_host.split('@')
+                    remote_username, remote_host = remote_host.split('@', 1)
                 else:
                     remote_username = username
 

--- a/src/middlewared/middlewared/plugins/rsync.py
+++ b/src/middlewared/middlewared/plugins/rsync.py
@@ -436,7 +436,7 @@ class RsyncTaskService(CRUDService):
                 remote_port
             ):
                 if '@' in remote_host:
-                    remote_username, remote_host = remote_host.split('@', 1)
+                    remote_username, remote_host = remote_host.rsplit('@', 1)
                 else:
                     remote_username = username
 


### PR DESCRIPTION
This commit fixes a bug where we when trying to validate different rsync task params did a split which did not cover all scenarios.
Ticket: #67762