### PR TITLE
tkt-69879: fix(jail/get_activated_pool): Check dataset existence first

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -357,8 +357,13 @@ class JailService(CRUDService):
             pool = ioc.IOCage(skip_jails=True).get("", pool=True)
         except RuntimeError as e:
             raise CallError(f'Error occurred getting activated pool: {e}')
-        except ioc_exceptions.PoolNotActivated:
-            pool = None
+        except (ioc_exceptions.PoolNotActivated, FileNotFoundError):
+            self.check_dataset_existence()
+
+            try:
+                pool = ioc.IOCage(skip_jails=True).get("", pool=True)
+            except ioc_exceptions.PoolNotActivated:
+                pool = None
 
         return pool
 

--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -354,14 +354,14 @@ class JailService(CRUDService):
     def get_activated_pool(self):
         """Returns the activated pool if there is one, or None"""
         try:
-            pool = ioc.IOCage(skip_jails=True).get("", pool=True)
+            pool = ioc.IOCage(skip_jails=True).get('', pool=True)
         except RuntimeError as e:
             raise CallError(f'Error occurred getting activated pool: {e}')
         except (ioc_exceptions.PoolNotActivated, FileNotFoundError):
             self.check_dataset_existence()
 
             try:
-                pool = ioc.IOCage(skip_jails=True).get("", pool=True)
+                pool = ioc.IOCage(skip_jails=True).get('', pool=True)
             except ioc_exceptions.PoolNotActivated:
                 pool = None
 


### PR DESCRIPTION
iocage tries to write a defaults file as it expects the datasets to exist when the active pool is being fetched. If we have these two exceptions, we make sure to create those datasets and try one more time.

Ticket: #69879