### PR TITLE
tkt-79419: Correct kern.corefile setting

### DIFF
--- a/src/freenas/etc/sysctl.conf
+++ b/src/freenas/etc/sysctl.conf
@@ -6,7 +6,6 @@
 # of blocks after they have been in the queues for X seconds.  It is critical
 # that metadelay < dirdelay < filedelay and no fractions are allowed.
 
-kern.corefile=/var/tmp/%N.core
 kern.metadelay=3
 kern.dirdelay=4
 kern.filedelay=5

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -131,6 +131,9 @@ class SystemDatasetService(ConfigService):
     @accepts(Bool('mount', default=True), Str('exclude_pool', default=None, null=True))
     @private
     async def setup(self, mount, exclude_pool=None):
+        # We default kern.corefile value
+        await run('sysctl', "kern.corefile='/var/tmp/%N.core'")
+
         config = await self.config()
 
         if not await self.middleware.call('system.is_freenas'):


### PR DESCRIPTION
This commit reverts setting kern.corefile sysctl in sysctl.conf as the conf file is reloaded near the end of booting stage where we lose kern.corefile value if it is set by systemdataset plugin.