### PR TITLE
tkt-73380: Update ups service to listen to ipv6 addresses

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nut/upsd.conf
+++ b/src/middlewared/middlewared/etc_files/local/nut/upsd.conf
@@ -3,7 +3,9 @@
 %>\
 % if ups_config['rmonitor']:
 LISTEN 0.0.0.0
+LISTEN ::0
 % else:
 LISTEN 127.0.0.1
+LISTEN ::1
 % endif
 ${ups_config['optionsupsd']}


### PR DESCRIPTION
This commit updates ups service to listen to ipv6 addresses as well with ipv4 by default.
Ticket: #73380