### PR TITLE
tkt-77089: Init/shutdown script fixes

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-preinit
+++ b/src/freenas/etc/ix.rc.d/ix-preinit
@@ -20,10 +20,10 @@ execute_task()
 	"SELECT $sf FROM tasks_initshutdown WHERE ini_when = 'preinit' AND ini_enabled = 1 AND ini_type = '$stype' ORDER BY id" | \
 	while eval read -r $f; do
 		if [ "${stype}" = "command" ]; then
-			eval ${ini_command}
+			sh -c "${ini_command}" < /dev/null
 		else
 			if [ -e "${ini_script}" ]; then
-				sh -c "exec ${ini_script}"
+				sh -c "exec ${ini_script}" < /dev/null
 			fi
 		fi
 	done

--- a/src/freenas/etc/ix.rc.d/ix-shutdown
+++ b/src/freenas/etc/ix.rc.d/ix-shutdown
@@ -20,10 +20,10 @@ execute_task()
 	"SELECT $sf FROM tasks_initshutdown WHERE ini_when = 'shutdown' AND ini_enabled = 1 AND ini_type = '$stype' ORDER BY id" | \
 	while eval read -r $f; do
 		if [ "${stype}" = "command" ]; then
-			eval ${ini_command}
+			sh -c "${ini_command}" < /dev/null
 		else
 			if [ -e "${ini_script}" ]; then
-				sh -c "exec ${ini_script}"
+				sh -c "exec ${ini_script}" < /dev/null
 			fi
 		fi
 	done

--- a/src/freenas/etc/rc.d/ix-postinit
+++ b/src/freenas/etc/rc.d/ix-postinit
@@ -19,10 +19,10 @@ execute_task()
 	"SELECT $sf FROM tasks_initshutdown WHERE ini_when = 'postinit' AND ini_enabled = 1 AND ini_type = '$stype' ORDER BY id" | \
 	while eval read -r $f; do
 		if [ "${stype}" = "command" ]; then
-			eval ${ini_command}
+			sh -c "${ini_command}" < /dev/null
 		else
 			if [ -e "${ini_script}" ]; then
-				sh -c "exec ${ini_script}"
+				sh -c "exec ${ini_script}" < /dev/null
 			fi
 		fi
 	done

--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -907,10 +907,10 @@ class ServiceService(CRUDService):
         await self._service("inadyn", "restart", **kwargs)
 
     async def _restart_system(self, **kwargs):
-        asyncio.ensure_future(self._system("/bin/sleep 3 && /sbin/shutdown -r now"))
+        asyncio.ensure_future(self.middleware.call('system.reboot', {'delay': 3}))
 
     async def _stop_system(self, **kwargs):
-        asyncio.ensure_future(self._system("/bin/sleep 3 && /sbin/shutdown -p now"))
+        asyncio.ensure_future(self.middleware.call('system.shutdown', {'delay': 3}))
 
     async def _reload_cifs(self, **kwargs):
         await self._service("ix-pre-samba", "start", quiet=True, **kwargs)

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -354,7 +354,7 @@ class SystemService(Service):
         if delay:
             time.sleep(delay)
 
-        await Popen(["/sbin/reboot"])
+        await Popen(['/sbin/shutdown', '-r', 'now'])
 
     @accepts(Dict('system-shutdown', Int('delay', required=False), required=False))
     @job()
@@ -375,7 +375,7 @@ class SystemService(Service):
         if delay:
             time.sleep(delay)
 
-        await Popen(["/sbin/poweroff"])
+        await Popen(['/sbin/poweroff'])
 
     @accepts()
     @job(lock='systemdebug')


### PR DESCRIPTION
This PR fixes the following issues:
1) Normalizes reboot, reboot done via new UI resulted in shutdown scripts to not be executed at all.
2) There are commands which can drain stdin in a while read loop resulting in the termination of the loop i.e ssh. This results in scripts/commands still left to be executed. The issue arises because stdin is shared with the whole while loop body.

Ticket: #77089