### PR TITLE
S3 Service fails to start

### DIFF
--- a/src/freenas/etc/rc.conf.local
+++ b/src/freenas/etc/rc.conf.local
@@ -452,16 +452,16 @@ _s3_config()
 			services_services
 		ON
 			srv_service = 's3'
-		WHERE
-			srv_enable = '1'
 		ORDER BY
-			-services_s3.id
+			services_s3.id
 		LIMIT 1
 	" |\
 	while read s3_enable s3_bindip s3_bindport s3_access_key \
 		s3_secret_key s3_browser s3_mode s3_disks; do
+		if [ "${s3_enable}" = "1" ]; then
+			echo minio_enable="YES"
+		fi
 		cat <<-__MINIO__
-			minio_enable="YES"
 			minio_disks="${s3_disks}"
 			minio_address="${s3_bindip}:${s3_bindport}"
 			minio_env="\\


### PR DESCRIPTION
This commit introduces the following changes:
1) Fixes a bug where S3 service failed to start because S3 configuration was not generated in rc.conf.freenas when it was not set to start on boot. As the rc script for minio uses rc.conf.freenas for getting the values for starting S3 service, it failed.
2) There was a case where we could insert more then one row when config method for a config service were called simultaneously. This commit fixes that issue.
3) S3 was compromised by point no 2 as well in some scenarios. So this commit also fixes how we order the s3 rows if there are more then one to mirror it how middlewared does.
Ticket: #68871