### PR TITLE
tkt-79239: Ensure UPS is not ONLINE at shutdown event

### DIFF
--- a/src/middlewared/middlewared/plugins/ups.py
+++ b/src/middlewared/middlewared/plugins/ups.py
@@ -206,7 +206,7 @@ class UPSService(SystemServiceService):
                     f'{config["identifier"]} is ONLINE (OL).'
                 )
             else:
-                syslog.syslog(syslog.LOG_INFO, 'upssched-cmd "issuing shutdown"')
+                syslog.syslog(syslog.LOG_NOTICE, 'upssched-cmd "issuing shutdown"')
                 await run('/usr/local/sbin/upsmon', '-c', 'fsd', check=False)
         elif notify_type.lower() in ('email', 'commbad', 'commok'):
             if config['emailnotify']:


### PR DESCRIPTION
This commit ensures UPS is not ONLINE when shutdown event is passed by upssched. There are cases where battery/charger issues can result in ups.status being 'OL LB' at the same time. This will ensure that we don't initiate a shutdown if ups is OL.
Ticket: #79239