### PR TITLE
Donot encrypt empty dictionary

### DIFF
--- a/gui/freeadmin/models/fields.py
+++ b/gui/freeadmin/models/fields.py
@@ -95,10 +95,8 @@ class EncryptedDictField(models.Field):
         return "TextField"
 
     def get_db_prep_value(self, value, connection, prepared=False):
-        if FREENAS_INSTALL:
+        if FREENAS_INSTALL or not value:
             return ''
-        if not value:
-            value = {}
         return notifier().pwenc_encrypt(json.dumps(value))
 
     def from_db_value(self, value, expression, connection, context):


### PR DESCRIPTION
This commit introduces a change where we don't try to encrypt an empty dictionary which resulted in failure of certificate setup in case pwenc_secret file did not exist as pwenc service setup function is executed later then crypto plugin.