### PR TITLE
tkt-80472: fix(rc): re-read rc.conf using ALRM to /bin/sh

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-etc
+++ b/src/freenas/etc/ix.rc.d/ix-etc
@@ -34,6 +34,9 @@ generate_etc()
 	[ -s /data/dhparam.pem ] || openssl dhparam -rand /dev/random 2048 > /data/dhparam.pem
 
 	LD_LIBRARY_PATH=/usr/local/lib /usr/local/bin/midclt call etc.generate_all > /dev/null
+
+	# etc rc plugin will generate rc.conf.freenas which needs to be re-read by /etc/rc script
+	killall -ALRM sh
 }
 
 name="ix-etc"

--- a/src/freenas/etc/ix.rc.d/ix-netif
+++ b/src/freenas/etc/ix.rc.d/ix-netif
@@ -230,7 +230,7 @@ netif_start()
 	# we need to fallback to configuring interfaces using rc.d/netif for debugging.
 	if ! /usr/local/bin/midclt -t 120 call interfaces.sync true > /dev/null 2>&1; then
 		_interface_config > /etc/rc.conf.network
-		kill -ALRM 1
+		killall -ALRM sh
 	fi
 
 }

--- a/src/middlewared/middlewared/etc_files/rc.conf.py
+++ b/src/middlewared/middlewared/etc_files/rc.conf.py
@@ -2,7 +2,6 @@ import contextlib
 import itertools
 import os
 import re
-import signal
 import subprocess
 import sysctl
 
@@ -446,5 +445,4 @@ def render(service, middleware):
         except Exception:
             middleware.logger.error('Failed to generate %s', i.__name__, exc_info=True)
 
-    if write_if_changed('/etc/rc.conf.freenas', '\n'.join(rcs) + '\n'):
-        os.kill(1, signal.SIGALRM)
+    write_if_changed('/etc/rc.conf.freenas', '\n'.join(rcs) + '\n')


### PR DESCRIPTION
I previously thought that would be handled by signaling /sbin/init but
obviously that is not the case.

Ticket:	#80472