### PR TITLE
tkt-75883: Fix "valid users" parameter for [homes] in Samba 4.9

### DIFF
--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -1173,7 +1173,7 @@ def generate_smb4_shares(client, smb4_shares, shares):
 
             if client.call('notifier.common', 'system', 'activedirectory_enabled'):
                 valid_users_path = "%D/%U"
-                valid_users = "%D\%U"
+                valid_users = "%U"
 
                 try:
                     ad = Struct(client.call('notifier.directoryservice', 'AD'))


### PR DESCRIPTION
The "valid users=%U" parameters below seem odd.  ACL should be inherited
from parent directory, and the homedir path will be automatically created
as the authenticated user. So user should automatically have permissions.
Goes back to e4f2a5d115f146e4befeb701679cc1ea3771d644 where the initial 
value was "valid users = %S". Through the creation of various bug tickets, it 
evolved into the current version, which is effectively a no-op.
No indication of why this was set. It is possibly related to comments in the 
debian smb.conf manpage from that time period:
```
# By default, \\server\username shares can be connected to by anyone
# with access to the samba server. Un-comment the following parameter
# to make sure that only “username” can connect to \\server\username
valid users = %S"
```
This does not apply to our configuration. For now leave this in place until have time to 
thoroughly confirm that there are no edge-cases in which removal will break 
access to home shares.