### PR TITLE
tkt-76027: Update init/shutdown ix* scripts

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-preinit
+++ b/src/freenas/etc/ix.rc.d/ix-preinit
@@ -9,20 +9,17 @@
 
 . /etc/rc.subr
 
-do_preinit()
+execute_task()
 {
-	local IFS="|"
-	local f="ini_type ini_command ini_script ini_when"
+	local stype=$1
+	local f="ini_$stype"
 	eval local $f
 	local sf=$(var_to_sf $f)
 
-	RO_FREENAS_CONFIG=$(ro_sqlite ${name} 2> /tmp/${name}.fail && rm /tmp/${name}.fail)
-	trap 'rm -f ${RO_FREENAS_CONFIG}' EXIT
-
-	${FREENAS_SQLITE_CMD} ${RO_FREENAS_CONFIG} \
-	"SELECT $sf FROM tasks_initshutdown WHERE ini_when = 'preinit' AND ini_enabled = 1 ORDER BY id" | \
+	${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} \
+	"SELECT $sf FROM tasks_initshutdown WHERE ini_when = 'preinit' AND ini_enabled = 1 AND ini_type = '$stype' ORDER BY id" | \
 	while eval read -r $f; do
-		if [ "${ini_type}" = "command" ]; then
+		if [ "${stype}" = "command" ]; then
 			eval ${ini_command}
 		else
 			if [ -e "${ini_script}" ]; then
@@ -30,6 +27,15 @@ do_preinit()
 			fi
 		fi
 	done
+}
+
+do_preinit()
+{
+	RO_FREENAS_CONFIG=$(ro_sqlite ${name} 2> /tmp/${name}.fail && rm /tmp/${name}.fail)
+	trap 'rm -f ${RO_FREENAS_CONFIG}' EXIT
+
+	execute_task "command"
+	execute_task "script"
 }
 
 name="ix-preinit"

--- a/src/freenas/etc/ix.rc.d/ix-shutdown
+++ b/src/freenas/etc/ix.rc.d/ix-shutdown
@@ -9,20 +9,17 @@
 
 . /etc/rc.subr
 
-do_shutdown()
+execute_task()
 {
-	local IFS="|"
-	local f="ini_type ini_command ini_script ini_when"
+	local stype=$1
+	local f="ini_$stype"
 	eval local $f
 	local sf=$(var_to_sf $f)
 
-	RO_FREENAS_CONFIG=$(ro_sqlite ${name} 2> /tmp/${name}.fail && rm /tmp/${name}.fail)
-	trap 'rm -f ${RO_FREENAS_CONFIG}' EXIT
-
-	${FREENAS_SQLITE_CMD} ${RO_FREENAS_CONFIG} \
-	"SELECT $sf FROM tasks_initshutdown WHERE ini_when = 'shutdown' AND ini_enabled = 1 ORDER BY id" | \
+	${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} \
+	"SELECT $sf FROM tasks_initshutdown WHERE ini_when = 'shutdown' AND ini_enabled = 1 AND ini_type = '$stype' ORDER BY id" | \
 	while eval read -r $f; do
-		if [ "${ini_type}" = "command" ]; then
+		if [ "${stype}" = "command" ]; then
 			eval ${ini_command}
 		else
 			if [ -e "${ini_script}" ]; then
@@ -30,6 +27,15 @@ do_shutdown()
 			fi
 		fi
 	done
+}
+
+do_shutdown()
+{
+	RO_FREENAS_CONFIG=$(ro_sqlite ${name} 2> /tmp/${name}.fail && rm /tmp/${name}.fail)
+	trap 'rm -f ${RO_FREENAS_CONFIG}' EXIT
+
+	execute_task "command"
+	execute_task "script"
 }
 
 name="ix-shutdown"

--- a/src/freenas/etc/rc.d/ix-postinit
+++ b/src/freenas/etc/rc.d/ix-postinit
@@ -8,13 +8,28 @@
 
 . /etc/rc.subr
 
-do_postinit()
+execute_task()
 {
-	local IFS="|"
-	local f="ini_type ini_command ini_script ini_when"
+	local stype=$1
+	local f="ini_$stype"
 	eval local $f
 	local sf=$(var_to_sf $f)
 
+	${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} \
+	"SELECT $sf FROM tasks_initshutdown WHERE ini_when = 'postinit' AND ini_enabled = 1 AND ini_type = '$stype' ORDER BY id" | \
+	while eval read -r $f; do
+		if [ "${stype}" = "command" ]; then
+			eval ${ini_command}
+		else
+			if [ -e "${ini_script}" ]; then
+				sh -c "exec ${ini_script}"
+			fi
+		fi
+	done
+}
+
+do_postinit()
+{
 	# Sentinel file to tell we have gone far enough in the boot process.
 	# See #17508
 	touch /tmp/.bootready
@@ -23,17 +38,8 @@ do_postinit()
 	# to call it ready
 	/usr/local/bin/midclt call core.event_send system ADDED '{"id": "ready"}' > /dev/null
 
-	${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} \
-	"SELECT $sf FROM tasks_initshutdown WHERE ini_when = 'postinit' AND ini_enabled = 1 ORDER BY id" | \
-	while eval read -r $f; do
-		if [ "${ini_type}" = "command" ]; then
-			eval ${ini_command}
-		else
-			if [ -e "${ini_script}" ]; then
-				sh -c "exec ${ini_script}"
-			fi
-		fi
-	done
+	execute_task "command"
+	execute_task "script"
 }
 
 name="ix-postinit"


### PR DESCRIPTION
This PR introduces makes sure that we retrieve only when column from db at a time bypassing the delimiting issue we have when we would like to execute commands which might be making use of those delimiters for all init/shutdown ix* scripts.
