### PR TITLE
Skip fstab generation

### DIFF
--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -180,7 +180,7 @@ class EtcService(Service):
         ]
     }
 
-    SKIP_LIST = ['system_dataset', 'collectd']
+    SKIP_LIST = ['system_dataset', 'collectd', 'fstab']
 
     class Config:
         private = True


### PR DESCRIPTION
This commit fixes a potential issue which would result in undesired behaviour as we configure swap and generate fstab file before a few other scripts which must be run prior to the fstab actions.