### PR TITLE
Disallow invalid keys in datastore insert/update

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -383,10 +383,16 @@ class UserService(CRUDService):
         e.g. Setting key="foo" value="var" will result in {"attributes": {"foo": "bar"}}
         """
         user = await self._get_instance(pk)
-        user.pop('group')
 
         user['attributes'][key] = value
-        await self.middleware.call('datastore.update', 'account.bsdusers', pk, user, {'prefix': 'bsdusr_'})
+
+        await self.middleware.call(
+            'datastore.update',
+            'account.bsdusers',
+            pk,
+            {'attributes': user['attributes']},
+            {'prefix': 'bsdusr_'}
+        )
 
         return True
 
@@ -400,11 +406,17 @@ class UserService(CRUDService):
         Remove user general purpose `attributes` dictionary `key`.
         """
         user = await self._get_instance(pk)
-        user.pop('group')
 
         if key in user['attributes']:
             user['attributes'].pop(key)
-            await self.middleware.call('datastore.update', 'account.bsdusers', pk, user, {'prefix': 'bsdusr_'})
+
+            await self.middleware.call(
+                'datastore.update',
+                'account.bsdusers',
+                pk,
+                {'attributes': user['attributes']},
+                {'prefix': 'bsdusr_'}
+            )
             return True
         else:
             return False
@@ -659,6 +671,8 @@ class GroupService(CRUDService):
         if 'name' in data and data['name'] != group['group']:
             delete_groupmap = group['group']
             group['group'] = group.pop('name')
+        else:
+            group.pop('name', None)
 
         await self.middleware.call('datastore.update', 'account.bsdgroups', pk, group, {'prefix': 'bsdgrp_'})
 

--- a/src/middlewared/middlewared/plugins/cloud_sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync.py
@@ -435,6 +435,8 @@ class CloudSyncService(CRUDService):
 
         Cron.convert_schedule_to_db_format(cloud_sync)
 
+        cloud_sync.pop('job', None)
+
         return cloud_sync
 
     @private

--- a/src/middlewared/middlewared/plugins/crypto.py
+++ b/src/middlewared/middlewared/plugins/crypto.py
@@ -1224,7 +1224,7 @@ class CertificateService(CRUDService):
                 'datastore.update',
                 self._config.datastore,
                 id,
-                new,
+                {'name': new['name']},
                 {'prefix': self._config.datastore_prefix}
             )
 
@@ -1813,7 +1813,7 @@ class CertificateAuthorityService(CRUDService):
                 'datastore.update',
                 self._config.datastore,
                 id,
-                new,
+                {'name': new['name']},
                 {'prefix': self._config.datastore_prefix}
             )
 

--- a/src/middlewared/middlewared/plugins/datastore.py
+++ b/src/middlewared/middlewared/plugins/datastore.py
@@ -1,4 +1,4 @@
-from middlewared.service import CallError, Service
+from middlewared.service import CallError, Service, ValidationErrors
 from middlewared.schema import accepts, Any, Bool, Dict, List, Ref, Str
 from sqlite3 import OperationalError
 
@@ -201,6 +201,28 @@ class DatastoreService(Service):
         options['get'] = True
         return self.query(name, None, options)
 
+    def validate_data_keys(self, data, model, schema, prefix):
+        verrors = ValidationErrors()
+        fields = list(
+            map(
+                lambda f: f.name.replace(prefix or '', ''),
+                chain(model._meta.fields, model._meta.many_to_many)
+            )
+        )
+
+        # _id is a special condition in filter where the key in question can be a related descriptor in django
+        # i.e share_id - so we remove _id and check if the field is present in `fields` list
+        for key in filter(
+            lambda v: all(c not in fields for c in (v, v if not v.endswith('_id') else v[:-3])),
+            data
+        ):
+            verrors.add(
+                f'{schema}.{key}',
+                f'{key} field not recognized'
+            )
+
+        verrors.check()
+
     @accepts(Str('name'), Dict('data', additional_attrs=True), Dict('options', Str('prefix', null=True)))
     def insert(self, name, data, options=None):
         """
@@ -211,6 +233,8 @@ class DatastoreService(Service):
         options = options or {}
         prefix = options.get('prefix')
         model = self.__get_model(name)
+        self.validate_data_keys(data, model, 'datastore_insert', prefix)
+
         for field in chain(model._meta.fields, model._meta.many_to_many):
             if prefix:
                 name = field.name.replace(prefix, '')
@@ -246,6 +270,8 @@ class DatastoreService(Service):
         options = options or {}
         prefix = options.get('prefix')
         model = self.__get_model(name)
+        self.validate_data_keys(data, model, 'datastore_update', prefix)
+
         obj = model.objects.get(pk=id)
         for field in chain(model._meta.fields, model._meta.many_to_many):
             if prefix:

--- a/src/middlewared/middlewared/plugins/iscsi.py
+++ b/src/middlewared/middlewared/plugins/iscsi.py
@@ -1147,7 +1147,7 @@ class iSCSITargetService(CRUDService):
             raise verrors
 
         await self.compress(new)
-        groups = data.pop('groups')
+        groups = new.pop('groups')
 
         oldgroups = old.copy()
         await self.compress(oldgroups)

--- a/src/middlewared/middlewared/plugins/replication.py
+++ b/src/middlewared/middlewared/plugins/replication.py
@@ -308,6 +308,8 @@ class ReplicationService(CRUDService):
         periodic_snapshot_tasks = new["periodic_snapshot_tasks"]
         await self.compress(new)
 
+        new.pop('state', None)
+
         await self.middleware.call(
             "datastore.update",
             self._config.datastore,

--- a/src/middlewared/middlewared/plugins/snapshot.py
+++ b/src/middlewared/middlewared/plugins/snapshot.py
@@ -202,6 +202,9 @@ class PeriodicSnapshotTaskService(CRUDService):
 
         Cron.convert_schedule_to_db_format(new, begin_end=True)
 
+        for key in ('legacy', 'vmware_sync', 'state'):
+            new.pop(key, None)
+
         await self.middleware.call(
             'datastore.update',
             self._config.datastore,

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -98,7 +98,18 @@ class SystemDatasetService(ConfigService):
 
         new['syslog_usedataset'] = new['syslog']
         new['rrd_usedataset'] = new['rrd']
-        await self.middleware.call('datastore.update', 'system.systemdataset', config['id'], new, {'prefix': 'sys_'})
+
+        update_dict = new.copy()
+        for key in ('is_decrypted', 'basename', 'uuid_a', 'syslog', 'rrd', 'path'):
+            update_dict.pop(key, None)
+
+        await self.middleware.call(
+            'datastore.update',
+            'system.systemdataset',
+            config['id'],
+            update_dict,
+            {'prefix': 'sys_'}
+        )
 
         if config['pool'] != new['pool']:
             await self.migrate(config['pool'], new['pool'])


### PR DESCRIPTION
This PR aims to introduce the following changes:
1) Disallow invalid keys in datastore service for insert/update methods raising validation errors for each such key
2) Cover the following plugins which are affected by this change:
  - Accounts
  - Cloud Sync
  - Crypto
  - Iscsi
  - Snapshot
  - Replication
  - System Dataset

Ticket: #64773