### PR TITLE
tkt-81489: Improve datastore listing in vmware (by sonicaj)

### DIFF
--- a/gui/storage/views.py
+++ b/gui/storage/views.py
@@ -1226,14 +1226,11 @@ def vmwareplugin_datastores(request):
         else:
             password = ''
         with client as c:
-            ds = c.call('vmware.get_datastores', {
+            data['value'] = c.call('vmware.get_datastores', {
                 'hostname': request.POST.get('hostname'),
                 'username': request.POST.get('username'),
                 'password': password,
             })
-        data['value'] = []
-        for i in ds.values():
-            data['value'] += i.keys()
     except Exception as e:
         data['error'] = True
         data['errmsg'] = str(e)

--- a/src/middlewared/middlewared/plugins/vmware.py
+++ b/src/middlewared/middlewared/plugins/vmware.py
@@ -200,7 +200,14 @@ class VMWareService(CRUDService):
             datastores[esxi_host.name] = datastores_host
 
         connect.Disconnect(server_instance)
-        return datastores
+
+        # Datastore names are unique among different esxi host under a single vcenter server. As we only require
+        # datastore names and additional information is not needed for datastore choices, we refine the datastores
+        # dict and send back only the datastore names
+
+        return sorted({
+            name for host in datastores.values() for name in host
+        })
 
     @accepts(Int('pk'))
     async def get_virtual_machines(self, pk):

--- a/src/middlewared/middlewared/plugins/vmware.py
+++ b/src/middlewared/middlewared/plugins/vmware.py
@@ -47,10 +47,7 @@ class VMWareService(CRUDService):
                 }
             )
 
-            datastores = []
-            for i in ds.values():
-                datastores += i.keys()
-            if data.get('datastore') not in datastores:
+            if data.get('datastore') not in ds:
                 verrors.add(
                     f'{schema_name}.datastore',
                     f'Datastore "{datastore}" not found on the server'

--- a/src/middlewared/middlewared/pytest/functional/test_0095_vmware.py
+++ b/src/middlewared/middlewared/pytest/functional/test_0095_vmware.py
@@ -31,5 +31,5 @@ def test_vmware_get_datastores(conn, creds):
     })
     assert req.status_code == 200
     datastores = req.json()
-    assert isinstance(datastores, dict) is True
+    assert isinstance(datastores, list) is True
     assert len(datastores) > 0

--- a/tests/api2/vmware.py
+++ b/tests/api2/vmware.py
@@ -37,5 +37,4 @@ def test_02_create_vmware(data):
     }
     results = POST('/vmware/get_datastores/', payload)
     assert results.status_code == 200, results.text
-    assert isinstance(results.json(), dict) is True, results.text
-    data['vmid'] = results.json()
+    assert isinstance(results.json(), list) is True, results.text


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick 607d3da9ca4b495326d70b697ade1b6ba686bb36
    git cherry-pick 4b3602c7b76cfe2f71864529f3fc9af1659d66bc
    git cherry-pick 1e76825026df9bd420fc558a13731fe4761b196a

This commit removes duplicates and sorts the datastores which are fetched for vmware plugin in legacy UI.
Ticket: #72957