### PR TITLE
tkt-76126: change arp -a to arp -an in freenas-debug

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/network/network.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/network/network.sh
@@ -96,8 +96,8 @@ network_func()
 	netstat -nrW
 	section_footer
 
-	section_header "ARP entries (arp -a)"
-	arp -a
+	section_header "ARP entries (arp -an)"
+	arp -an
 	section_footer
 
 	section_header "mbuf statistics (netstat -m)"


### PR DESCRIPTION
This is a cherry-pick from commit: f78f20015d42e84e3b207a3f3b7ebd867379055f because bugclerk didn't backport to the 11.2 branch correctly.

Redmine: https://redmine.ixsystems.com/issues/76126