### PR TITLE
tkt-75927: Bring in "unified" SMB HA mode. (by anodos325)

### DIFF
--- a/gui/directoryservice/forms.py
+++ b/gui/directoryservice/forms.py
@@ -452,9 +452,12 @@ class ActiveDirectoryForm(ModelForm):
         if not netbiosname:
             return netbiosname
         if netbiosname_a and netbiosname_a == netbiosname:
-            raise forms.ValidationError(_(
-                'NetBIOS cannot be the same as the first.'
-            ))
+            with client as c:
+                system_dataset = c.call('systemdataset.config')
+            if system_dataset['path'] == "freenas-boot":
+                raise forms.ValidationError(_(
+                    'NetBIOS names cannot be identical when the system dataset is located on the boot device.'
+                ))
         try:
             validate_netbios_name(netbiosname)
         except Exception as e:

--- a/gui/directoryservice/forms.py
+++ b/gui/directoryservice/forms.py
@@ -456,7 +456,7 @@ class ActiveDirectoryForm(ModelForm):
                 system_dataset = c.call('systemdataset.config')
             if system_dataset['path'] == "freenas-boot":
                 raise forms.ValidationError(_(
-                    'NetBIOS names cannot be identical when the system dataset is located on the boot device.'
+                    'When the system dataset is located on the boot device, the same NetBIOS name cannot be used on both controllers.'
                 ))
         try:
             validate_netbios_name(netbiosname)

--- a/src/middlewared/middlewared/etc_files/local/smb4.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf
@@ -29,13 +29,15 @@
             conf['shares'] = middleware.call_sync('sharing.smb.query')
             conf['role'] = 'standalone'
             conf['guest_enabled'] = False
+            conf['system_dataset'] = middleware.call_sync('systemdataset.config')
             conf['loglevel'] = LOGLEVEL_UNMAP.get(conf['cifs']['loglevel'])
 
-            conf['truenas_conf'] = {'is_truenas_ha': False, 'failover_status': 'DEFAULT', 'smb_ha_mode': None}
+            conf['truenas_conf'] = {'is_truenas_ha': False, 'failover_status': 'DEFAULT', 'smb_ha_mode': 'LEGACY'}
             if not middleware.call_sync('system.is_freenas') and middleware.call_sync('failover.licensed'):
                 conf['truenas_conf']['is_truenas_ha'] = True
                 conf['truenas_conf']['failover_status'] = middleware.call_sync('failover.status')
-
+                if conf['system_dataset']['pool'] is not 'freenas-boot':
+                     truenas_params['smb_ha_mode'] = 'UNIFIED'
             if conf['ad']['ad_enable']:
                 conf['role'] = 'ad_member'
             elif conf['ldap']['ldap_enable'] and conf['ldap']['ldap_has_samba_schema']:
@@ -119,9 +121,23 @@
             return pc 
 
         def add_licensebased_params(pc, db):
-            if not db['truenas_conf']['smb_ha_mode']:
-                pc.update({'netbios name': db['cifs']['netbiosname']})
-                pc.update({'netbios aliases': db['cifs']['netbiosalias']})
+            if db['truenas_conf']['smb_ha_mode'] == 'UNIFIED':
+                pc.update({
+                    'netbios name': db['gc']['hostname_virtual'],
+                    'netbios aliases': db['cifs']['netbiosalias']
+                })
+            elif db['truenas_conf']['is_truenas_ha']:
+                pc.update({
+                    'netbios name': db['cifs']['netbiosname'],
+                    'netbios aliases': db['cifs']['netbiosalias'],
+                    'private dir': '/root/samba/private',
+                    'winbind netbios alias spn': 'true'
+                })
+            else:
+                pc.update({
+                    'netbios name': db['cifs']['netbiosname'],
+                    'netbios aliases': db['cifs']['netbiosalias'],
+                })
 
             return pc
 
@@ -289,6 +305,12 @@
 %>
 
 [global]
+%if db['truenas_conf']['smb_ha_mode'] == 'UNIFIED' and db['truenas_config']['failover_status'] != 'MASTER':
+        [global]
+        netbios name = {db['gc']['hostname_virtual']}_PASSIVE
+        multicast dns register = False
+        logging = file
+%else:
     % for param, value in parsed_conf.items():
       % if type(value) == list:
         ${param} = ${' '.join(value)}
@@ -296,6 +318,7 @@
         ${param} = ${value}
       % endif
     % endfor
+%endif
 
         include = /usr/local/etc/smb4_share.conf
 


### PR DESCRIPTION
If system dataset is not on boot device, then set netbios name to virtual hostname.
This will allow us to correctly generate a single shared Computer Object for
AD, fix kerberos auth for HA, and has the benefit of allowing us to move samba's
TDB files entirely off the boot device.

"Unified"
- samba's private directory located on /var/db/samba4 (on data pool)
- single computer object in AD.
- "netbios alias to spn = no" is not set, and so netbios aliases will get kerberos SPN entries.
- passive controller gets a minimal stub smb4.conf file

"Legacy"
- samba's private directory located in /root/samba/private
- separate computer objects for storage controllers
- netbios aliases do not have SPN entries
- both controllers have samba fully configured and running.