### PR TITLE
tkt-70300: Convert ix-shutdown to Middlewared

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-shutdown
+++ b/src/freenas/etc/ix.rc.d/ix-shutdown
@@ -11,25 +11,7 @@
 
 do_shutdown()
 {
-	local IFS="|"
-	local f="ini_type ini_command ini_script ini_when"
-	eval local $f
-	local sf=$(var_to_sf $f)
-
-	RO_FREENAS_CONFIG=$(ro_sqlite ${name} 2> /tmp/${name}.fail && rm /tmp/${name}.fail)
-	trap 'rm -f ${RO_FREENAS_CONFIG}' EXIT
-
-	${FREENAS_SQLITE_CMD} ${RO_FREENAS_CONFIG} \
-	"SELECT $sf FROM tasks_initshutdown WHERE ini_when = 'shutdown' AND ini_enabled = 1 ORDER BY id" | \
-	while eval read -r $f; do
-		if [ "${ini_type}" = "command" ]; then
-			eval ${ini_command}
-		else
-			if [ -e "${ini_script}" ]; then
-				sh -c "exec ${ini_script}"
-			fi
-		fi
-	done
+	/usr/local/bin/midclt call initshutdownscript.execute_init_tasks SHUTDOWN > /dev/null
 }
 
 name="ix-shutdown"


### PR DESCRIPTION
This commit removes redundant logic in ix-shutdown for executing tasks at shutdown and instead calls middlewared to perform the relevant SHUTDOWN related tasks when it is called.
Ticket: #70300