### PR TITLE
NAS-101478 / 11.3 / fix(vm/device_create): Referencing this schema without an id failed

### DIFF
--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -1261,7 +1261,7 @@ class VMDeviceService(CRUDService):
         Create a new device for the VM of id `vm`.
         """
         if not data.get('vm'):
-            raise ValidationError('vm', '"vm" is required')
+            raise ValidationError('vmdevice_create.vm', '"vm" is required')
 
         data = await self.validate_device(data)
 

--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -1260,8 +1260,8 @@ class VMDeviceService(CRUDService):
         """
         Create a new device for the VM of id `vm`.
         """
-        if not data['vm']:
-            raise ValidationError('id', '"id" is required')
+        if not data.get('vm'):
+            raise ValidationError('vm', '"vm" is required')
 
         data = await self.validate_device(data)
 

--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -1249,7 +1249,7 @@ class VMDeviceService(CRUDService):
         Dict(
             'vmdevice_create',
             Str('dtype', enum=['NIC', 'DISK', 'CDROM', 'VNC', 'RAW'], required=True),
-            Int('vm', required=True),
+            Int('vm', required=False),
             Dict('attributes', additional_attrs=True, default=None),
             Int('order', default=None, null=True),
             register=True,
@@ -1259,11 +1259,15 @@ class VMDeviceService(CRUDService):
         """
         Create a new device for the VM of id `vm`.
         """
-        data = await self.validate_device(data)
-        id = await self.middleware.call('datastore.insert', self._config.datastore, data)
-        await self.__reorder_devices(id, data['vm'], data['order'])
+        if data['vm']:
+            data = await self.validate_device(data)
 
-        return await self._get_instance(id)
+            id = await self.middleware.call(
+                'datastore.insert', self._config.datastore, data
+            )
+            await self.__reorder_devices(id, data['vm'], data['order'])
+
+            return await self._get_instance(id)
 
     @accepts(Int('id'), Patch(
         'vmdevice_create',


### PR DESCRIPTION
There is no way to supply this id to build the enum for vm.create, so if the id is not supplied, we simply do nothing.

NAS-101478

Signed-off-by: Brandon Schneider <brandon@ixsystems.com>