### PR TITLE
tkt-70264: Fix linebreak for motd

### DIFF
--- a/src/middlewared/middlewared/etc_files/motd
+++ b/src/middlewared/middlewared/etc_files/motd
@@ -1,3 +1,6 @@
+<%
+	motd = middleware.call_sync('system.advanced.config')['motd']
+%>\
 FreeBSD ?.?.?  (UNKNOWN)
 
 	FreeNAS (c) 2009-2019, The FreeNAS Development Team
@@ -6,4 +9,6 @@ FreeBSD ?.?.?  (UNKNOWN)
 
 	For more information, documentation, help or support, go here:
 	http://freenas.org
-${middleware.call_sync('system.advanced.config')['motd']}
+% if motd:
+${motd}
+% endif


### PR DESCRIPTION
This commit makes sure that we don't add a linebreak in motd if the value of motd is empty.