### PR TITLE
Bug fix for ntp.conf

### DIFF
--- a/src/middlewared/middlewared/etc_files/ntp.conf
+++ b/src/middlewared/middlewared/etc_files/ntp.conf
@@ -20,8 +20,10 @@ server ${ntp['address']}\
 	% endif
 
 % endfor
+% if ntp_query:
 restrict default limited kod nomodify notrap nopeer noquery
 restrict -6 default limited kod nomodify notrap nopeer noquery
 restrict 127.0.0.1
 restrict -6 ::1
 restrict 127.127.1.0
+% endif


### PR DESCRIPTION
This commit fixes a bug where we wrote restrict* lines even if no ntp servers were present.