### PR TITLE
tkt-78232: Remove all usages of ix-resolv

### DIFF
--- a/src/freenas/etc/directoryservice/DomainController/ctl
+++ b/src/freenas/etc/directoryservice/DomainController/ctl
@@ -127,7 +127,7 @@ dcctl_start()
 	echo ${cifs_started} > "${cifs_file}"
 
 	dcctl_cmd ${service} ix-kerberos quietstart
-	dcctl_cmd ${service} ix-resolv quietstart
+	dcctl_cmd ${python} ${notifier} call dns.sync
 	dcctl_cmd ${service} ix-nsswitch quietstart
 	dcctl_cmd ${service} ix-pam quietstart
 
@@ -192,7 +192,7 @@ dcctl_stop()
 	fi
 
 	domaincontroller_set 0
-	dcctl_cmd ${service} ix-resolv quietstart
+	dcctl_cmd ${python} ${notifier} call dns.sync
 
 	return 0
 }

--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -506,7 +506,7 @@ class ServiceService(CRUDService):
 
     async def _reload_resolvconf(self, **kwargs):
         await self._reload_hostname()
-        await self._service("ix-resolv", "start", quiet=True, **kwargs)
+        await self.middleware.call('dns.sync')
 
     async def _reload_networkgeneral(self, **kwargs):
         await self._reload_resolvconf()


### PR DESCRIPTION
This commit removes all usages of ix-resolv and makes sure we use middlewared instead.