### PR TITLE
tkt-85195: Correctly write multiple isns servers (by sonicaj)

### DIFF
--- a/src/freenas/usr/local/libexec/nas/generate_ctl_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_ctl_conf.py
@@ -138,7 +138,7 @@ def main():
         node = client.call('notifier.failover_node')
 
     if gconf.iscsi_isns_servers:
-        for server in gconf.iscsi_isns_servers.split(' '):
+        for server in gconf.iscsi_isns_servers.split():
             addline('isns-server "%s"\n\n' % server)
 
     # Generate the portal-group section


### PR DESCRIPTION
This commit fixes a bug where when we wrote isns-servers, we split on spaces only.
Ticket: #85012