### PR TITLE
tkt-77916: Use nfsd command-line option instead of /etc/nfsd.virtualhost

### DIFF
--- a/src/middlewared/middlewared/etc_files/nfsd.py
+++ b/src/middlewared/middlewared/etc_files/nfsd.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 from middlewared.utils import run
 
@@ -82,19 +81,5 @@ async def render(service, middleware):
 
     with open("/etc/exports", "w") as f:
         f.write(await get_exports(config, shares, kerberos_keytabs))
-
-    try:
-        os.unlink("/etc/nfsd.virtualhost")
-    except Exception:
-        pass
-
-    if config["v4_krb"] or kerberos_keytabs:
-        gc = await middleware.call("datastore.config", "network.globalconfiguration")
-        if gc["gc_hostname_virtual"] and gc["gc_domain"]:
-            with open("/etc/nfsd.virtualhost", "w") as f:
-                f.write(f'{gc["gc_hostname_virtual"]}.{gc["gc_domain"]}')
-
-            await run("service", "nfsd", "restart", check=False)
-            await run("service", "gssd", "restart", check=False)
 
     await run("service", "mountd", "quietreload", check=False)

--- a/src/middlewared/middlewared/etc_files/rc.conf.py
+++ b/src/middlewared/middlewared/etc_files/rc.conf.py
@@ -237,6 +237,11 @@ def nfs_config(middleware, context):
     gssd = 'NO'
     if nfs['v4_krb'] or middleware.call_sync('datastore.query', 'directoryservice.kerberoskeytab'):
         gssd = 'YES'
+
+        gc = middleware.call_sync("datastore.config", "network.globalconfiguration")
+        if gc["gc_hostname_virtual"] and gc["gc_domain"]:
+            yield f'nfs_server_vhost="{gc["gc_hostname_virtual"]}.{gc["gc_domain"]}"'
+
     yield f'gssd_enable="{gssd}"'
 
 


### PR DESCRIPTION
@william-gr should this be backported to 11.2? Changes in `network.py` should be backported anyway because original code was not functional.