### PR TITLE
tkt-78852: Improve stability and error handling in DC service

### DIFF
--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -1757,7 +1757,7 @@ def main():
         min password requirements. Provisioning raises an exception in case of failure.
         """
         if client.call('notifier.samba4', 'domain_provisioned'):
-            client.call('domaincontroller.set_provisioned', 'yes')
+            client.call('domaincontroller.set_provisioned', True)
             client.call('notifier.samba4', 'domain_sentinel_file_remove')
 
         if client.call('domaincontroller.provision'):

--- a/src/middlewared/middlewared/plugins/domain_controller.py
+++ b/src/middlewared/middlewared/plugins/domain_controller.py
@@ -3,6 +3,7 @@ import libzfs
 
 from middlewared.schema import accepts, Dict, Int, Str
 from middlewared.service import private, SystemServiceService
+from middlewared.service_exception import CallError
 from middlewared.utils import run
 
 
@@ -59,7 +60,7 @@ class DomainControllerService(SystemServiceService):
         is_already_provisioned = await self.is_provisioned()
         if is_already_provisioned and not force:
             self.logger.debug("Domain is already provisioned and command does not have 'force' flag. Bypassing.")
-            return False 
+            return False
 
         dc = await self.middleware.call('domaincontroller.config')
         prov = await run([

--- a/src/middlewared/middlewared/plugins/domain_controller.py
+++ b/src/middlewared/middlewared/plugins/domain_controller.py
@@ -32,7 +32,6 @@ class DomainControllerService(SystemServiceService):
         ret = False
         with libzfs.ZFS() as zfs:
             ds = zfs.get_dataset_by_path(sysvol_path)
-            self.logger.debug(ds.properties[provisioned].value)
             if provisioned in ds.properties and ds.properties[provisioned].value == 'yes':
                 ret = True
             else:
@@ -80,7 +79,7 @@ class DomainControllerService(SystemServiceService):
             raise CallError(f"Failed to provision domain: {prov.stderr.decode()}")
         else:
             self.logger.debug(f"Successfully provisioned domain [{dc['domain']}]")
-            await self.middleware.call('domaincontroller.set_provisioned', 'yes')
+            await self.middleware.call('domaincontroller.set_provisioned', True)
             return True
 
     @accepts(Dict(
@@ -125,7 +124,7 @@ class DomainControllerService(SystemServiceService):
                                                                    new_realm)
 
         if any(new[k] != old[k] for k in ["realm", "domain"]):
-            await self.middleware.call('domaincontroller.set_provisioned', 'no')
+            await self.middleware.call('domaincontroller.set_provisioned', False)
 
         await self.domaincontroller_compress(new)
 

--- a/src/middlewared/middlewared/plugins/domain_controller.py
+++ b/src/middlewared/middlewared/plugins/domain_controller.py
@@ -58,7 +58,7 @@ class DomainControllerService(SystemServiceService):
         systemdataset = self.middleware.call_sync('systemdataset.config')
         sysvol_path = f"{systemdataset['basename']}/samba4"
         ds = {'properties': {'org.ix.activedirectory:provisioned': {'value': 'yes' if value else 'no'}}}
-        self.middleware.call_sync('zfs.dataset.do_update', sysvol_path, ds)
+        self.middleware.call_sync('zfs.dataset.update', sysvol_path, ds)
         return True
 
     @private


### PR DESCRIPTION
- Make extra sure that zfsacl is present in smb4.conf during provision
- Raise exception if provision fails
- Get rid of sentinel files