### PR TITLE
[install.sh] Fix upgrades from installer (11.2)

### DIFF
--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -564,7 +564,7 @@ disk_is_freenas()
 	# This code is very clumsy.  There
 	# should be a way to structure it such that
 	# all of the cleanup happens as we want it to.
-	zdb -l ${os_part} | fgrep -q "name: 'freenas-boot'" || return 1
+	zdb -l ${os_part} | grep -qF "name: 'freenas-boot'" || return 1
 	zpool import -N -f freenas-boot || return 1
 
 	# Now we want to figure out which dataset to use.


### PR DESCRIPTION
fgrep doesn't exist on the installer, so it would never detect an
existing freenas-boot pool.

Ticket: #78231