### PR TITLE
tkt-78133: Fix idmap_ldap parameters (by anodos325)

### DIFF
--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -506,17 +506,17 @@ def configure_idmap_ldap(smb4_conf, idmap, domain):
         idmap.idmap_ldap_range_high
     ))
     if idmap.idmap_ldap_ldap_base_dn:
-        confset1(smb4_conf, "idmap config %s: ldap base dn = %s" % (
+        confset1(smb4_conf, "idmap config %s: ldap_base_dn = %s" % (
             domain,
             idmap.idmap_ldap_ldap_base_dn
         ))
     if idmap.idmap_ldap_ldap_user_dn:
-        confset1(smb4_conf, "idmap config %s: ldap user dn = %s" % (
+        confset1(smb4_conf, "idmap config %s: ldap_user_dn = %s" % (
             domain,
             idmap.idmap_ldap_ldap_user_dn
         ))
     if idmap.idmap_ldap_ldap_url:
-        confset1(smb4_conf, "idmap config %s: ldap url = %s" % (
+        confset1(smb4_conf, "idmap config %s: ldap_url = %s" % (
             domain,
             idmap.idmap_ldap_ldap_url
         ))


### PR DESCRIPTION
There should be underscores instead of spaces in these parameters per idmap manpage.