### PR TITLE
tkt-84916: Ensure UPS is not ONLINE at shutdown event (by sonicaj)

### DIFF
--- a/src/freenas/usr/local/bin/custom-upssched-cmd
+++ b/src/freenas/usr/local/bin/custom-upssched-cmd
@@ -16,7 +16,7 @@ PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/sbin:/usr/local/bin
 
 IFS=\|
 
-f="ups_emailnotify ups_toemail ups_subject ups_shutdown"
+f="ups_emailnotify ups_toemail ups_subject ups_shutdown ups_mode ups_identifier ups_remotehost ups_remoteport"
 sf=$(echo $f | sed -e 's/ /, /g')
 ${FREENAS_SQLITE_CMD} ${FREENAS_CONFIG} \
 "SELECT $sf FROM services_ups ORDER BY -id LIMIT 1" | \
@@ -24,8 +24,17 @@ while eval read $f; do
 
 case $1 in
 	"SHUTDOWN")
-		logger -t upssched-cmd "issuing shutdown"
-		/usr/local/sbin/upsmon -c fsd
+		if [ "${ups_mode}" = "master" ]; then
+			ident="${ups_identifier}"
+		else
+			ident="${ups_identifier}@${ups_remotehost}:${ups_remoteport}"
+		fi
+		if [ -n $(upsc $ident | grep "ups.status.*OL") ]; then
+			logger -t upssched-cmd "Shutdown not initiated as ups.status indicates ${ident} is ONLINE (OL)"
+		else
+			logger -t upssched-cmd "issuing shutdown"
+			/usr/local/sbin/upsmon -c fsd
+		fi
 		;;
 	"EMAIL"|"COMMBAD"|"COMMOK")
 		if [ "${ups_emailnotify}" -eq 1 ]; then


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick e22eff91c6f783981094022c01dd0b8468439953
    git cherry-pick ce3116a36f58a223b9d51190a4c198dd5ca845be

This commit ensures UPS is not ONLINE when shutdown event is passed by upssched. There are cases where battery/charger issues can result in ups.status being 'OL LB' at the same time. This will ensure that we don't initiate a shutdown if ups is OL.
Ticket: #79239