### PR TITLE
[install.sh] Escape single-quotes in description (and other things from master)

### DIFF
--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -53,10 +53,9 @@ get_image_name()
 # This does memory size only for now.
 pre_install_check()
 {
-    # We need at least this many GB of RAM
-    local readonly minmemgb=8
-    # subtract 1GB to allow for reserved memory
-    local readonly minmem=$(expr \( ${minmemgb} \- 1 \) \* 1024 \* 1024 \* 1024)
+    # We need at least 8 GB of RAM
+    # minus 1 GB to allow for reserved memory
+    local minmem=$((7 * GiB))
     local memsize=$(sysctl -n hw.physmem)
 
     if [ ${memsize} -lt ${minmem} ]; then
@@ -207,20 +206,25 @@ get_media_description()
 	_description=`geom disk list ${_media} 2>/dev/null \
 	    | sed -ne 's/^   descr: *//p'`
 	if [ -z "$_description" ] ; then
-		_description="Unknown Device"
+	    _description="Unknown Device"
 	fi
-        _cap=`diskinfo ${_media} | awk '{
+	_cap=`diskinfo ${_media} | awk \
+	    -v TiB=${TiB}.0 \
+	    -v GiB=${GiB}.0 \
+	    -v MiB=${MiB}.0 \
+	'{
             capacity = $3;
-            if (capacity >= 1099511627776) {
-                printf("%.1f TiB", capacity / 1099511627776.0);
-            } else if (capacity >= 1073741824) {
-                printf("%.1f GiB", capacity / 1073741824.0);
-            } else if (capacity >= 1048576) {
-                printf("%.1f MiB", capacity / 1048576.0);
+            if (capacity >= TiB) {
+                printf("%.1f TiB", capacity / TiB);
+            } else if (capacity >= GiB) {
+                printf("%.1f GiB", capacity / GiB);
+            } else if (capacity >= MiB) {
+                printf("%.1f MiB", capacity / MiB);
             } else {
                 printf("%d Bytes", capacity);
-        }}'`
-        VAL="${_description} -- ${_cap}"
+	    }
+	}'`
+	VAL="${_description} -- ${_cap}"
     fi
     export VAL
 }
@@ -416,10 +420,12 @@ mount_disk()
 create_partitions()
 {
     local _disk="$1"
-    local _size=""
+    local _size="$2"
 
-    if [ $# -eq 2 ]; then
-	_size="-s $2"
+    if [ -n "${_size}" ]; then
+	# Round ZFS partition size down to a multiple of 16 MiB (2^24),
+	# leaving units in MiB (2^20).
+	_size="-s $(( (_size >> 24) << 4 ))m"
     fi
     if gpart create -s GPT -f active ${_disk}; then
 	if [ "$BOOTMODE" = "UEFI" ] ; then
@@ -454,15 +460,6 @@ get_minimum_size()
     local _min=0
     local _disk
     local _size
-    # We use 1mbyte because the fat16 partition is 512k,
-    # and there's some header space.
-    # Now we use 8MBytes because gpart and some thumb drives
-    # misbehave.
-    local _m1=$(expr 1024 \* 1024 \* 8)
-    # If we decide we want to round it down,
-    # set this to the size (eg, 256 * 1024 * 1024)
-    local _round=0
-    local _g16=$(expr 16 \* 1024 \* 1024 \* 1024)
 
     for _disk
     do
@@ -476,66 +473,69 @@ get_minimum_size()
 	    echo "Could not do anything with ${_disk}, skipping" 1>&2
 	    continue
 	fi
-	if [ ${_round} -gt 0 ]; then
-	    _size=$(expr \( ${_size} / ${_round} \) \* ${_round})
-	fi
-	_size=$(expr ${_size} / 1024)
 	if [ ${_min} -eq 0 -o ${_size} -lt ${_min} ]; then
 	    _min=${_size}
 	fi
     done
-    echo ${_min}k
+
+    echo ${_min}
 }
+
+# Minimum required space for an installation.
+# Docs state 8 GiB is the bare minimum, but we specify 8 GB here for wiggle room.
+# That should leave enough slop for alignment, boot partition, etc.
+: ${MIN_ZFS_PARTITION_SIZE:=$((8 * GB))}; readonly MIN_ZFS_PARTITION_SIZE
 
 partition_disks()
 {
-	local _disks _disksparts
-	local _mirror
-	local _minsize
+    local _disks _disksparts
+    local _mirror
+    local _minsize
+    local _size
 
-	_disks=$*
+    _disks=$*
 
-	if is_truenas; then
-		gmirror destroy -f swap || true
+    if is_truenas; then
+	gmirror destroy -f swap || true
+    fi
+    # Erase both typical metadata area.
+    for _disk in ${_disks}; do
+	gpart destroy -F ${_disk} >/dev/null 2>&1 || true
+	dd if=/dev/zero of=/dev/${_disk} bs=1m count=2 >/dev/null
+	_size=$(diskinfo ${_disk} | cut -f 3)
+	dd if=/dev/zero of=/dev/${_disk} bs=1m oseek=$((_size / MiB - 2)) >/dev/null || true
+    done
+
+    _minsize=$(get_minimum_size ${_disks})
+
+    if [ ${_minsize} -lt ${MIN_ZFS_PARTITION_SIZE} ]; then
+	echo "Disk is too small to install ${AVATAR_PROJECT}" 1>&2
+	return 1
+    fi
+
+    _disksparts=$(for _disk in ${_disks}; do
+	create_partitions ${_disk} ${_minsize} >&2
+	if [ "$BOOTMODE" != "UEFI" ] ; then
+	    # Make the disk active
+	    gpart set -a active ${_disk} >&2
 	fi
-	# Erase both typical metadata area.
-	for _disk in ${_disks}; do
-	    gpart destroy -F ${_disk} >/dev/null 2>&1 || true
-	    dd if=/dev/zero of=/dev/${_disk} bs=1m count=2 >/dev/null
-	    dd if=/dev/zero of=/dev/${_disk} bs=1m oseek=$(diskinfo /dev/${_disk} | awk '{ print int($3/(1024*1024))-2 }') >/dev/null || true
-	done
+	echo ${_disk}p2
+    done)
 
-	_minsize=$(get_minimum_size ${_disks})
+    if [ $# -gt 1 ]; then
+	_mirror="mirror"
+    else
+	_mirror=""
+    fi
+    zpool create -f -o cachefile=/tmp/zpool.cache -o version=28 -O mountpoint=none -O atime=off -O canmount=off freenas-boot ${_mirror} ${_disksparts}
+    zpool set feature@async_destroy=enabled freenas-boot
+    zpool set feature@empty_bpobj=enabled freenas-boot
+    zpool set feature@lz4_compress=enabled freenas-boot
+    zfs set compress=lz4 freenas-boot
+    zfs create -o canmount=off freenas-boot/ROOT
+    zfs create -o mountpoint=legacy freenas-boot/ROOT/${BENAME}
 
-	if [ "${_minsize}" = "0k" ]; then
-	    echo "Disk is too small to install ${AVATAR_PROJECT}" 1>&2
-	    return 1
-	fi
-
-	_disksparts=$(for _disk in ${_disks}; do
-	    create_partitions ${_disk} ${_minsize} >&2
-	    if [ "$BOOTMODE" != "UEFI" ] ; then
-	      # Make the disk active
-	      gpart set -a active ${_disk} >&2
-	    fi
-
-	    echo ${_disk}p2
-	done)
-
-	if [ $# -gt 1 ]; then
-	    _mirror="mirror"
-	else
-	    _mirror=""
-	fi
-	zpool create -f -o cachefile=/tmp/zpool.cache -o version=28 -O mountpoint=none -O atime=off -O canmount=off freenas-boot ${_mirror} ${_disksparts}
-	zpool set feature@async_destroy=enabled freenas-boot
-	zpool set feature@empty_bpobj=enabled freenas-boot
-	zpool set feature@lz4_compress=enabled freenas-boot
-	zfs set compress=lz4 freenas-boot
-	zfs create -o canmount=off freenas-boot/ROOT
-	zfs create -o mountpoint=legacy freenas-boot/ROOT/${BENAME}
-
-	return 0
+    return 0
 }
 
 disk_is_freenas()

--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -574,7 +574,7 @@ disk_is_freenas()
 	if [ -z "$DS" ]; then
 	    zpool export freenas-boot || true
 	    return 1
-        elif mount -t zfs freenas-boot/ROOT/"${DS}" /tmp/data_old; then
+	elif mount -t zfs freenas-boot/ROOT/"${DS}" /tmp/data_old; then
 	    # If the active dataset doesn't have a database file,
 	    # then it's not FN as far as we're concerned (the upgrade code
 	    # will go badly).
@@ -614,7 +614,7 @@ disk_is_freenas()
 	    umount /tmp/data_old || return 1
 	    zpool export freenas-boot || return 1
 	    return 0
-        fi # elif mount ...
+	fi # elif mount ...
     fi # if [ "${upgrade_style}" = "new" ]
 
     # This is now legacy code, to support the old

--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -201,11 +201,10 @@ get_media_description()
     local _cap
 
     _media=$1
-    VAL=""
     if [ -n "${_media}" ]; then
 	_description=`geom disk list ${_media} 2>/dev/null \
 	    | sed -ne 's/^   descr: *//p'`
-	if [ -z "$_description" ] ; then
+	if [ -z "${_description}" ]; then
 	    _description="Unknown Device"
 	fi
 	_cap=`diskinfo ${_media} | awk \
@@ -213,7 +212,7 @@ get_media_description()
 	    -v GiB=${GiB}.0 \
 	    -v MiB=${MiB}.0 \
 	'{
-	    capacity = $3;
+	    capacity = int($3);
 	    if (capacity >= TiB) {
 	        printf("%.1f TiB", capacity / TiB);
 	    } else if (capacity >= GiB) {
@@ -224,9 +223,8 @@ get_media_description()
 	        printf("%d Bytes", capacity);
 	    }
 	}'`
-	VAL="${_description} -- ${_cap}"
+	echo "${_description} -- ${_cap}"
     fi
-    export VAL
 }
 
 disk_is_mounted()
@@ -839,8 +837,7 @@ menu_install()
 	    _list=""
 	    _items=0
 	    for _disk in ${_disklist}; do
-		get_media_description "${_disk}"
-		_desc="${VAL}"
+		_desc=$(get_media_description "${_disk}" | sed "s/'/'\\\''/g")
 		_list="${_list} ${_disk} '${_desc}' off"
 		_items=$((${_items} + 1))
 	    done

--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -427,7 +427,7 @@ create_partitions()
 	# leaving units in MiB (2^20).
 	_size="-s $(( (_size >> 24) << 4 ))m"
     fi
-    if gpart create -s GPT -f active ${_disk}; then
+    if gpart create -s GPT ${_disk}; then
 	if [ "$BOOTMODE" = "UEFI" ] ; then
 	  # EFI Mode
 	  sysctl kern.geom.debugflags=16

--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -566,12 +566,9 @@ disk_is_freenas()
 	# This code is very clumsy.  There
 	# should be a way to structure it such that
 	# all of the cleanup happens as we want it to.
-	if zdb -l ${os_part} | grep "name: 'freenas-boot'" > /dev/null ; then
-	    :
-	else
-	    return 1
-	fi
+	zdb -l ${os_part} | fgrep -q "name: 'freenas-boot'" || return 1
 	zpool import -N -f freenas-boot || return 1
+
 	# Now we want to figure out which dataset to use.
 	DS=$(zpool list -H -o bootfs freenas-boot | head -n 1 | cut -d '/' -f 3)
 	if [ -z "$DS" ] ; then

--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -12,6 +12,13 @@ export TERM
 
 . /etc/avatar.conf
 
+
+# Constants for base 10 and base 2 units
+: ${kB:=$((1000))}      ${kiB:=$((1024))};       readonly kB kiB
+: ${MB:=$((1000 * kB))} ${MiB:=$((1024 * kiB))}; readonly MB MiB
+: ${GB:=$((1000 * MB))} ${GiB:=$((1024 * MiB))}; readonly GB GiB
+: ${TB:=$((1000 * GB))} ${TiB:=$((1024 * GiB))}; readonly TB TiB
+
 is_truenas()
 {
 
@@ -112,6 +119,7 @@ bootManager=bsd
 commitDiskPart
 EOF
 }
+
 build_config()
 {
     # build_config ${_disk} ${_image} ${_config_file}
@@ -473,7 +481,7 @@ get_minimum_size() {
     echo ${_min}k
 }
 
-partition_disk() {
+partition_disks() {
 	local _disks _disksparts
 	local _mirror
 	local _minsize
@@ -1058,7 +1066,7 @@ menu_install()
       # We repartition on fresh install, or old upgrade_style
       # This destroys all of the pool data, and
       # ensures a clean filesystems.
-      partition_disk ${_realdisks}
+      partition_disks ${_realdisks}
       mount_disk /tmp/data
     fi
 
@@ -1163,30 +1171,12 @@ menu_install()
     if is_truenas && [ "${_do_upgrade}" -eq 0 ]; then
         : > /tmp/data/${TRUENAS_EULA_PENDING_SENTINEL}
     fi
-    # Finally, before we unmount, start a srub.
+    # Finally, before we unmount, start a scrub.
     # zpool scrub freenas-boot || true
 
     umount /tmp/data/dev
     umount /tmp/data/var
     umount /tmp/data/
-
-    # We created a 16m swap partition earlier, for TrueNAS
-    # And created /data/fstab.swap as well.
-    if is_truenas ; then
-#        # Put a swap partition on newly created installation image
-#        if [ -e /dev/${_disk}s3 ]; then
-#            gpart delete -i 3 ${_disk}
-#            gpart add -t freebsd ${_disk}
-#            echo "/dev/${_disk}s3.eli		none			swap		sw		0	0" > /tmp/fstab.swap
-#        fi
-#
-#        mkdir -p /tmp/data
-#        mount /dev/${_disk}s4 /tmp/data
-#        ls /tmp/data > /dev/null
-#        mv /tmp/fstab.swap /tmp/data/
-#        umount /tmp/data
-#        rmdir /tmp/data
-    fi
 
     # End critical section.
     set +e

--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -65,6 +65,7 @@ pre_install_check()
     fi
     return 0
 }
+
 # Convert /etc/version* to /etc/avatar.conf
 #
 # 1 - old /etc/version* file
@@ -322,7 +323,8 @@ EOD
     return $?
 }
 
-install_loader() {
+install_loader()
+{
     local _disk _disks
     local _mnt
 
@@ -363,7 +365,8 @@ install_loader() {
     return 0
 }
 
-save_serial_settings() {
+save_serial_settings()
+{
     _mnt="$1"
 
     # If the installer was booted with serial mode enabled, we should
@@ -395,7 +398,8 @@ save_serial_settings() {
     fi
 }
 
-mount_disk() {
+mount_disk()
+{
 	local _mnt
 
 	if [ $# -ne 1 ]; then
@@ -409,7 +413,8 @@ mount_disk() {
 	return 0
 }
 
-create_partitions() {
+create_partitions()
+{
     local _disk="$1"
     local _size=""
 
@@ -444,7 +449,8 @@ create_partitions() {
     return 1
 }
 
-get_minimum_size() {
+get_minimum_size()
+{
     local _min=0
     local _disk
     local _size
@@ -481,7 +487,8 @@ get_minimum_size() {
     echo ${_min}k
 }
 
-partition_disks() {
+partition_disks()
+{
 	local _disks _disksparts
 	local _mirror
 	local _minsize
@@ -658,32 +665,33 @@ disk_is_freenas()
 	if [ -f /tmp/data_old/conf/base/etc/hostid ]; then
 	    cp -p /tmp/data_old/conf/base/etc/hostid /tmp/
 	fi
-        if [ -d /tmp/data_old/root/.ssh ]; then
-            cp -pR /tmp/data_old/root/.ssh /tmp/
-        fi
-        if [ -d /tmp/data_old/boot/modules ]; then
-            mkdir -p /tmp/modules
-            for i in `ls /tmp/data_old/boot/modules`
-            do
-                cp -p /tmp/data_old/boot/modules/$i /tmp/modules/
-            done
-        fi
-        if [ -d /tmp/data_old/usr/local/fusionio ]; then
-            cp -pR /tmp/data_old/usr/local/fusionio /tmp/
-        fi
+	if [ -d /tmp/data_old/root/.ssh ]; then
+	    cp -pR /tmp/data_old/root/.ssh /tmp/
+	fi
+	if [ -d /tmp/data_old/boot/modules ]; then
+	    mkdir -p /tmp/modules
+	    for i in `ls /tmp/data_old/boot/modules`
+	    do
+		cp -p /tmp/data_old/boot/modules/$i /tmp/modules/
+	    done
+	fi
+	if [ -d /tmp/data_old/usr/local/fusionio ]; then
+	    cp -pR /tmp/data_old/usr/local/fusionio /tmp/
+	fi
 	if [ -f /tmp/data_old/boot.config ]; then
 	    cp /tmp/data_old/boot.config /tmp/
 	fi
 	if [ -f /tmp/data_old/boot/loader.conf.local ]; then
 	    cp /tmp/data_old/boot/loader.conf.local /tmp/
 	fi
-        umount /tmp/data_old
+	umount /tmp/data_old
     fi
     rmdir /tmp/data_old
     return $_rv
 }
 
-prompt_password() {
+prompt_password()
+{
 
     local values value password="" password1 password2 _counter _tmpfile="/tmp/pwd.$$"
 
@@ -1324,7 +1332,8 @@ fi
 # The output is suitable to be used as the arguments
 # to main(), which will directl ycall menu_install().
 
-yesno() {
+yesno()
+{
     # Output "true" or "false" depending on the argument
     if [ $# -ne 1 ]; then
 	echo "false"
@@ -1337,7 +1346,8 @@ yesno() {
     return 0
 }
 
-getsize() {
+getsize()
+{
     # Given a size specifier, convert it to bytes.
     # No suffix, or a suffix of "[bBcC]", means bytes;
     # [kK] is 1024, etc.
@@ -1356,7 +1366,8 @@ getsize() {
     return 0
 }
 	
-parse_config() {
+parse_config()
+{
     local _conf="/etc/install.conf"
     local _diskList=""
     local _minSize=""

--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -213,15 +213,15 @@ get_media_description()
 	    -v GiB=${GiB}.0 \
 	    -v MiB=${MiB}.0 \
 	'{
-            capacity = $3;
-            if (capacity >= TiB) {
-                printf("%.1f TiB", capacity / TiB);
-            } else if (capacity >= GiB) {
-                printf("%.1f GiB", capacity / GiB);
-            } else if (capacity >= MiB) {
-                printf("%.1f MiB", capacity / MiB);
-            } else {
-                printf("%d Bytes", capacity);
+	    capacity = $3;
+	    if (capacity >= TiB) {
+	        printf("%.1f TiB", capacity / TiB);
+	    } else if (capacity >= GiB) {
+	        printf("%.1f GiB", capacity / GiB);
+	    } else if (capacity >= MiB) {
+	        printf("%.1f MiB", capacity / MiB);
+	    } else {
+	        printf("%d Bytes", capacity);
 	    }
 	}'`
 	VAL="${_description} -- ${_cap}"

--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -571,40 +571,35 @@ disk_is_freenas()
 
 	# Now we want to figure out which dataset to use.
 	DS=$(zpool list -H -o bootfs freenas-boot | head -n 1 | cut -d '/' -f 3)
-	if [ -z "$DS" ] ; then
+	if [ -z "$DS" ]; then
 	    zpool export freenas-boot || true
 	    return 1
-	fi
-	# There should always be a "set default=" line in a grub.cfg
-	# that we created.
-        if [ -n "${DS}" ]; then
-    	   # Okay, mount this pool
-	   if mount -t zfs freenas-boot/ROOT/"${DS}" /tmp/data_old; then
-		    # If the active dataset doesn't have a database file,
-		    # then it's not FN as far as we're concerned (the upgrade code
-		    # will go badly).
-		    # We also check for the Corral database directory.
-		    if [ ! -f /tmp/data_old/data/freenas-v1.db -o \
-			   -d /tmp/data_old/data/freenas.db ]; then
-			umount /tmp/data_old || true
-			zpool export freenas-boot || true
-			return 1
-		    fi
-		    cp -pR /tmp/data_old/data/. /tmp/data_preserved
-		    # Don't want to keep the old pkgdb around, since we're
-		    # nuking the filesystem
-		    rm -rf /tmp/data_preserved/pkgdb
-		    if [ -f /tmp/data_old/conf/base/etc/hostid ]; then
-			cp -p /tmp/data_old/conf/base/etc/hostid /tmp/
-		    fi
-		    if [ -d /tmp/data_old/root/.ssh ]; then
-			cp -pR /tmp/data_old/root/.ssh /tmp/
-		    fi
-		    if [ -d /tmp/data_old/boot/modules ]; then
-			mkdir -p /tmp/modules
-			for i in `ls /tmp/data_old/boot/modules`
+        elif mount -t zfs freenas-boot/ROOT/"${DS}" /tmp/data_old; then
+	    # If the active dataset doesn't have a database file,
+	    # then it's not FN as far as we're concerned (the upgrade code
+	    # will go badly).
+	    # We also check for the Corral database directory.
+	    if [ ! -f /tmp/data_old/data/freenas-v1.db -o \
+		   -d /tmp/data_old/data/freenas.db ]; then
+		umount /tmp/data_old || true
+		zpool export freenas-boot || true
+		return 1
+	    fi
+	    cp -pR /tmp/data_old/data/. /tmp/data_preserved
+	    # Don't want to keep the old pkgdb around, since we're
+	    # nuking the filesystem
+	    rm -rf /tmp/data_preserved/pkgdb
+	    if [ -f /tmp/data_old/conf/base/etc/hostid ]; then
+		cp -p /tmp/data_old/conf/base/etc/hostid /tmp/
+	    fi
+	    if [ -d /tmp/data_old/root/.ssh ]; then
+		cp -pR /tmp/data_old/root/.ssh /tmp/
+	    fi
+	    if [ -d /tmp/data_old/boot/modules ]; then
+		mkdir -p /tmp/modules
+		for i in `ls /tmp/data_old/boot/modules`
 		do
-	    cp -p /tmp/data_old/boot/modules/$i /tmp/modules/
+		    cp -p /tmp/data_old/boot/modules/$i /tmp/modules/
 		done
 	    fi
 	    if [ -d /tmp/data_old/usr/local/fusionio ]; then
@@ -619,9 +614,8 @@ disk_is_freenas()
 	    umount /tmp/data_old || return 1
 	    zpool export freenas-boot || return 1
 	    return 0
-        fi
-      fi
-    fi # End of if NEW upgrade style
+        fi # elif mount ...
+    fi # if [ "${upgrade_style}" = "new" ]
 
     # This is now legacy code, to support the old
     # partitioning scheme (freenas-9.2 and earlier)
@@ -631,7 +625,7 @@ disk_is_freenas()
 
     ls /tmp/data_old > /tmp/data_old.ls
     if [ -f /tmp/data_old/freenas-v1.db ]; then
-        _rv=0
+	_rv=0
     fi
     # XXX side effect, shouldn't be here!
     cp -pR /tmp/data_old/. /tmp/data_preserved


### PR DESCRIPTION
Mostly cherry-picked housekeeping commits from master. Grabbing them significantly reduces the diff between master and 11.2-stable, making it easier to cherry-pick fixes from master.

Functional changes:
* cherry-picked from 9ae7fba26335e0b5a5acf49407e6fcaae45a429e
  - Escape single-quotes in media description (fixes #67071)
* cherry-picked from 7825a1502dda61f8db524e24034063b1bb2a3021
  - Round ZFS partition size down to a multiple of 16 MiB
  - Enforce documented minimum 8 GiB ZFS partition size 

Ticket: #67071