### PR TITLE
Correctly set kern.corefile

### DIFF
--- a/src/freenas/etc/sysctl.conf
+++ b/src/freenas/etc/sysctl.conf
@@ -6,6 +6,7 @@
 # of blocks after they have been in the queues for X seconds.  It is critical
 # that metadelay < dirdelay < filedelay and no fractions are allowed.
 
+kern.corefile=/var/tmp/%N.core
 kern.metadelay=3
 kern.dirdelay=4
 kern.filedelay=5


### PR DESCRIPTION
This commit fixes an issue where we could fill up /etc directory with application's core dumps.
Ticket: #71955