### PR TITLE
tkt-79527: fix(jail/fetch): Check for existence of plugin_index before second run (by skarekrow)

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -125,13 +125,6 @@ class JailService(CRUDService):
     @private
     @job(lock=lambda args: f'jail_create:{args[-1]["uuid"]}')
     def create_job(self, job, options):
-        print('*'*50)
-        print('*'*50)
-        print('*'*50)
-        print(job, options)
-        print('*'*50)
-        print('*'*50)
-        print('*'*50)
         verrors = ValidationErrors()
         uuid = options["uuid"]
 

--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -125,6 +125,13 @@ class JailService(CRUDService):
     @private
     @job(lock=lambda args: f'jail_create:{args[-1]["uuid"]}')
     def create_job(self, job, options):
+        print('*'*50)
+        print('*'*50)
+        print('*'*50)
+        print(job, options)
+        print('*'*50)
+        print('*'*50)
+        print('*'*50)
         verrors = ValidationErrors()
         uuid = options["uuid"]
 
@@ -393,6 +400,7 @@ class JailService(CRUDService):
         """Fetches a release or plugin."""
         fetch_output = {'error': False, 'install_notes': []}
         release = options.get('release', None)
+
         post_install = False
 
         verrors = ValidationErrors()
@@ -456,13 +464,20 @@ class JailService(CRUDService):
         iocage = ioc.IOCage(callback=progress_callback, silent=False)
 
         if options["name"] is not None:
-            # WORKAROUND until rewritten for #39653
-            # We want the plugins to not prompt interactively
-            try:
-                iocage.fetch(plugin_file=True, _list=True, **options)
-            except Exception:
-                # Expected, this is to avoid it later
-                pass
+            pool = IOCJson().json_get_value('pool')
+            iocroot = IOCJson(pool).json_get_value('iocroot')
+            plugin_index = pathlib.Path(
+                f'{iocroot}/.plugin_index'
+            )
+
+            if not plugin_index.is_dir():
+                # WORKAROUND until rewritten for #39653
+                # We want the plugins to not prompt interactively
+                try:
+                    iocage.fetch(plugin_file=True, _list=True, **options)
+                except Exception:
+                    # Expected, this is to avoid it later
+                    pass
 
             options["plugin_file"] = True
             start_msg = 'Starting plugin install'
@@ -474,8 +489,6 @@ class JailService(CRUDService):
         iocage.fetch(**options)
 
         if post_install and options['name'] is not None:
-            pool = IOCJson().json_get_value('pool')
-            iocroot = IOCJson(pool).json_get_value('iocroot')
             plugin_manifest = pathlib.Path(
                 f'{iocroot}/.plugin_index/{options["name"]}.json'
             )


### PR DESCRIPTION
The second run only succeeds because the directory would have caused an EOF, but afterwards results in duplicate creation of plugins

Ticket: #77710