### PR TITLE
tkt-72131: Configure timezone correctly

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -808,7 +808,14 @@ class Middleware(object):
                     self.add_service(cls(self))
 
                 if hasattr(mod, 'setup'):
-                    setup_funcs.append((mod.__name__.rsplit('.', 1)[-1], mod.setup))
+                    setup_plugin = mod.__name__.rsplit('.', 1)[-1]
+                    # TODO: Let's please remove this conditional when we have order defined for setup functions
+                    # We need to run system plugin setup's function first because when system boots, the right
+                    # timezone is not configured. See #72131
+                    if setup_plugin == 'system':
+                        setup_funcs.insert(0, (setup_plugin, mod.setup))
+                    else:
+                        setup_funcs.append((setup_plugin, mod.setup))
 
         self._console_write(f'resolving plugins schemas')
         # Now that all plugins have been loaded we can resolve all method params

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -955,7 +955,15 @@ class SystemHealthEventSource(EventSource):
             })
 
 
-def setup(middleware):
+async def setup(middleware):
+    settings = await middleware.call(
+        'system.general.config',
+    )
+    os.environ['TZ'] = settings['timezone']
+    time.tzset()
+
+    middleware.logger.debug(f'Timezone set to {settings["timezone"]}')
+
     global SYSTEM_READY
     if os.path.exists("/tmp/.bootready"):
         SYSTEM_READY = True


### PR DESCRIPTION
This commit makes sure that we configure timezone correctly in Middlewared when the system boots as this resulted in Middlewared still using UTC for it's actions even after the boot is complete.
Ticket: #72131