### PR TITLE
Fix quoting of generated values in ctl.conf

### DIFF
--- a/src/freenas/usr/local/libexec/nas/generate_ctl_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_ctl_conf.py
@@ -41,13 +41,13 @@ logging.config.dictConfig({
 
 # This file has plain text CHAP users and passwords in it, and is
 # the config file used by CTL.
-ctl_config = "/etc/ctl.conf"
+ctl_config = '/etc/ctl.conf'
 cf_contents = []
 # This file has the CHAP usernames and passwords replaced with
 # REDACTED.  It is consumed by freenas-debug.  We generate both
 # files every time the system determines a new config file
 # needs to be created from the database.
-ctl_config_shadow = "/etc/ctl.conf.shadow"
+ctl_config_shadow = '/etc/ctl.conf.shadow'
 cf_contents_shadow = []
 
 
@@ -74,19 +74,19 @@ def auth_group_config(auth_tag=None, auth_list=None, auth_type=None, initiator=N
     inets = []
     if initiator:
         if initiator.iscsi_target_initiator_initiators:
-            sep = "\n"
-            if "," in initiator.iscsi_target_initiator_initiators:
-                sep = ","
-            elif " " in initiator.iscsi_target_initiator_initiators:
-                sep = " "
+            sep = '\n'
+            if ',' in initiator.iscsi_target_initiator_initiators:
+                sep = ','
+            elif ' ' in initiator.iscsi_target_initiator_initiators:
+                sep = ' '
             inames = initiator.iscsi_target_initiator_initiators.strip('\n').split(sep)
             inames = [x for x in inames if x != 'ALL' and x != '']
         if initiator.iscsi_target_initiator_auth_network:
-            sep = "\n"
-            if "," in initiator.iscsi_target_initiator_auth_network:
-                sep = ","
-            elif " " in initiator.iscsi_target_initiator_auth_network:
-                sep = " "
+            sep = '\n'
+            if ',' in initiator.iscsi_target_initiator_auth_network:
+                sep = ','
+            elif ' ' in initiator.iscsi_target_initiator_auth_network:
+                sep = ' '
             inets = initiator.iscsi_target_initiator_auth_network.strip('\n').split(sep)
             inets = [x for x in inets if x != 'ALL' and x != '']
 
@@ -95,34 +95,34 @@ def auth_group_config(auth_tag=None, auth_list=None, auth_type=None, initiator=N
         return False
 
     # There are some real paremeters, so write the auth group.
-    addline("auth-group %s {\n" % auth_tag)
+    addline('auth-group %s {\n' % auth_tag)
     for name in inames:
-        addline("""\tinitiator-name "%s"\n""" % name.lstrip())
+        addline('\tinitiator-name "%s"\n' % name.lstrip())
     for name in inets:
-        addline("""\tinitiator-portal "%s"\n""" % name.lstrip())
+        addline('\tinitiator-portal "%s"\n' % name.lstrip())
     # It is an error to mix CHAP and Mutual CHAP in the same auth group
     # But not in istgt, so we need to catch this and do something.
     # For now just skip over doing something that would cause ctld to bomb
     for auth in auth_list:
-        if auth.iscsi_target_auth_peeruser and auth_type != "CHAP":
-            auth_type = "Mutual"
-            addline("\tchap-mutual %s \"%s\" %s \"%s\"\n" % (
+        if auth.iscsi_target_auth_peeruser and auth_type != 'CHAP':
+            auth_type = 'Mutual'
+            addline('\tchap-mutual %s "%s" %s "%s"\n' % (
                 auth.iscsi_target_auth_user,
                 auth.iscsi_target_auth_secret,
                 auth.iscsi_target_auth_peeruser,
                 auth.iscsi_target_auth_peersecret,
             ), plaintextonly=True)
-            addline("\tchap-mutual REDACTED REDACTED REDACTED REDACTED\n", shadowonly=True)
-        elif auth_type != "Mutual":
-            auth_type = "CHAP"
-            addline("\tchap %s \"%s\"\n" % (
+            addline('\tchap-mutual REDACTED REDACTED REDACTED REDACTED\n', shadowonly=True)
+        elif auth_type != 'Mutual':
+            auth_type = 'CHAP'
+            addline('\tchap %s "%s"\n' % (
                 auth.iscsi_target_auth_user,
                 auth.iscsi_target_auth_secret,
             ), plaintextonly=True)
-            addline("\tchap REDACTED REDACTED\n", shadowonly=True)
+            addline('\tchap REDACTED REDACTED\n', shadowonly=True)
     if not auth_list and (auth_type == 'None' or auth_type == 'auto'):
-        addline("\tauth-type \"none\"\n")
-    addline("}\n\n")
+        addline('\tauth-type "none"\n')
+    addline('}\n\n')
     return True
 
 
@@ -157,7 +157,7 @@ def main():
         if not auth_group_config(auth_tag=agname,
                                  auth_list=auth_list,
                                  auth_type=pg.iscsi_target_portal_discoveryauthmethod):
-            agname = "no-authentication"
+            agname = 'no-authentication'
 
         # Prepare IPs to listen on for all portal groups.
         portals = [
@@ -174,58 +174,58 @@ def main():
                 address = portal.iscsi_target_portalip_ip
             found = False
             if gconf.iscsi_alua:
-                if address == "0.0.0.0":
-                    listenA.append("%s:%s" % (address, portal.iscsi_target_portalip_port))
-                    listenB.append("%s:%s" % (address, portal.iscsi_target_portalip_port))
+                if address == '0.0.0.0':
+                    listenA.append('%s:%s' % (address, portal.iscsi_target_portalip_port))
+                    listenB.append('%s:%s' % (address, portal.iscsi_target_portalip_port))
                     found = True
                     break
                 if not found:
                     for net in client.call('datastore.query', 'network.Interfaces'):
                         if net['int_vip'] == address and net['int_ipv4address'] and net['int_ipv4address_b']:
-                            listenA.append("%s:%s" % (net['int_ipv4address'], portal.iscsi_target_portalip_port))
-                            listenB.append("%s:%s" % (net['int_ipv4address_b'], portal.iscsi_target_portalip_port))
+                            listenA.append('%s:%s' % (net['int_ipv4address'], portal.iscsi_target_portalip_port))
+                            listenB.append('%s:%s' % (net['int_ipv4address_b'], portal.iscsi_target_portalip_port))
                             found = True
                             break
                 if not found:
                     for alias in client.call('datastore.query', 'network.Alias'):
                         if alias['alias_vip'] == address and alias['alias_v4address'] and alias['alias_v4address_b']:
-                            listenA.append("%s:%s" % (alias['alias_v4address'], portal.iscsi_target_portalip_port))
-                            listenB.append("%s:%s" % (alias['alias_v4address_b'], portal.iscsi_target_portalip_port))
+                            listenA.append('%s:%s' % (alias['alias_v4address'], portal.iscsi_target_portalip_port))
+                            listenB.append('%s:%s' % (alias['alias_v4address_b'], portal.iscsi_target_portalip_port))
                             found = True
                             break
             else:
-                listen.append("%s:%s" % (address, portal.iscsi_target_portalip_port))
+                listen.append('%s:%s' % (address, portal.iscsi_target_portalip_port))
 
         if gconf.iscsi_alua:
             # Two portal groups for ALUA HA case.
-            addline("portal-group pg%dA {\n" % pg.iscsi_target_portal_tag)
-            addline("\ttag 0x%04x\n" % pg.iscsi_target_portal_tag)
-            addline("\tdiscovery-filter portal-name\n")
-            addline("\tdiscovery-auth-group %s\n" % agname)
+            addline('portal-group pg%dA {\n' % pg.iscsi_target_portal_tag)
+            addline('\ttag 0x%04x\n' % pg.iscsi_target_portal_tag)
+            addline('\tdiscovery-filter portal-name\n')
+            addline('\tdiscovery-auth-group %s\n' % agname)
             for i in listenA:
-                addline("\tlisten %s\n" % i)
-            if node != "A":
-                addline("\tforeign\n")
-            addline("}\n")
-            addline("portal-group pg%dB {\n" % pg.iscsi_target_portal_tag)
-            addline("\ttag 0x%04x\n" % (pg.iscsi_target_portal_tag + 0x8000))
-            addline("\tdiscovery-filter portal-name\n")
-            addline("\tdiscovery-auth-group %s\n" % agname)
+                addline('\tlisten %s\n' % i)
+            if node != 'A':
+                addline('\tforeign\n')
+            addline('}\n')
+            addline('portal-group pg%dB {\n' % pg.iscsi_target_portal_tag)
+            addline('\ttag 0x%04x\n' % (pg.iscsi_target_portal_tag + 0x8000))
+            addline('\tdiscovery-filter portal-name\n')
+            addline('\tdiscovery-auth-group %s\n' % agname)
             for i in listenB:
-                addline("\tlisten %s\n" % i)
-            if node != "B":
-                addline("\tforeign\n")
-            addline("}\n\n")
+                addline('\tlisten %s\n' % i)
+            if node != 'B':
+                addline('\tforeign\n')
+            addline('}\n\n')
         else:
             # One portal group for non-HA and CARP HA cases.
-            addline("portal-group pg%d {\n" % pg.iscsi_target_portal_tag)
-            addline("\ttag 0x%04x\n" % pg.iscsi_target_portal_tag)
-            addline("\tdiscovery-filter portal-name\n")
-            addline("\tdiscovery-auth-group %s\n" % agname)
+            addline('portal-group pg%d {\n' % pg.iscsi_target_portal_tag)
+            addline('\ttag 0x%04x\n' % pg.iscsi_target_portal_tag)
+            addline('\tdiscovery-filter portal-name\n')
+            addline('\tdiscovery-auth-group %s\n' % agname)
             for i in listen:
-                addline("\tlisten %s\n" % i)
-            addline("\toption ha_shared on\n")
-            addline("}\n\n")
+                addline('\tlisten %s\n' % i)
+            addline('\toption ha_shared on\n')
+            addline('}\n\n')
 
     # Cache zpool threshold
     poolthreshold = {}
@@ -247,11 +247,11 @@ def main():
                 continue
             disk = Struct(disk[0])
             if disk.disk_multipath_name:
-                path = "/dev/multipath/%s" % disk.disk_multipath_name
+                path = '/dev/multipath/%s' % disk.disk_multipath_name
             else:
-                path = "/dev/%s" % client.call('disk.identifier_to_device', disk.disk_identifier)
+                path = '/dev/%s' % client.call('disk.identifier_to_device', disk.disk_identifier)
         else:
-            if not path.startswith("/mnt"):
+            if not path.startswith('/mnt'):
                 poolname = path.split('/', 2)[1]
                 if gconf.iscsi_pool_avail_threshold:
                     if poolname in zpoollist:
@@ -266,7 +266,7 @@ def main():
                     if zfslist:
                         lunthreshold = int(zfslist[zvolname]['volsize'] *
                                            (extent.iscsi_target_extent_avail_threshold / 100.0))
-                path = "/dev/" + path
+                path = '/dev/' + path
             else:
                 if extent.iscsi_target_extent_avail_threshold and os.path.exists(path):
                     try:
@@ -275,23 +275,23 @@ def main():
                                            (extent.iscsi_target_extent_avail_threshold / 100.0))
                     except OSError:
                         pass
-        addline("lun \"%s\" {\n" % extent.iscsi_target_extent_name)
-        addline("\tctl-lun %d\n" % (extent.id - 1))
+        addline('lun "%s" {\n' % extent.iscsi_target_extent_name)
+        addline('\tctl-lun %d\n' % (extent.id - 1))
         size = extent.iscsi_target_extent_filesize
-        addline("\tpath \"%s\"\n" % path)
-        addline("\tblocksize %s\n" % extent.iscsi_target_extent_blocksize)
+        addline('\tpath "%s"\n' % path)
+        addline('\tblocksize %s\n' % extent.iscsi_target_extent_blocksize)
         if extent.iscsi_target_extent_pblocksize:
-            addline("\toption pblocksize 0\n")
-        addline("\tserial \"%s\"\n" % (extent.iscsi_target_extent_serial, ))
+            addline('\toption pblocksize 0\n')
+        addline('\tserial "%s"\n' % (extent.iscsi_target_extent_serial, ))
         padded_serial = extent.iscsi_target_extent_serial
         if not extent.iscsi_target_extent_xen:
             for i in range(31 - len(extent.iscsi_target_extent_serial)):
-                padded_serial += " "
+                padded_serial += ' '
         addline('\tdevice-id "iSCSI Disk      %s"\n' % padded_serial)
-        if size != "0":
+        if size != '0':
             if size.endswith('B'):
                 size = size.strip('B')
-            addline("\t\tsize %s\n" % size)
+            addline('\t\tsize %s\n' % size)
 
         # We can't change the vendor name of existing
         # LUNs without angering VMWare, but we can
@@ -313,16 +313,16 @@ def main():
                 addline('\toption avail-threshold %s\n' % lunthreshold)
         if poolname is not None and poolname in poolthreshold:
             addline('\toption pool-avail-threshold %s\n' % poolthreshold[poolname])
-        if extent.iscsi_target_extent_rpm == "Unknown":
+        if extent.iscsi_target_extent_rpm == 'Unknown':
             addline('\toption rpm 0\n')
-        elif extent.iscsi_target_extent_rpm == "SSD":
+        elif extent.iscsi_target_extent_rpm == 'SSD':
             addline('\toption rpm 1\n')
         else:
             addline('\toption rpm %s\n' % extent.iscsi_target_extent_rpm)
         if extent.iscsi_target_extent_ro:
             addline('\toption readonly on\n')
-        addline("}\n")
-        addline("\n")
+        addline('}\n')
+        addline('\n')
 
     # Generate the target section
     target_basename = gconf.iscsi_basename
@@ -345,30 +345,30 @@ def main():
                                  auth_type=grp.iscsi_target_authtype,
                                  initiator=grp.iscsi_target_initiatorgroup):
                 authgroups[grp.id] = agname
-        if (target.iscsi_target_name.startswith("iqn.") or
-                target.iscsi_target_name.startswith("eui.") or
-                target.iscsi_target_name.startswith("naa.")):
-            addline("target %s {\n" % target.iscsi_target_name)
+        if (target.iscsi_target_name.startswith('iqn.') or
+                target.iscsi_target_name.startswith('eui.') or
+                target.iscsi_target_name.startswith('naa.')):
+            addline('target %s {\n' % target.iscsi_target_name)
         else:
-            addline("target %s:%s {\n" % (target_basename, target.iscsi_target_name))
+            addline('target %s:%s {\n' % (target_basename, target.iscsi_target_name))
         if target.iscsi_target_alias:
-            addline("\talias \"%s\"\n" % target.iscsi_target_alias)
+            addline('\talias "%s"\n' % target.iscsi_target_alias)
         elif target.iscsi_target_name:
-            addline("\talias \"%s\"\n" % target.iscsi_target_name)
+            addline('\talias "%s"\n' % target.iscsi_target_name)
 
         for fctt in client.call('datastore.query', 'services.fibrechanneltotarget', [('fc_target', '=', target.id)]):
             fctt = Struct(fctt)
-            addline("\tport %s\n" % fctt.fc_port)
+            addline('\tport %s\n' % fctt.fc_port)
 
         for grp in client.call('datastore.query', 'services.iscsitargetgroups', [('iscsi_target', '=', target.id)]):
             grp = Struct(grp)
             agname = authgroups.get(grp.id) or 'no-authentication'
             if gconf.iscsi_alua:
-                addline("\tportal-group pg%dA %s\n" % (grp.iscsi_target_portalgroup.iscsi_target_portal_tag, agname))
-                addline("\tportal-group pg%dB %s\n" % (grp.iscsi_target_portalgroup.iscsi_target_portal_tag, agname))
+                addline('\tportal-group pg%dA %s\n' % (grp.iscsi_target_portalgroup.iscsi_target_portal_tag, agname))
+                addline('\tportal-group pg%dB %s\n' % (grp.iscsi_target_portalgroup.iscsi_target_portal_tag, agname))
             else:
-                addline("\tportal-group pg%d %s\n" % (grp.iscsi_target_portalgroup.iscsi_target_portal_tag, agname))
-        addline("\n")
+                addline('\tportal-group pg%d %s\n' % (grp.iscsi_target_portalgroup.iscsi_target_portal_tag, agname))
+        addline('\n')
         used_lunids = [
             o['iscsi_lunid']
             for o in client.call('datastore.query', 'services.iscsitargettoextent', [('iscsi_target', '=', target.id), ('iscsi_lunid', '!=', None)])
@@ -380,26 +380,26 @@ def main():
             if t2e.iscsi_lunid is None:
                 while cur_lunid in used_lunids:
                     cur_lunid += 1
-                addline("\tlun %s \"%s\"\n" % (cur_lunid,
+                addline('\tlun %s "%s"\n' % (cur_lunid,
                                                t2e.iscsi_extent.iscsi_target_extent_name))
                 cur_lunid += 1
             else:
-                addline("\tlun %s \"%s\"\n" % (t2e.iscsi_lunid,
+                addline('\tlun %s "%s"\n' % (t2e.iscsi_lunid,
                                                t2e.iscsi_extent.iscsi_target_extent_name))
-        addline("}\n\n")
+        addline('}\n\n')
 
     os.umask(0o77)
     # Write out the CTL config file
-    fh = open(ctl_config, "w")
+    fh = open(ctl_config, 'w')
     for line in cf_contents:
         fh.write(line)
     fh.close()
 
     # Write out the CTL config file with redacted CHAP passwords
-    fh = open(ctl_config_shadow, "w")
+    fh = open(ctl_config_shadow, 'w')
     for line in cf_contents_shadow:
         fh.write(line)
     fh.close()
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/src/freenas/usr/local/libexec/nas/generate_ctl_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_ctl_conf.py
@@ -95,7 +95,7 @@ def auth_group_config(auth_tag=None, auth_list=None, auth_type=None, initiator=N
         return False
 
     # There are some real paremeters, so write the auth group.
-    addline('auth-group %s {\n' % auth_tag)
+    addline('auth-group "%s" {\n' % auth_tag)
     for name in inames:
         addline('\tinitiator-name "%s"\n' % name.lstrip())
     for name in inets:
@@ -106,20 +106,20 @@ def auth_group_config(auth_tag=None, auth_list=None, auth_type=None, initiator=N
     for auth in auth_list:
         if auth.iscsi_target_auth_peeruser and auth_type != 'CHAP':
             auth_type = 'Mutual'
-            addline('\tchap-mutual %s "%s" %s "%s"\n' % (
+            addline('\tchap-mutual "%s" "%s" "%s" "%s"\n' % (
                 auth.iscsi_target_auth_user,
                 auth.iscsi_target_auth_secret,
                 auth.iscsi_target_auth_peeruser,
                 auth.iscsi_target_auth_peersecret,
             ), plaintextonly=True)
-            addline('\tchap-mutual REDACTED REDACTED REDACTED REDACTED\n', shadowonly=True)
+            addline('\tchap-mutual "REDACTED" "REDACTED" "REDACTED" "REDACTED"\n', shadowonly=True)
         elif auth_type != 'Mutual':
             auth_type = 'CHAP'
-            addline('\tchap %s "%s"\n' % (
+            addline('\tchap "%s" "%s"\n' % (
                 auth.iscsi_target_auth_user,
                 auth.iscsi_target_auth_secret,
             ), plaintextonly=True)
-            addline('\tchap REDACTED REDACTED\n', shadowonly=True)
+            addline('\tchap "REDACTED" "REDACTED"\n', shadowonly=True)
     if not auth_list and (auth_type == 'None' or auth_type == 'auto'):
         addline('\tauth-type "none"\n')
     addline('}\n\n')
@@ -139,10 +139,10 @@ def main():
 
     if gconf.iscsi_isns_servers:
         for server in gconf.iscsi_isns_servers.split(' '):
-            addline('isns-server %s\n\n' % server)
+            addline('isns-server "%s"\n\n' % server)
 
     # Generate the portal-group section
-    addline('portal-group default {\n}\n\n')
+    addline('portal-group "default" {\n}\n\n')
     for pg in client.call('datastore.query', 'services.iSCSITargetPortal'):
         pg = Struct(pg)
         # Prepare auth group for the portal group
@@ -198,33 +198,33 @@ def main():
 
         if gconf.iscsi_alua:
             # Two portal groups for ALUA HA case.
-            addline('portal-group pg%dA {\n' % pg.iscsi_target_portal_tag)
-            addline('\ttag 0x%04x\n' % pg.iscsi_target_portal_tag)
-            addline('\tdiscovery-filter portal-name\n')
-            addline('\tdiscovery-auth-group %s\n' % agname)
+            addline('portal-group "pg%dA" {\n' % pg.iscsi_target_portal_tag)
+            addline('\ttag "0x%04x"\n' % pg.iscsi_target_portal_tag)
+            addline('\tdiscovery-filter "portal-name"\n')
+            addline('\tdiscovery-auth-group "%s"\n' % agname)
             for i in listenA:
-                addline('\tlisten %s\n' % i)
+                addline('\tlisten "%s"\n' % i)
             if node != 'A':
                 addline('\tforeign\n')
             addline('}\n')
-            addline('portal-group pg%dB {\n' % pg.iscsi_target_portal_tag)
-            addline('\ttag 0x%04x\n' % (pg.iscsi_target_portal_tag + 0x8000))
-            addline('\tdiscovery-filter portal-name\n')
-            addline('\tdiscovery-auth-group %s\n' % agname)
+            addline('portal-group "pg%dB" {\n' % pg.iscsi_target_portal_tag)
+            addline('\ttag "0x%04x"\n' % (pg.iscsi_target_portal_tag + 0x8000))
+            addline('\tdiscovery-filter "portal-name"\n')
+            addline('\tdiscovery-auth-group "%s"\n' % agname)
             for i in listenB:
-                addline('\tlisten %s\n' % i)
+                addline('\tlisten "%s"\n' % i)
             if node != 'B':
                 addline('\tforeign\n')
             addline('}\n\n')
         else:
             # One portal group for non-HA and CARP HA cases.
-            addline('portal-group pg%d {\n' % pg.iscsi_target_portal_tag)
-            addline('\ttag 0x%04x\n' % pg.iscsi_target_portal_tag)
-            addline('\tdiscovery-filter portal-name\n')
-            addline('\tdiscovery-auth-group %s\n' % agname)
+            addline('portal-group "pg%d" {\n' % pg.iscsi_target_portal_tag)
+            addline('\ttag "0x%04x"\n' % pg.iscsi_target_portal_tag)
+            addline('\tdiscovery-filter "portal-name"\n')
+            addline('\tdiscovery-auth-group "%s"\n' % agname)
             for i in listen:
-                addline('\tlisten %s\n' % i)
-            addline('\toption ha_shared on\n')
+                addline('\tlisten "%s"\n' % i)
+            addline('\toption "ha_shared" "on"\n')
             addline('}\n\n')
 
     # Cache zpool threshold
@@ -276,12 +276,12 @@ def main():
                     except OSError:
                         pass
         addline('lun "%s" {\n' % extent.iscsi_target_extent_name)
-        addline('\tctl-lun %d\n' % (extent.id - 1))
+        addline('\tctl-lun "%d"\n' % (extent.id - 1))
         size = extent.iscsi_target_extent_filesize
         addline('\tpath "%s"\n' % path)
-        addline('\tblocksize %s\n' % extent.iscsi_target_extent_blocksize)
+        addline('\tblocksize "%s"\n' % extent.iscsi_target_extent_blocksize)
         if extent.iscsi_target_extent_pblocksize:
-            addline('\toption pblocksize 0\n')
+            addline('\toption "pblocksize" "0"\n')
         addline('\tserial "%s"\n' % (extent.iscsi_target_extent_serial, ))
         padded_serial = extent.iscsi_target_extent_serial
         if not extent.iscsi_target_extent_xen:
@@ -291,36 +291,36 @@ def main():
         if size != '0':
             if size.endswith('B'):
                 size = size.strip('B')
-            addline('\t\tsize %s\n' % size)
+            addline('\t\tsize "%s"\n' % size)
 
         # We can't change the vendor name of existing
         # LUNs without angering VMWare, but we can
         # use the right names going forward.
         if extent.iscsi_target_extent_legacy is True:
-            addline('\toption vendor "FreeBSD"\n')
+            addline('\toption "vendor" "FreeBSD"\n')
         else:
             if client.call('notifier.is_freenas'):
-                addline('\toption vendor "FreeNAS"\n')
+                addline('\toption "vendor" "FreeNAS"\n')
             else:
-                addline('\toption vendor "TrueNAS"\n')
+                addline('\toption "vendor" "TrueNAS"\n')
 
-        addline('\toption product "iSCSI Disk"\n')
-        addline('\toption revision "0123"\n')
-        addline('\toption naa %s\n' % extent.iscsi_target_extent_naa)
+        addline('\toption "product" "iSCSI Disk"\n')
+        addline('\toption "revision" "0123"\n')
+        addline('\toption "naa" "%s"\n' % extent.iscsi_target_extent_naa)
         if extent.iscsi_target_extent_insecure_tpc:
-            addline('\toption insecure_tpc on\n')
+            addline('\toption "insecure_tpc" "on"\n')
             if lunthreshold:
-                addline('\toption avail-threshold %s\n' % lunthreshold)
+                addline('\toption "avail-threshold" "%s"\n' % lunthreshold)
         if poolname is not None and poolname in poolthreshold:
-            addline('\toption pool-avail-threshold %s\n' % poolthreshold[poolname])
+            addline('\toption "pool-avail-threshold" "%s"\n' % poolthreshold[poolname])
         if extent.iscsi_target_extent_rpm == 'Unknown':
-            addline('\toption rpm 0\n')
+            addline('\toption "rpm" "0"\n')
         elif extent.iscsi_target_extent_rpm == 'SSD':
-            addline('\toption rpm 1\n')
+            addline('\toption "rpm" "1"\n')
         else:
-            addline('\toption rpm %s\n' % extent.iscsi_target_extent_rpm)
+            addline('\toption "rpm" "%s"\n' % extent.iscsi_target_extent_rpm)
         if extent.iscsi_target_extent_ro:
-            addline('\toption readonly on\n')
+            addline('\toption "readonly" "on"\n')
         addline('}\n')
         addline('\n')
 
@@ -348,9 +348,9 @@ def main():
         if (target.iscsi_target_name.startswith('iqn.') or
                 target.iscsi_target_name.startswith('eui.') or
                 target.iscsi_target_name.startswith('naa.')):
-            addline('target %s {\n' % target.iscsi_target_name)
+            addline('target "%s" {\n' % target.iscsi_target_name)
         else:
-            addline('target %s:%s {\n' % (target_basename, target.iscsi_target_name))
+            addline('target "%s:%s" {\n' % (target_basename, target.iscsi_target_name))
         if target.iscsi_target_alias:
             addline('\talias "%s"\n' % target.iscsi_target_alias)
         elif target.iscsi_target_name:
@@ -358,16 +358,16 @@ def main():
 
         for fctt in client.call('datastore.query', 'services.fibrechanneltotarget', [('fc_target', '=', target.id)]):
             fctt = Struct(fctt)
-            addline('\tport %s\n' % fctt.fc_port)
+            addline('\tport "%s"\n' % fctt.fc_port)
 
         for grp in client.call('datastore.query', 'services.iscsitargetgroups', [('iscsi_target', '=', target.id)]):
             grp = Struct(grp)
             agname = authgroups.get(grp.id) or 'no-authentication'
             if gconf.iscsi_alua:
-                addline('\tportal-group pg%dA %s\n' % (grp.iscsi_target_portalgroup.iscsi_target_portal_tag, agname))
-                addline('\tportal-group pg%dB %s\n' % (grp.iscsi_target_portalgroup.iscsi_target_portal_tag, agname))
+                addline('\tportal-group "pg%dA" "%s"\n' % (grp.iscsi_target_portalgroup.iscsi_target_portal_tag, agname))
+                addline('\tportal-group "pg%dB" "%s"\n' % (grp.iscsi_target_portalgroup.iscsi_target_portal_tag, agname))
             else:
-                addline('\tportal-group pg%d %s\n' % (grp.iscsi_target_portalgroup.iscsi_target_portal_tag, agname))
+                addline('\tportal-group "pg%d" "%s"\n' % (grp.iscsi_target_portalgroup.iscsi_target_portal_tag, agname))
         addline('\n')
         used_lunids = [
             o['iscsi_lunid']
@@ -380,11 +380,11 @@ def main():
             if t2e.iscsi_lunid is None:
                 while cur_lunid in used_lunids:
                     cur_lunid += 1
-                addline('\tlun %s "%s"\n' % (cur_lunid,
+                addline('\tlun "%s" "%s"\n' % (cur_lunid,
                                                t2e.iscsi_extent.iscsi_target_extent_name))
                 cur_lunid += 1
             else:
-                addline('\tlun %s "%s"\n' % (t2e.iscsi_lunid,
+                addline('\tlun "%s" "%s"\n' % (t2e.iscsi_lunid,
                                                t2e.iscsi_extent.iscsi_target_extent_name))
         addline('}\n\n')
 


### PR DESCRIPTION
Two parts:
1. Use single quotes for all the python strings.
   - This eliminated a lot of escaped internal quotes and made the next change a lot easier.
2. Enclose all generated string values in double quotes.
   - The lex and yacc specifications for ctld tokenize all values as optionally-quoted strings. Quoting all strings eliminates any possibility of the value being mistaken for a different token's lexeme.

Before the change:
```
portal-group default {
}

auth-group ag4pg1 {
        chap chap "abcdefg1234567"
}

portal-group pg1 {
        tag 0x0001
        discovery-filter portal-name
        discovery-auth-group ag4pg1
        listen 0.0.0.0:3260
        option ha_shared on
}

auth-group ag4tg1_1 {
        chap chap "abcdefg1234567"
}

target iqn.2005-10.org.freenas.ctl:target0 {
        alias "target0"
        portal-group pg1 ag4tg1_1

}

```

After the change:
```
portal-group "default" {
}

auth-group "ag4pg1" {
        chap "chap" "abcdefg1234567"
}

portal-group "pg1" {
        tag "0x0001"
        discovery-filter "portal-name"
        discovery-auth-group "ag4pg1"
        listen "0.0.0.0:3260"
        option "ha_shared" "on"
}

auth-group "ag4tg1_1" {
        chap "chap" "abcdefg1234567"
}

target "iqn.2005-10.org.freenas.ctl:target0" {
        alias "target0"
        portal-group "pg1" "ag4tg1_1"

}

```