### PR TITLE
Remove leftovers of OpenSSL configuration

### DIFF
--- a/src/freenas/etc/rc.freenas
+++ b/src/freenas/etc/rc.freenas
@@ -51,13 +51,6 @@
 : ${FIRST_INSTALL_SENTINEL="/data/first-boot"}
 
 #
-#	OPENSSL settings
-#
-: ${OPENSSL:="/usr/local/bin/openssl"}
-: ${SSLDIR:="/etc/certificates"}
-: ${SSLCADIR:="${SSLDIR}/CA"}
-
-#
 #	Misc settings
 #
 : ${FREENAS_CACHEDIR:="/var/tmp/.cache"}


### PR DESCRIPTION
This commit removes leftover variables configuration related to OpenSSL in rc.freenas as they are not used anywhere now.