### PR TITLE
tkt-73587: Password fix for Dynamic DNS

### DIFF
--- a/gui/services/forms.py
+++ b/gui/services/forms.py
@@ -472,14 +472,10 @@ class DynamicDNSForm(MiddlewareModelForm, ModelForm):
             )
         return password2
 
-    def clean(self):
-        cdata = self.cleaned_data
-        if not cdata.get("ddns_password"):
-            cdata['ddns_password'] = self.instance.ddns_password
-        return cdata
-
     def middleware_clean(self, update):
         update["domain"] = update["domain"].replace(',', ' ').replace(';', ' ').split()
+        if not update.get('password'):
+            update.pop('password', None)
         return update
 
 


### PR DESCRIPTION
This commit fixes an issue where we while using legacy UI set the encrypted password taken from db as user specified one resulting in a double encrypted password which to the end user makes no sense and also breaks the config file generation.