### PR TITLE
tkt-77341: Always use upsmon as primary indicator of UPS service status because … (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -793,12 +793,7 @@ class ServiceService(CRUDService):
         await self._service("nut_upslog", "restart", **kwargs)
 
     async def _started_ups(self, **kwargs):
-        mode = (await self.middleware.call('datastore.query', 'services.ups', [], {'order_by': ['-id'], 'get': True}))['ups_mode']
-        if mode == "master":
-            svc = "ups"
-        else:
-            svc = "upsmon"
-        return await self._started(svc)
+        return await self._started('upsmon')
 
     async def _start_afp(self, **kwargs):
         await self._service("ix-afpd", "start", **kwargs)


### PR DESCRIPTION
…upsd can crash if UPS is disconnected