### PR TITLE
tkt-79428: Correct kern.corefile setting (by sonicaj)

### DIFF
--- a/src/freenas/etc/sysctl.conf
+++ b/src/freenas/etc/sysctl.conf
@@ -6,7 +6,6 @@
 # of blocks after they have been in the queues for X seconds.  It is critical
 # that metadelay < dirdelay < filedelay and no fractions are allowed.
 
-kern.corefile=/var/tmp/%N.core
 kern.metadelay=3
 kern.dirdelay=4
 kern.filedelay=5

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -100,6 +100,9 @@ class SystemDatasetService(ConfigService):
     @accepts(Bool('mount', default=True))
     @private
     async def setup(self, mount):
+        # We default kern.corefile value
+        await run('sysctl', "kern.corefile='/var/tmp/%N.core'")
+
         config = await self.config()
 
         if not await self.middleware.call('system.is_freenas'):


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick 327b80d96e679b1cea6cf0ad03bc0d93491edea1

This commit reverts setting kern.corefile sysctl in sysctl.conf as the conf file is reloaded near the end of booting stage where we lose kern.corefile value if it is set by systemdataset plugin.