### PR TITLE
tkt-76018: Increase timeout for inittasks

### DIFF
--- a/docs/api/resources/tasks.rst
+++ b/docs/api/resources/tasks.rst
@@ -261,7 +261,8 @@ List resource
                 "id": 1
                 "ini_type": "command",
                 "ini_command": "rm /mnt/tank/temp*",
-                "ini_when": "postinit"
+                "ini_when": "postinit",
+                "ini_timeout": 10
         }
       ]
 
@@ -288,7 +289,8 @@ Create resource
         {
                 "ini_type": "command",
                 "ini_command": "rm /mnt/tank/temp*",
-                "ini_when": "postinit"
+                "ini_when": "postinit",
+                "ini_timeout": 10
         }
 
    **Example response**:
@@ -304,13 +306,15 @@ Create resource
                 "ini_command": "rm /mnt/tank/temp*",
                 "ini_script": null,
                 "ini_type": "command",
-                "ini_when": "postinit"
+                "ini_when": "postinit",
+                "ini_timeout": 10
         }
 
    :json string ini_command: command to execute
    :json string ini_script: path to script to execute
    :json string ini_type: run a command ("command") or a script ("script")
    :json string ini_when: preinit, postinit, shutdown
+   :json integer ini_timeout: number of seconds to wait for script or command execution before triggering a timeout
    :reqheader Content-Type: the request content type
    :resheader Content-Type: the response content type
    :statuscode 201: no error
@@ -347,13 +351,15 @@ Update resource
                 "ini_command": "rm /mnt/tank/temp*",
                 "ini_script": null,
                 "ini_type": "command",
-                "ini_when": "preinit"
+                "ini_when": "preinit",
+                "ini_timeout": 10
         }
 
    :json string ini_command: command to execute
    :json string ini_script: path to script to execute
    :json string ini_type: run a command ("command") or a script ("script")
    :json string ini_when: preinit, postinit, shutdown
+   :json integer ini_timeout: number of seconds to wait for script or command execution before triggering a timeout
    :reqheader Content-Type: the request content type
    :resheader Content-Type: the response content type
    :statuscode 200: no error

--- a/gui/tasks/migrations/0013_init_tasks_timeout.py
+++ b/gui/tasks/migrations/0013_init_tasks_timeout.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tasks', '0012_merge_20190108_1040'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='initshutdown',
+            name='ini_timeout',
+            field=models.IntegerField(
+                default=10,
+                verbose_name='Timeout',
+                help_text='Automatically stop the script or command after the specified seconds.'
+            ),
+        ),
+    ]

--- a/gui/tasks/models.py
+++ b/gui/tasks/models.py
@@ -327,6 +327,11 @@ class InitShutdown(Model):
         default=True,
         verbose_name=_("Enabled"),
     )
+    ini_timeout = models.IntegerField(
+        default=10,
+        verbose_name='Timeout',
+        help_text='Automatically stop the script or command after the specified seconds.'
+    )
 
     def __str__(self):
         if self.ini_type == 'command':

--- a/src/freenas/etc/ix.rc.d/ix-preinit
+++ b/src/freenas/etc/ix.rc.d/ix-preinit
@@ -11,7 +11,7 @@
 
 do_preinit()
 {
-	/usr/local/bin/midclt call initshutdownscript.execute_init_tasks PREINIT > /dev/null
+	/usr/local/bin/midclt call -job initshutdownscript.execute_init_tasks PREINIT > /dev/null 2>&1
 }
 
 name="ix-preinit"

--- a/src/freenas/etc/ix.rc.d/ix-shutdown
+++ b/src/freenas/etc/ix.rc.d/ix-shutdown
@@ -11,7 +11,7 @@
 
 do_shutdown()
 {
-	/usr/local/bin/midclt call initshutdownscript.execute_init_tasks SHUTDOWN > /dev/null
+	/usr/local/bin/midclt call -job initshutdownscript.execute_init_tasks SHUTDOWN > /dev/null 2>&1
 }
 
 name="ix-shutdown"

--- a/src/freenas/etc/rc.conf
+++ b/src/freenas/etc/rc.conf
@@ -84,3 +84,6 @@ inadyn_flags="--continue-on-error"
 
 # Apply CPU microcode updates, if any
 microcode_update_enable="YES"
+
+# Disabling watchdog timer. We will enforce a hard timeout dynamically
+rcshutdown_timeout=""

--- a/src/freenas/etc/rc.d/ix-postinit
+++ b/src/freenas/etc/rc.d/ix-postinit
@@ -11,7 +11,7 @@
 do_postinit()
 {
 	/usr/local/bin/midclt call core.notify_postinit > /dev/null
-	/usr/local/bin/midclt call initshutdownscript.execute_init_tasks POSTINIT > /dev/null
+	/usr/local/bin/midclt call -job initshutdownscript.execute_init_tasks POSTINIT > /dev/null 2>&1
 }
 
 name="ix-postinit"

--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -876,10 +876,10 @@ class ServiceService(CRUDService):
         await self._service("inadyn", "restart", **kwargs)
 
     async def _restart_system(self, **kwargs):
-        asyncio.ensure_future(self._system("/bin/sleep 3 && /sbin/shutdown -r now"))
+        asyncio.ensure_future(self.middleware.call('system.reboot', {'delay': 3}))
 
     async def _stop_system(self, **kwargs):
-        asyncio.ensure_future(self._system("/bin/sleep 3 && /sbin/shutdown -p now"))
+        asyncio.ensure_future(self.middleware.call('system.shutdown', {'delay': 3}))
 
     async def _reload_cifs(self, **kwargs):
         await self.middleware.call("etc.generate", "smb_share")

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -369,7 +369,7 @@ class SystemService(Service):
         if delay:
             await asyncio.sleep(delay)
 
-        await Popen(["/sbin/reboot"])
+        await Popen(['/sbin/shutdown', '-r', 'now'])
 
     @accepts(Dict('system-shutdown', Int('delay', required=False), required=False))
     @job()
@@ -390,7 +390,7 @@ class SystemService(Service):
         if delay:
             await asyncio.sleep(delay)
 
-        await Popen(["/sbin/poweroff"])
+        await Popen(['/sbin/poweroff'])
 
     @accepts()
     @job(lock='systemdebug')


### PR DESCRIPTION
This PR introduces the following changes:
1) Introduce timeout field which will control timeout for each init task
2) Make sure timeout field is respected by middlewared when executing init tasks
3) Update init ix* scripts to wait for the execution of init tasks. It is ensured by middlewared that this doesn't take forever by ensuring a timeout as specified by the user.
4) For shutdown, value of kern.init_shutdown_timeout is dynamically set by middlewared on reboot/shutdown events so that init does not enforce a hard time out of 120 seconds.
5) Watchdog timer is disabled and instead we use kern.init_shutdown_timeout to enforce a hard timeout on shutdown
6) Normalize reboot/shutdown