### PR TITLE
tkt-70626: fix(middlewared/mdns): hook does not have `middleware` as first argument

### DIFF
--- a/src/middlewared/middlewared/plugins/mdns.py
+++ b/src/middlewared/middlewared/plugins/mdns.py
@@ -720,7 +720,7 @@ class mDNSAdvertiseService(Service):
         self.start()
 
 
-async def dns_post_sync(middleware):
+async def dns_post_sync():
     mDNSDaemonMonitor.instance.dns_sync.set()
 
 


### PR DESCRIPTION
Change was introduced in 11.3.

Ticket:	#70626