### PR TITLE
tkt-72057: fix(jail/create): If domaincontroller is enabled, use the forwarder (by skarekrow)

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -150,10 +150,10 @@ class JailService(CRUDService):
             job.set_progress(20, 'Initial validation complete')
 
         if not any('resolver' in p for p in options['props']):
-            dc = self.middleware.call(
+            dc = self.middleware.call_sync(
                 'service.query', [('service', '=', 'domaincontroller')]
             )
-            dc_config = self.middleware.call('domaincontroller.config')
+            dc_config = self.middleware.call_sync('domaincontroller.config')
 
             if dc['enable'] and (
                 dc_config['dns_forwarder'] and

--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -149,6 +149,20 @@ class JailService(CRUDService):
 
             job.set_progress(20, 'Initial validation complete')
 
+        if not any('resolver' in p for p in options['props']):
+            dc = self.middleware.call(
+                'service.query', [('service', '=', 'domaincontroller')]
+            )
+            dc_config = self.middleware.call('domaincontroller.config')
+
+            if dc['enable'] and (
+                dc_config['dns_forwarder'] and
+                dc_config['dns_backend'] == 'SAMBA_INTERNAL'
+            ):
+                options['props'].append(
+                    f'resolver=nameserver {dc_config["dns_forwarder"]}'
+                )
+
         iocage = ioc.IOCage(skip_jails=True)
 
         release = options["release"]


### PR DESCRIPTION
This only applies if they did not already specify their own resolver. If DC is not enabled, it will fall back to the default that is configured in iocage defaults (copy hosts by default, unless the user changed it.)

Ticket: #71083