### PR TITLE
tkt-73317: Restart collectd/rrdcached properly

### DIFF
--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -186,8 +186,8 @@ class SystemDatasetService(ConfigService):
 
         if await self.__setup_datasets(config['pool'], config['uuid']):
             # There is no need to wait this to finish
+            # Restarting rrdcached will ensure that we start/restart collectd as well
             asyncio.ensure_future(self.middleware.call('service.restart', 'rrdcached'))
-            asyncio.ensure_future(self.middleware.call('service.start', 'collectd'))
 
         if not os.path.isdir(SYSDATASET_PATH):
             if os.path.exists(SYSDATASET_PATH):


### PR DESCRIPTION
This commit fixes an issue where when we restart system datasets, it is possible that collectd is running already before we call a restart on rrdcached which results in error messagas printed out as collectd fails to connect to rrdcached.