### PR TITLE
tkt-85019: Save SSH keys in database

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix_sshd_save_keys
+++ b/src/freenas/etc/ix.rc.d/ix_sshd_save_keys
@@ -10,7 +10,7 @@
 # Save any generated keys by /usr/local/etc/rc.d/sshd into the config db.
 #
 
-. /etc/rc.subr
+. /etc/rc.freenas
 
 save_keys()
 {


### PR DESCRIPTION
This commit fixes a bug where we referenced freenas_sqlite_cmd variable from a file which no longer can give us access to it ( as that portion was removed in migration of rc.conf to middlewared ).