### PR TITLE
Replace prefix appropriately

### DIFF
--- a/src/middlewared/middlewared/plugins/datastore.py
+++ b/src/middlewared/middlewared/plugins/datastore.py
@@ -205,7 +205,7 @@ class DatastoreService(Service):
         verrors = ValidationErrors()
         fields = list(
             map(
-                lambda f: f.name.replace(prefix or '', ''),
+                lambda f: f.name.replace(prefix or '', '', 1),
                 chain(model._meta.fields, model._meta.many_to_many)
             )
         )
@@ -237,7 +237,7 @@ class DatastoreService(Service):
 
         for field in chain(model._meta.fields, model._meta.many_to_many):
             if prefix:
-                name = field.name.replace(prefix, '')
+                name = field.name.replace(prefix, '', 1)
             else:
                 name = field.name
             if name not in data:
@@ -275,7 +275,7 @@ class DatastoreService(Service):
         obj = model.objects.get(pk=id)
         for field in chain(model._meta.fields, model._meta.many_to_many):
             if prefix:
-                name = field.name.replace(prefix, '')
+                name = field.name.replace(prefix, '', 1)
             else:
                 name = field.name
             if name not in data:

--- a/src/middlewared/middlewared/plugins/dyndns.py
+++ b/src/middlewared/middlewared/plugins/dyndns.py
@@ -43,4 +43,4 @@ class DynDNSService(SystemServiceService):
 
         await self.dyndns_extend(new)
 
-        return new
+        return await self.config()


### PR DESCRIPTION
This commit fixes an issue with the datastore service where we replaced all instances of a prefix in the field name. This changes that behaviour to only replace the first occurrence.

Ticket: #71635