### PR TITLE
tkt-76045: Fix "valid users" parameter for [homes] in Samba 4.9 (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4_share.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4_share.conf
@@ -3,6 +3,7 @@
 # $FreeBSD$
 #
 <%
+        import os
         import logging
         logger = logging.getLogger(__name__)
 
@@ -25,6 +26,16 @@
 
             return db
 
+        def make_homedir(homedir_path=None):
+            ret = True
+            if not os.access(homedir_path, os.F_OK):
+                try:
+                    os.mkdir(homedir_path) 
+                except Exception as e:
+                    logger.debug(f"Failed to create home directory {homedir_path}: ({e})") 
+                    ret = False
+            return ret
+
         def order_vfs_objects(vfs_objects):
             vfs_objects_special = ('catia', 'zfs_space', 'zfsacl', 'fruit', 'streams_xattr', 'recycle')
             vfs_objects_ordered = []
@@ -46,8 +57,34 @@
         def parse_db_config(db):
             pc = {}
             for share in db['shares']:
+                """
+                    Special behavior is needed for [homes]:
+                    We append %U (authenticated username) to the share path
+                    for non-AD environments, and %D/%U for AD environments.
+                    This prevents users from being able to access the each 
+                    others home directories. %D is required for AD to prevent
+                    collisions between AD users and local users or users in
+                    trusted domains. 
+                """
+                is_home_share = False
+                is_ad_environment = False
+                if share["home"]:
+                    is_home_share = True
+                    share["name"] = "homes" 
+                    ad =  middleware.call_sync('datastore.config', 'directoryservice.activedirectory') 
+                    if ad['ad_enable']:
+                        is_ad_environment = True
+
                 pc[share["name"]] = {}
-                pc[share["name"]].update({"path": share["path"]})
+                if is_home_share and is_ad_environment:
+                    pc[share["name"]].update({"path": f'{share["path"]}/%D/%U'})
+                    base_homedir = f"{share['path']}/{db['cifs']['workgroup']}"
+                    make_homedir(base_homedir) 
+
+                elif is_home_share:
+                    pc[share["name"]].update({"path": f'{share["path"]}/%U'})
+                else:
+                    pc[share["name"]].update({"path": share["path"]})
 
                 if share['comment']:
                     pc[share["name"]].update({"comment": share['comment']})


### PR DESCRIPTION
FreeNAS original had "valid users = %D\%U" or "valid users = %U" for 
[homes] shares. In 11.3 we remove these parameters. ACL should be inherited
from parent directory, and the homedir path will be automatically created
as the authenticated user. So user should automatically have permissions.
Goes back to e4f2a5d115f146e4befeb701679cc1ea3771d644 where the initial 
value was "valid users = %S". Through the creation of various bug tickets, it 
evolved into the current version, which is effectively a no-op.
No indication of why this was set. It is possibly related to comments in the 
debian smb.conf manpage from that time period:
```
# By default, \\server\username shares can be connected to by anyone
# with access to the samba server. Un-comment the following parameter
# to make sure that only “username” can connect to \\server\username
valid users = %S"
```
This does not apply to our configuration. 