### PR TITLE
tkt-73657: Fix ordering for vfs_crossrename

### DIFF
--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -1242,7 +1242,7 @@ def generate_smb4_shares(client, smb4_shares, shares):
         vfs_objects.extend(share.cifs_vfsobjects)
 
         if share.cifs_recyclebin:
-            vfs_objects.extend(["recycle","crossrename"])
+            vfs_objects.extend(["recycle", "crossrename"])
             confset1(smb4_shares, "recycle:repository = .recycle/%U")
             confset1(smb4_shares, "recycle:keeptree = yes")
             confset1(smb4_shares, "recycle:versions = yes")

--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -265,7 +265,7 @@ def config_share_for_zfs(share):
 # for fruit, and if catia and fruit are used, catia comes before fruit
 #
 def order_vfs_objects(vfs_objects):
-    vfs_objects_special = ('catia', 'zfs_space', 'zfsacl', 'fruit', 'streams_xattr', 'recycle', 'aio_pthread')
+    vfs_objects_special = ('catia', 'zfs_space', 'zfsacl', 'fruit', 'streams_xattr', 'recycle', 'crossrename', 'aio_pthread')
     vfs_objects_ordered = []
 
     if 'fruit' in vfs_objects:

--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -1242,7 +1242,7 @@ def generate_smb4_shares(client, smb4_shares, shares):
         vfs_objects.extend(share.cifs_vfsobjects)
 
         if share.cifs_recyclebin:
-            vfs_objects.append('recycle')
+            vfs_objects.extend(["recycle","crossrename"])
             confset1(smb4_shares, "recycle:repository = .recycle/%U")
             confset1(smb4_shares, "recycle:keeptree = yes")
             confset1(smb4_shares, "recycle:versions = yes")


### PR DESCRIPTION
crossrename was being placed before recycle, which breaks recycle bin across ZFS datasets.