### PR TITLE
tkt-73182: Bug fix for Dynamic DNS

### DIFF
--- a/gui/services/forms.py
+++ b/gui/services/forms.py
@@ -479,7 +479,7 @@ class DynamicDNSForm(MiddlewareModelForm, ModelForm):
         return cdata
 
     def middleware_clean(self, update):
-        update["domain"] = update["domain"].split()
+        update["domain"] = update["domain"].replace(',', ' ').replace(';', ' ').split()
         return update
 
 

--- a/src/middlewared/middlewared/plugins/dyndns.py
+++ b/src/middlewared/middlewared/plugins/dyndns.py
@@ -12,7 +12,7 @@ class DynDNSService(SystemServiceService):
     @private
     async def dyndns_extend(self, dyndns):
         dyndns["password"] = await self.middleware.call("pwenc.decrypt", dyndns["password"])
-        dyndns["domain"] = dyndns["domain"].split()
+        dyndns["domain"] = dyndns["domain"].replace(',', ' ').replace(';', ' ').split()
         return dyndns
 
     @accepts(Dict(


### PR DESCRIPTION
This commit fixes a potential bug where we weren't delimiting ,; characters when parsing domain attribute of dynamic dns and only doing so on whitespace ones.