### PR TITLE
tkt-73819: Fix OpenSSL path

### DIFF
--- a/src/freenas/etc/rc.freenas
+++ b/src/freenas/etc/rc.freenas
@@ -51,7 +51,7 @@
 #
 #	OPENSSL settings
 #
-: ${OPENSSL:="/usr/local/bin/openssl"}
+: ${OPENSSL:="/usr/bin/openssl"}
 : ${SSLDIR:="/etc/certificates"}
 : ${SSLCADIR:="${SSLDIR}/CA"}
 


### PR DESCRIPTION
This commit fixes a path issue for OpenSSL where it was changed recently as the port version of openssl was removed from the build.