### PR TITLE
tkt-75910: Fix ordering for vfs_crossrename (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4_share.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4_share.conf
@@ -26,7 +26,7 @@
             return db
 
         def order_vfs_objects(vfs_objects):
-            vfs_objects_special = ('catia', 'zfs_space', 'zfsacl', 'fruit', 'streams_xattr', 'recycle')
+            vfs_objects_special = ('catia', 'zfs_space', 'zfsacl', 'fruit', 'streams_xattr', 'crossrename', 'recycle')
             vfs_objects_ordered = []
 
             if 'fruit' in vfs_objects:
@@ -102,6 +102,10 @@
                 if db['fruit_enabled']:
                     if "fruit" not in share['vfsobjects']:
                         share['vfsobjects'].append('fruit')
+
+                if share['recyclebin']:
+                    # crossrename is required for 'recycle' to work across sub-datasets
+                    share['vfsobjects'].extend(['recycle','crossrename'])
 
                 ordered_vfs_objects = order_vfs_objects(share['vfsobjects'])
                 pc[share["name"]].update({"vfs objects": ordered_vfs_objects})


### PR DESCRIPTION
Fix ordering of VFS objects for crossrename. Also enable cross rename automatically if "export recycle bin" has been selected. This is to address issues where files deleted in sub-datasets don't appear in the recycle bin.
