### PR TITLE
tkt-85012: Correctly write multiple isns servers

### DIFF
--- a/src/middlewared/middlewared/etc_files/ctld.py
+++ b/src/middlewared/middlewared/etc_files/ctld.py
@@ -116,7 +116,7 @@ def main(middleware):
         node = middleware.call_sync('failover.node')
 
     if gconf.iscsi_isns_servers:
-        for server in gconf.iscsi_isns_servers.split(' '):
+        for server in gconf.iscsi_isns_servers.split():
             addline('isns-server "%s"\n\n' % server)
 
     # Generate the portal-group section


### PR DESCRIPTION
This commit fixes a bug where when we wrote isns-servers, we split on spaces only.
Ticket: #85012