### PR TITLE
NAS-101442 / 11.3 / Detect EFI system partition when upgrading loader

### DIFF
--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -405,7 +405,7 @@ install_loader()
     # Default to re-stamping what was already used on the current install
     _boottype="$BOOTMODE"
     if [ "${_upgrade_type}" = "inplace" ] ; then
-      if glabel list | grep -q 'efibsd' ; then
+      if gpart show ${_disks} | grep -qF 'efi' ; then
          _boottype="UEFI"
       else
          _boottype="BIOS"

--- a/src/freenas-installer/etc/installer12.sh
+++ b/src/freenas-installer/etc/installer12.sh
@@ -386,7 +386,7 @@ install_loader()
     # Default to re-stamping what was already used on the current install
     _boottype="$BOOTMODE"
     if [ "${_upgrade_type}" = "inplace" ] ; then
-      if glabel list | grep -q 'efibsd' ; then
+      if gpart show ${_disks} | grep -qF 'efi' ; then
          _boottype="UEFI"
       else
          _boottype="BIOS"


### PR DESCRIPTION
For in-place upgrades, the boot type of the existing installation is detected to ensure the correct type of boot code is installed.  When GRUB was the boot loader, installations labelled the ESP 'efibsd', however the new bsdloader installations do not use a label.  Both installation styles use the 'efi' partition type, so check for that instead of the 'efibsd' label to ensure we do not convert the UEFI system partition to a broken legacy BIOS boot partition.