### PR TITLE
tkt-83075: Correct encoding logic for certificates

### DIFF
--- a/gui/common/ssl.py
+++ b/gui/common/ssl.py
@@ -49,7 +49,7 @@ def export_certificate_chain(buf):
         certificate = crypto.load_certificate(crypto.FILETYPE_PEM, m)
         certificates.append(crypto.dump_certificate(crypto.FILETYPE_PEM, certificate))
 
-    return ''.join(certificates).strip()
+    return b''.join(certificates).strip()
 
 
 def export_certificate(buf):


### PR DESCRIPTION
This commit corrects encoding logic for certificates where we tried to join list of bytes on a string.
Ticket: #83075