### PR TITLE
Revert "tkt-43558: [loader.conf] Raise max TCP segment queue length"

### DIFF
--- a/src/freenas/boot/loader.conf
+++ b/src/freenas/boot/loader.conf
@@ -43,10 +43,6 @@ module_path="/boot/kernel;/boot/modules;/usr/local/modules"
 # if IPv6 is configured for the interface later on in boot.
 net.inet6.ip6.auto_linklocal="0"
 
-# Relax the TCP reassembly queue length limit to improve performance
-# in the event of packet loss or reordering.
-net.inet.tcp.reass.maxqueuelen=1448
-
 # Switch ZVOLs into "dev" mode, skipping GEOM.
 vfs.zfs.vol.mode=2
 


### PR DESCRIPTION
This reverts commit 6f79caa8a205bee8875f647086c7f23cf2823979.

New TCP reassembly code has been merged to 11-stable, rendering this
tuning obsolete.

Ticket: #78222