### PR TITLE
tkt-83924: Normalize/Validate Crontab Commands

### DIFF
--- a/src/middlewared/middlewared/etc_files/crontab
+++ b/src/middlewared/middlewared/etc_files/crontab
@@ -7,40 +7,26 @@
     system_advanced = middleware.call_sync("system.advanced.config")
     resilver = middleware.call_sync("pool.resilver.config")
     legacy_replication = middleware.call_sync("replication.query", [["transport", "=", "LEGACY"], ["enabled", "=", True]])
-%>
-
-<%def name="entry(schedule, user, command, redirect_stdout=True, redirect_stderr=True)">
-    ${schedule["minute"]} ${schedule["hour"]} ${schedule["dom"]} ${schedule["month"]} ${schedule["dow"]} \
-    ${user} \
-    PATH="/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/root/bin" \
-    ${command.replace("\n", "").replace("%", "\\%")} \
-    % if redirect_stdout:
-        > /dev/null\
-    % endif
-    % if redirect_stderr:
-        2> /dev/null\
-    % endif
-</%def>
-
+%>\
 ${system_crontab}
 
 ## Don't run these on TrueNAS HA passive controllers
 ## Redmine 55908
 % if middleware.call_sync("system.is_freenas") or middleware.call_sync("failover.status") != "BACKUP":
     % for job in middleware.call_sync("cronjob.query", [["enabled", "=", True]]):
-        ${entry(job["schedule"], job["user"], job["command"], job["stdout"], job["stderr"])}
+${' '.join(middleware.call_sync('cronjob.construct_cron_command', job["schedule"], job["user"], job["command"], job["stdout"], job["stderr"]))}
     % endfor
 
     % for job in middleware.call_sync("rsynctask.query", [["enabled", "=", True]]):
-        ${entry(job["schedule"], "root", f"midclt call rsynctask.run {job['id']}")}
+${' '.join(middleware.call_sync('cronjob.construct_cron_command', job["schedule"], "root", f"midclt call rsynctask.run {job['id']}"))}
     % endfor
 
     % for job in middleware.call_sync("cloudsync.query", [["enabled", "=", True]]):
-        ${entry(job["schedule"], "root", f"midclt call cloudsync.sync {job['id']}")}
+${' '.join(middleware.call_sync('cronjob.construct_cron_command', job["schedule"], "root", f"midclt call cloudsync.sync {job['id']}"))}
     % endfor
 
     % for job in middleware.call_sync("pool.scrub.query", [["enabled", "=", True]]):
-        ${entry(job["schedule"], "root", f"/usr/local/libexec/nas/scrub -t {job['threshold']} {job['pool_name']}")}
+${' '.join(middleware.call_sync('cronjob.construct_cron_command', job["schedule"], "root", f"/usr/local/libexec/nas/scrub -t {job['threshold']} {job['pool_name']}"))}
     % endfor
 
     % if resilver["enabled"]:
@@ -52,14 +38,14 @@ ${system_crontab}
     % endif
 
     % if legacy_replication:
-        * * * * * root /usr/local/bin/python /usr/local/www/freenasUI/tools/autosnap.py > /dev/null 2>&1
+* * * * * root /usr/local/bin/python /usr/local/www/freenasUI/tools/autosnap.py > /dev/null 2>&1
     % else:
-        15 4 * * * root /usr/local/bin/python /usr/local/www/freenasUI/tools/autosnap.py > /dev/null 2>&1
+15 4 * * * root /usr/local/bin/python /usr/local/www/freenasUI/tools/autosnap.py > /dev/null 2>&1
     % endif
 
-    ${random.randint(0, 59)} \
-    ${random.randint(1, 4)} \
-    * * * root /usr/local/bin/midclt call update.download > /dev/null 2>&1
+${random.randint(0, 59)} \
+${random.randint(1, 4)} \
+* * * root /usr/local/bin/midclt call update.download > /dev/null 2>&1
 
-    @weekly root /usr/local/sbin/update-smart-drivedb > /dev/null 2>&1
+@weekly root /usr/local/sbin/update-smart-drivedb > /dev/null 2>&1
 % endif

--- a/src/middlewared/middlewared/plugins/cron.py
+++ b/src/middlewared/middlewared/plugins/cron.py
@@ -17,6 +17,20 @@ class CronJobService(CRUDService):
         return data
 
     @private
+    async def construct_cron_command(self, schedule, user, command, stdout=True, stderr=True):
+        return list(
+            filter(
+                bool, (
+                    schedule['minute'], schedule['hour'], schedule['dom'], schedule['month'],
+                    schedule['dow'], user,
+                    'PATH="/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/root/bin"',
+                    command.replace('\n', '').replace('%', r'\%'),
+                    '> /dev/null' if stdout else '', '2> /dev/null' if stderr else ''
+                )
+            )
+        )
+
+    @private
     async def validate_data(self, data, schema):
         verrors = ValidationErrors()
 
@@ -41,14 +55,37 @@ class CronJobService(CRUDService):
                     'Specified user does not exist'
                 )
 
+        command = data.get('command')
+        if not command:
+            verrors.add(
+                f'{schema}.command',
+                'Please specify a command for cronjob task.'
+            )
+        else:
+            crontab_cmd = (await self.construct_cron_command(
+                data['schedule'], user, command, data['stdout'], data['stderr']
+            ))[6:]
+            command = crontab_cmd.pop(1)
+
+            # When cron(8) reads an entry from a crontab, it keeps a buffer of 1000 characters and anything more then
+            # that is truncated. We validate that the user supplied command is not more than 1000 characters.
+            allowed_length = 1000 - len(' '.join(crontab_cmd))
+
+            if len(command) > allowed_length:
+                verrors.add(
+                    f'{schema}.command',
+                    f'Command must be less than or equal to {allowed_length} characters. '
+                    'Newline characters are automatically removed and "%" characters escaped with a backslash.'
+                )
+
         return verrors, data
 
     @accepts(
         Dict(
             'cron_job_create',
             Bool('enabled'),
-            Bool('stderr'),
-            Bool('stdout'),
+            Bool('stderr', default=False),
+            Bool('stdout', default=True),
             Cron('schedule'),
             Str('command', required=True),
             Str('description'),
@@ -104,7 +141,7 @@ class CronJobService(CRUDService):
 
         await self.middleware.call('service.restart', 'cron')
 
-        return data
+        return await self._get_instance(data['id'])
 
     @accepts(
         Int('id', validators=[Range(min=1)]),
@@ -137,7 +174,7 @@ class CronJobService(CRUDService):
 
             await self.middleware.call('service.restart', 'cron')
 
-        return await self.query(filters=[('id', '=', id)], options={'get': True})
+        return await self._get_instance(id)
 
     @accepts(
         Int('id')


### PR DESCRIPTION
This PR aims to validate cron commands making sure they donot exceed 1000 characters as FreeBSD enforces a hard limit. It also normalizes how we write commands in crontab ensuring that we donot insert unnecessary spaces which consume 1000characters buffer.

Ticket: #83924