### PR TITLE
NAS-101360 / 11.2 / Remove collectd.conf before generation

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-collectd
+++ b/src/freenas/etc/ix.rc.d/ix-collectd
@@ -68,6 +68,9 @@ get_rrd_dataset()
 
 generate_collectd()
 {
+    cfg="/usr/local/etc/collectd.conf"
+    rm $cfg
+
     local datadir
     local rrdmnt
     local hostname
@@ -181,7 +184,6 @@ generate_collectd()
         aggregation_plugin_cpu_type="percent"
     fi
 
-    cfg="/usr/local/etc/collectd.conf"
     cat << EOF > $cfg
 Hostname "${hostname}"
 FQDNLookup true


### PR DESCRIPTION
Remove collectd.conf before generation so if FS bootstrap or config generation fails, collectd won't start
at all, won't log with DEBUG level (it's default now) and won't pollute /var/db/collectd/rrd