### PR TITLE
tkt-77539: fix(jail/fetch): Workaround interactive plugin install on first init (by skarekrow)

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -453,14 +453,22 @@ class JailService(CRUDService):
         start_msg = f'{release} being fetched'
         final_msg = f'{release} fetched'
 
+        iocage = ioc.IOCage(callback=progress_callback, silent=False)
+
         if options["name"] is not None:
+            # WORKAROUND until rewritten for #39653
+            # We want the plugins to not prompt interactively
+            try:
+                iocage.fetch(plugin_file=True, _list=True, **options)
+            except Exception:
+                # Expected, this is to avoid it later
+                pass
+
             options["plugin_file"] = True
             start_msg = 'Starting plugin install'
             final_msg = f"Plugin: {options['name']} installed"
 
         options["accept"] = True
-
-        iocage = ioc.IOCage(callback=progress_callback, silent=False)
 
         job.set_progress(0, start_msg)
         iocage.fetch(**options)


### PR DESCRIPTION
Until the plugin routine can be rewritten to not prompt interactively on first init, this is a workaround for that behavior.

Ticket: #77503