### PR TITLE
tkt-79185: fix(middlewared): use login(1) for webshell (by william-gr)

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -556,7 +556,7 @@ class ShellWorkerThread(threading.Thread):
                     pass
             os.chdir('/root')
             cmd = [
-                '/usr/local/bin/bash'
+                '/usr/bin/login', '-fp', 'root',
             ]
 
             if self.jail is not None:


### PR DESCRIPTION
Ticket:	#78825