### PR TITLE
tkt-78034: [directoryservice] Fix shell errors (by freqlabs)

### DIFF
--- a/src/freenas/etc/directoryservice/rc.ActiveDirectory
+++ b/src/freenas/etc/directoryservice/rc.ActiveDirectory
@@ -130,7 +130,7 @@ __AD_get_SRV_host()
 
 __AD_tc()
 {
-	local timeout=$1
+	local timeout=${1:-0}
 	shift
 	local args="$*"
 

--- a/src/freenas/etc/directoryservice/rc.DomainController
+++ b/src/freenas/etc/directoryservice/rc.DomainController
@@ -27,7 +27,7 @@
 
 __DC_tc()
 {
-	local timeout=$1
+	local timeout=${1:-0}
 	shift
 	local args="$*"
 

--- a/src/freenas/etc/directoryservice/rc.LDAP
+++ b/src/freenas/etc/directoryservice/rc.LDAP
@@ -39,7 +39,7 @@
 
 __LDAP_tc()
 {
-	local timeout=$1
+	local timeout=${1:-0}
 	shift
 	local args="$*"
 


### PR DESCRIPTION
(cherry-picked from 2be91c753157587855fd5857a4a3aac1484417fd)

When Active Directory isn't working, the timeout can be empty.  We
should default to a timeout of 0 in this case.