### PR TITLE
Bump year in copyright

### DIFF
--- a/src/freenas/etc/motd
+++ b/src/freenas/etc/motd
@@ -1,6 +1,6 @@
 FreeBSD ?.?.?  (UNKNOWN)
 
-	FreeNAS (c) 2009-2017, The FreeNAS Development Team
+	FreeNAS (c) 2009-2019, The FreeNAS Development Team
 	All rights reserved.
 	FreeNAS is released under the modified BSD license.
 


### PR DESCRIPTION
This commit bumps year in copyright to 2019.
Ticket: #60660