### PR TITLE
Allow decimal input for serialport field

### DIFF
--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -102,19 +102,15 @@ class SytemAdvancedService(ConfigService):
                     f'{schema}.serialport',
                     'Please specify a serial port when serial console option is checked'
                 )
-            elif serial_choice not in await self.serial_port_choices():
-                verrors.add(
-                    f'{schema}.serialport',
-                    'Serial port specified has not been identified by the system'
-                )
-
-        elif not serial_choice:
-            # TODO: THIS CHECK CAN BE REMOVED WHEN WE DISALLOW NONE VALUES IN THE SCHEMA LAYER
-
-            verrors.add(
-                f'{schema}.serialport',
-                'Empty serial port is not allowed'
-            )
+            else:
+                data['serialport'] = serial_choice = hex(
+                    int(serial_choice)
+                ) if serial_choice.isdigit() else serial_choice
+                if serial_choice not in await self.serial_port_choices():
+                    verrors.add(
+                        f'{schema}.serialport',
+                        'Serial port specified has not been identified by the system'
+                    )
 
         return verrors, data
 


### PR DESCRIPTION
This commit fixes a bug where we expected serialport to be in hexadecimal always. Now if it is provided in base 10, we normalize it and convert to hexadecimal.