### PR TITLE
tkt-83235: Configure Encrypted Pools Correctly

### DIFF
--- a/gui/api/resources.py
+++ b/gui/api/resources.py
@@ -959,6 +959,19 @@ class VolumeResourceMixin(NestedMixin):
                 response=self.error_response(request, _('Volume is not encrypted.'))
             )
 
+        with client as c:
+            sys_dataset = c.call('systemdataset.config')
+
+        if obj.vol_name == sys_dataset['pool']:
+            raise ImmediateHttpResponse(
+                response=self.error_response(
+                    request,_(
+                        'Pool contains the system dataset and cannot be locked. Please select a different pool or '
+                        'configure the system dataset to be on a different pool.'
+                    )
+                )
+            )
+
         _n = notifier()
         _n.volume_detach(obj)
 

--- a/gui/storage/forms.py
+++ b/gui/storage/forms.py
@@ -2680,6 +2680,7 @@ class ChangePassphraseForm(Form):
     )
 
     def __init__(self, *args, **kwargs):
+        self.volume = kwargs.pop('volume')
         super(ChangePassphraseForm, self).__init__(*args, **kwargs)
         self.fields['remove'].widget.attrs['onClick'] = (
             'toggleGeneric("id_remove", ["id_passphrase", '
@@ -2715,6 +2716,16 @@ class ChangePassphraseForm(Form):
         if cdata.get("remove"):
             self._errors.pop('passphrase', None)
             self._errors.pop('passphrase2', None)
+        else:
+            with client as c:
+                sys_dataset = c.call('systemdataset.config')
+
+            if self.volume.vol_name == sys_dataset['pool']:
+                self._errors['__all__'] = self.error_class([
+                    _('An encrypted pool containing the system dataset must not have a passphrase. '
+                      'An existing passphrase on that pool can only be removed."')
+                ])
+
         return cdata
 
     def done(self, volume):

--- a/gui/storage/views.py
+++ b/gui/storage/views.py
@@ -987,6 +987,19 @@ def volume_lock(request, object_id):
                 log.warn('Failed to clear key on standby node, is it down?', exc_info=True)
         notifier().restart("system_datasets")
         return JsonResp(request, message=_("Volume locked"))
+
+    with client as c:
+        sys_dataset = c.call('systemdataset.config')
+
+    if volume.vol_name == sys_dataset['pool']:
+        return render(
+            request,
+            'freeadmin/generic_model_dialog.html', {
+                'msg': 'Pool contains the system dataset and cannot be locked. Please select a different pool '
+                       'or configure the system dataset to be on a different pool.'
+            }
+        )
+
     return render(request, "storage/lock.html")
 
 

--- a/gui/templates/freeadmin/generic_model_dialog.html
+++ b/gui/templates/freeadmin/generic_model_dialog.html
@@ -1,0 +1,14 @@
+{% extends "freeadmin/generic_form.html" %}
+{% block form %}
+    <tr><td>{% trans msg %}</td></tr>
+{% endblock %}
+{% block buttons %}
+    <button id="btn_generic_Cancel" data-dojo-type="dijit.form.Button" type="button">
+        {% block ok_label %}
+            {% trans "Ok" %}
+        {% endblock %}
+        <script type="dojo/method" data-dojo-event="onClick" data-dojo-args="evt">
+            cancelDialog(this);
+        </script>
+    </button>
+{% endblock %}


### PR DESCRIPTION
This PR introduces the following changes:

1) We don't lock a pool which is being used by system dataset
2) We don't allow end user to set/change passphrase for a pool which is being used by system dataset
3) We don't allow system datasets to be configured with any pool which has a passphrase set

Ticket: #83235