### PR TITLE
tkt-71987: Serial Port Choices

### DIFF
--- a/gui/choices.py
+++ b/gui/choices.py
@@ -918,11 +918,12 @@ CASE_SENSITIVITY_CHOICES = (
 class SERIAL_CHOICES(object):
 
     def __iter__(self):
+        ports = {}
         try:
             with client as c:
                 ports = c.call('system.advanced.serial_port_choices')
         except Exception:
-            ports = ['0x2f8']
+            ports['0x2f8'] = '0x2f8'
         for p in ports:
             yield (p, p)
 

--- a/gui/system/forms.py
+++ b/gui/system/forms.py
@@ -1125,6 +1125,8 @@ class AdvancedForm(MiddlewareModelForm, ModelForm):
         self.fields['adv_motd'].strip = False
         self.original_instance = self.instance.__dict__
 
+        self.fields['adv_serialport'].choices = list(choices.SERIAL_CHOICES())
+
         self.fields['adv_reset_sed_password'].widget.attrs['onChange'] = (
             'toggleGeneric("id_adv_reset_sed_password", ["id_adv_sed_passwd"], false);'
         )

--- a/gui/system/models.py
+++ b/gui/system/models.py
@@ -225,8 +225,7 @@ class Advanced(Model):
         help_text=_(
             "Set this to match your serial port address (0x3f8, 0x2f8, etc.)"
         ),
-        verbose_name=_("Serial Port Address"),
-        choices=choices.SERIAL_CHOICES(),
+        verbose_name=_("Serial Port Address")
     )
     adv_serialspeed = models.CharField(
         max_length=120,

--- a/tests/api2/system_advanced.py
+++ b/tests/api2/system_advanced.py
@@ -28,8 +28,8 @@ def test_02_system_advanced_serial_port_choices(sysadv_dict):
     results = GET('/system/advanced/serial_port_choices/')
     assert results.status_code == 200, results.text
     data = results.json()
-    sysadv_dict['serial_choices'] = data
-    assert isinstance(data, list), data
+    sysadv_dict['serial_choices'] = [k for k in data]
+    assert isinstance(data, dict), data
     assert len(data) > 0, data
 
 


### PR DESCRIPTION
This commit fixes an issue where a machine which did not support the default serial port ran into issues when updating values of different attributes of advanced model because we did not add the default port value in our serial port choices.
Ticket: #71987