### PR TITLE
tkt-70698: Bug fix for ZFS Wizard

### DIFF
--- a/gui/freeadmin/static/lib/js/freeadmin.js
+++ b/gui/freeadmin/static/lib/js/freeadmin.js
@@ -2094,6 +2094,16 @@ require([
 
     }
 
+    checked_zfs_extra_option = function(disk, radio_type) {
+        // Returns whether the radio button is checked
+        let radio_input = query("input[name=zpool_" + disk + "]:input[value=" + radio_type + "]");
+        if (radio_input.length > 0) {
+            return [radio_input[0].checked, true];
+        } else {
+            return [false, false];
+        }
+    }
+
     zfswizardcheckings = function(vol_change, first_load) {
 
         if(!registry.byId("wizarddisks")) return;
@@ -2130,7 +2140,6 @@ require([
             if(unselected.length > 0) {
 
                 var tab = dom.byId("disks_unselected");
-                query("#disks_unselected tbody tr").orphan();
                 var txt = "";
                 var toappend = [];
                 for(var i=0;i<unselected.length;i++) {
@@ -2138,32 +2147,48 @@ require([
                     var td = domConstruct.create("td", {innerHTML: unselected[i]});
                     tr.appendChild(td);
 
+                    let radio_name = "zpool_" + unselected[i];
+                    let checked = checked_zfs_extra_option(unselected[i], "none");
+
+                    if (checked[1] == false) {
+                        // if none does not exist, we would like to make sure that checked is true for none
+                        checked[0] = true;
+                    }
                     var td = domConstruct.create("td");
-                    var rad = new RadioButton({ checked: true, value: "none", name: "zpool_"+unselected[i]});
+                    var rad = new RadioButton({ checked: checked[0], value: "none", name: radio_name});
+                    on(rad, 'click', function() {checkNumLog(unselected);});
+                    on(rad, 'change', function() {zfsextrawizardcheckings(this);});
+                    td.appendChild(rad.domNode);
+                    tr.appendChild(td);
+
+                    checked = checked_zfs_extra_option(unselected[i], "log");
+
+                    var td = domConstruct.create("td");
+                    var rad = new RadioButton({ checked: checked[0], value: "log", name: radio_name});
                     on(rad, 'click', function() {checkNumLog(unselected);});
                     td.appendChild(rad.domNode);
                     tr.appendChild(td);
 
+                    checked = checked_zfs_extra_option(unselected[i], "cache");
+
                     var td = domConstruct.create("td");
-                    var rad = new RadioButton({ value: "log", name: "zpool_"+unselected[i]});
+                    var rad = new RadioButton({ checked: checked[0], value: "cache", name: radio_name});
                     on(rad, 'click', function() {checkNumLog(unselected);});
                     td.appendChild(rad.domNode);
                     tr.appendChild(td);
 
-                    var td = domConstruct.create("td");
-                    var rad = new RadioButton({ value: "cache", name: "zpool_"+unselected[i]});
-                    on(rad, 'click', function() {checkNumLog(unselected);});
-                    td.appendChild(rad.domNode);
-                    tr.appendChild(td);
+                    checked = checked_zfs_extra_option(unselected[i], "spare");
 
                     var td = domConstruct.create("td");
-                    var rad = new RadioButton({ value: "spare", name: "zpool_"+unselected[i]});
+                    var rad = new RadioButton({ checked: checked[0], value: "spare", name: radio_name});
                     on(rad, 'click', function() {checkNumLog(unselected);});
                     td.appendChild(rad.domNode);
                     tr.appendChild(td);
 
                     toappend.push(tr);
                 }
+
+                query("#disks_unselected tbody tr").orphan();
 
                 for(var i=0;i<toappend.length;i++) {
                     dojo.place(toappend[i], query("#disks_unselected tbody")[0]);
@@ -2211,6 +2236,23 @@ require([
             domStyle.set("grpraidz3", "display", "none");
         }
 
+    }
+
+    zfsextrawizardcheckings = function(selected_radio_disk) {
+        let name = selected_radio_disk.name.replace("zpool_", "");
+        let disk_option = query("option[value=" + name + "]");
+
+        if (disk_option.length > 0) {
+            disk_option = disk_option[0];
+            if(selected_radio_disk.checked) {
+                // add this option to disks
+                domStyle.set(disk_option, "display", "");
+
+            } else {
+                // remove this option from disks
+                domStyle.set(disk_option, "display", "none");
+            }
+        }
     }
 
     wizardcheckings = function(vol_change, first_load) {

--- a/gui/storage/views.py
+++ b/gui/storage/views.py
@@ -262,17 +262,20 @@ def volumemanager_zfs(request):
                 (zpoolfields.search(i).group(1), i, request.POST.get(i))
                 for i in list(request.POST.keys()) if zpoolfields.match(i)
             ]
+            zfsextradisks = [v[0] for v in zfsextra if v[2] != 'none']
 
     else:
         form = forms.ZFSVolumeWizardForm()
         disks = []
         zfsextra = None
+        zfsextradisks = []
     # dedup = forms._dedup_enabled()
     dedup = True
     return render(request, 'storage/zfswizard.html', {
         'form': form,
         'disks': disks,
         'zfsextra': zfsextra,
+        'zfsextradisks': zfsextradisks,
         'dedup': dedup,
     })
 

--- a/gui/templates/storage/zfswizard.html
+++ b/gui/templates/storage/zfswizard.html
@@ -67,7 +67,7 @@
                     zfswizardcheckings(true);
                 </script>
                 {% for e in form.volume_disks.field.choices %}
-                <option value="{{ e.0 }}" {% if e.0 in disks %}selected="selected"{% endif %}>{{ e.1 }}</option>
+                    <option value="{{ e.0 }}" {% if e.0 in disks %}selected="selected"{% endif %} {% if e.0 in zfsextradisks %}style="display: none"{% endif %}>{{ e.1 }}</option>
                 {% empty %}
                 {% endfor %}
             </select>
@@ -134,7 +134,7 @@
                         {% for disk, name, val in zfsextra %}
                         <tr>
                             <td>{{ disk }}</td>
-                            <td><input data-dojo-type="dijit.form.RadioButton" data-dojo-props="name: '{{ name }}', value: 'none'{% if val == "none" %}, checked: true{% endif %}"/></td>
+                            <td><input onchange="zfsextrawizardcheckings(this);" data-dojo-type="dijit.form.RadioButton" data-dojo-props="name: '{{ name }}', value: 'none'{% if val == "none" %}, checked: true{% endif %}"/></td>
                             <td><input data-dojo-type="dijit.form.RadioButton" data-dojo-props="name: '{{ name }}', value: 'log'{% if val == "log" %}, checked: true{% endif %}"/></td>
                             <td><input data-dojo-type="dijit.form.RadioButton" data-dojo-props="name: '{{ name }}', value: 'cache'{% if val == "cache" %}, checked: true{% endif %}"/></td>
                             <td><input data-dojo-type="dijit.form.RadioButton" data-dojo-props="name: '{{ name }}', value: 'spare'{% if val == "spare" %}, checked: true{% endif %}"/></td>


### PR DESCRIPTION
This commit fixes two bugs:
1) Remove options from Member Disks if selected in ZFS Extra
2) Retain values of ZFS Extra if a disk is selected in Member Disk

Ticket: #70689