### PR TITLE
tkt-36953: feat(system/debug): Report progress via the job

### DIFF
--- a/src/freenas/usr/local/bin/freenas-debug
+++ b/src/freenas/usr/local/bin/freenas-debug
@@ -230,6 +230,8 @@ main()
 	opts_spaced="${VAL_SPACED}"
 
 	aopts="${opts}${email_opt}:"
+	lenopts="$(echo $* | tr -d -C '-' | wc -c)"
+
 	while getopts "AZ${aopts}" opt ; do
 		case "${opt}" in
 			$email_opt)
@@ -274,12 +276,19 @@ main()
 
 	trap "exit 2"
 	if $all_debug; then
+		lenopts=${#opts}
+		local percent_increment=$((100/$lenopts))
+		local percent=0
+
 		for opt in ${opts_spaced} ; do
 			# This function must be explicitly called from the CLI
-			if [ "${opt}" = "B" ] 
+			if [ "${opt}" = "B" ]
 			then
 				continue
 			fi
+			local percent=$(($percent+$percent_increment))
+			local desc=$(eval "echo "\$$(echo "module_help_${opt}"))
+			echo "** $percent%: $(eval $desc)"
 
 			var=\$$(echo "module_func_${opt}")
 			func=$(eval "echo ${var}")
@@ -300,6 +309,8 @@ main()
 			fi
 		done
 	else
+		local percent_increment=$((100/$lenopts))
+		local percent=0
 		while getopts "${aopts}" opt
 		do
 			if [ "${opt}" != "${email_opt}" ]; then
@@ -308,6 +319,9 @@ main()
 
 				var=\$$(echo "module_directory_${opt}")
 				dirfunc=$(eval "echo ${var}")
+				local percent=$(($percent+$percent_increment))
+				local desc=$(eval "echo "\$$(echo "module_help_${opt}"))
+				echo "** $percent%: $(eval $desc)"
 
 				#
 				# Create individual directories for each module and write

--- a/src/freenas/usr/local/bin/ixdiagnose
+++ b/src/freenas/usr/local/bin/ixdiagnose
@@ -12,7 +12,7 @@ if [ ! -e "${tmpdir}" ]; then tmpdir="/var/tmp"; fi
 
 mydir=`dirname $0`
 
-# get the textdump file. On some systems this is a gzipped 
+# get the textdump file. On some systems this is a gzipped
 # tarball, so we we check for that here.
 get_textdump ()
 {
@@ -85,16 +85,19 @@ test -e /etc/rc.conf && . /etc/rc.conf
 
 has_ticket_info=false
 dont_delete=false
+print=false
 limit=10000
 textdump=$(get_textdump)
 
-while getopts "Fd:sl:" opt ; do
+while getopts "Fd:psl:" opt ; do
 	case "${opt}" in
 	d)	topdir=$OPTARG
 		;;
 	s)	dont_delete=true
 		;;
 	l)	limit=$OPTARG
+		;;
+	p)	print=true
 		;;
 	\?)	exit 2
 		;;
@@ -129,7 +132,12 @@ if [ $? -gt 0 ] ; then
 	exit 1
 fi
 
-$mydir/freenas-debug -A > /tmp/ixdiagnose.diagnose
+if ! $print ; then
+	$mydir/freenas-debug -A > /tmp/ixdiagnose.diagnose
+else
+	$mydir/freenas-debug -A
+fi
+
 tar -cHf - -C /var log | tar -C $dir -xf -
 tar -cHf - -C /var/tmp fndebug | tar -C $dir -xf -
 if [ "${limit}" != "-1" ] ; then


### PR DESCRIPTION
This PR introduces parsing the stdout of ixdiagnose to provide progress on the debug creation.

ixdiagnose changes
---
- Add -p flag to print to stdout instead of piping to the tmpfile

freenas-debug
----
- We now print ** PERCENT%: DESCRIPTION for each debug task requested

Ticket: #36953