### PR TITLE
NAS-101496 / 11.2 / fix legacy replication to allow spaces in dataset names

### DIFF
--- a/gui/tools/autorepl.py
+++ b/gui/tools/autorepl.py
@@ -355,7 +355,7 @@ for replication in replication_tasks:
         # We expect to see "on" in the output, or cannot open '%s': dataset does not exist
         # in the error.  To be safe, also check for children's readonly state.
         may_proceed = False
-        rzfscmd = "'zfs list -H -o readonly -t filesystem,volume -r \"%s\"'" % (remotefs_final)
+        rzfscmd = '"zfs list -H -o readonly -t filesystem,volume -r %s"' % (remotefs_final)
         sshproc = pipeopen('%s %s' % (sshcmd, rzfscmd))
         output, error = sshproc.communicate()
         error = error.strip('\n').strip('\r').replace('WARNING: ENABLED NONE CIPHER', '')
@@ -413,9 +413,9 @@ Hello,
 
     # Grab map from remote system
     if recursive:
-        rzfscmd = "'zfs list -H -t snapshot -p -o name,creation -r \"%s\"'" % (remotefs_final)
+        rzfscmd = '"zfs list -H -t snapshot -p -o name,creation -r \'%s\'"' % (remotefs_final)
     else:
-        rzfscmd = "'zfs list -H -t snapshot -p -o name,creation -d 1 -r \"%s\"'" % (remotefs_final)
+        rzfscmd = '"zfs list -H -t snapshot -p -o name,creation -d 1 -r \'%s\'"' % (remotefs_final)
     sshproc = pipeopen('%s %s' % (sshcmd, rzfscmd), debug)
     output, error = sshproc.communicate()
     error = error.strip('\n').strip('\r').replace('WARNING: ENABLED NONE CIPHER', '')

--- a/gui/tools/autorepl.py
+++ b/gui/tools/autorepl.py
@@ -320,7 +320,7 @@ for replication in replication_tasks:
         remote_zfslist[data[0]] = {'readonly': data[1] == 'on'}
 
     # Attempt to create the remote dataset.  If it fails, we don't care at this point.
-    rzfscmd = "'zfs create -o readonly=on "
+    rzfscmd = "zfs create -o readonly=on "
     ds = ''
     if "/" not in localfs:
         localfs_tmp = "%s/%s" % (localfs, localfs)
@@ -337,7 +337,7 @@ for replication in replication_tasks:
             if ds_full in remote_zfslist:
                 continue
             log.debug("ds = %s, remotefs = %s" % (ds, remotefs))
-            sshproc = pipeopen('%s %s \"%s\"' % (sshcmd, rzfscmd, ds_full) + "\'", quiet=True)
+            sshproc = pipeopen('%s %s \"%s\"' % (sshcmd, rzfscmd, ds_full), quiet=True)
             output, error = sshproc.communicate()
             error = error.strip('\n').strip('\r').replace('WARNING: ENABLED NONE CIPHER', '')
             # Debugging code

--- a/gui/tools/autorepl.py
+++ b/gui/tools/autorepl.py
@@ -127,7 +127,7 @@ def sendzfs(fromsnap, tosnap, dataset, localfs, remotefs, followdelete, throttle
         os.close(writefd)
 
     compress, decompress = compress_pipecmds(compression)
-    replcmd = '%s%s/usr/local/bin/pipewatcher $$ | %s \"%s/sbin/zfs receive -F -d \'%s\' && echo Succeeded\"' % (compress, throttle, sshcmd, decompress, remotefs)
+    replcmd = '%s%s/usr/local/bin/pipewatcher $$ | %s "%s/sbin/zfs receive -F -d \'%s\' && echo Succeeded"' % (compress, throttle, sshcmd, decompress, remotefs)
     log.debug('Sending zfs snapshot: %s | %s', ' '.join(cmd), replcmd)
     with open(templog, 'w+') as f:
         readobj = os.fdopen(readfd, 'rb', 0)
@@ -285,16 +285,16 @@ for replication in replication_tasks:
 
     sshcmd = '%s -p %d %s' % (sshcmd, remote_port, remote)
 
-    remotefs_final = '%s%s%s' % (remotefs, localfs.partition('/')[1], localfs.partition('/')[2])
+    remotefs_final = "%s%s%s" % (remotefs, localfs.partition('/')[1], localfs.partition('/')[2])
 
     # Examine local list of snapshots, then remote snapshots, and determine if there is any work to do.
     log.debug("Checking dataset %s" % (localfs))
 
     # Grab map from local system.
     if recursive:
-        zfsproc = pipeopen('/sbin/zfs list -H -t snapshot -p -o name,creation -r \"%s\"' % (localfs), debug)
+        zfsproc = pipeopen('/sbin/zfs list -H -t snapshot -p -o name,creation -r "%s"' % (localfs), debug)
     else:
-        zfsproc = pipeopen('/sbin/zfs list -H -t snapshot -p -o name,creation -r -d 1 \"%s\"' % (localfs), debug)
+        zfsproc = pipeopen('/sbin/zfs list -H -t snapshot -p -o name,creation -r -d 1 "%s"' % (localfs), debug)
 
     output, error = zfsproc.communicate()
     if zfsproc.returncode:

--- a/gui/tools/autorepl.py
+++ b/gui/tools/autorepl.py
@@ -315,8 +315,7 @@ for replication in replication_tasks:
     output, error = sshproc.communicate()
     remote_zfslist = {}
     for i in output.rstrip().split("\n"):
-        readonly_value = i.split()[-1]
-        data = [i.split("\t")[0].rstrip(), readonly_value]
+        data = i.rsplit("\t", 1)
         remote_zfslist[data[0]] = {'readonly': data[1] == 'on'}
 
     # Attempt to create the remote dataset.  If it fails, we don't care at this point.

--- a/gui/tools/autorepl.py
+++ b/gui/tools/autorepl.py
@@ -320,7 +320,7 @@ for replication in replication_tasks:
         remote_zfslist[data[0]] = {'readonly': data[1] == 'on'}
 
     # Attempt to create the remote dataset.  If it fails, we don't care at this point.
-    rzfscmd = "\'" + "zfs create -o readonly=on "
+    rzfscmd = "'zfs create -o readonly=on "
     ds = ''
     if "/" not in localfs:
         localfs_tmp = "%s/%s" % (localfs, localfs)

--- a/gui/tools/autorepl.py
+++ b/gui/tools/autorepl.py
@@ -314,9 +314,9 @@ for replication in replication_tasks:
     sshproc = pipeopen('%s %s' % (sshcmd, rzfscmd))
     output, error = sshproc.communicate()
     remote_zfslist = {}
-    for i in re.sub(r'\t+', ' ', output, flags=re.M).splitlines():
+    for i in output.rstrip().split("\n"):
         readonly_value = i.split()[-1]
-        data = [i.split(readonly_value)[0].rstrip(), readonly_value]
+        data = [i.split("\t")[0].rstrip(), readonly_value]
         remote_zfslist[data[0]] = {'readonly': data[1] == 'on'}
 
     # Attempt to create the remote dataset.  If it fails, we don't care at this point.


### PR DESCRIPTION
Ticket: NAS-101496

After investigation, creating datasets with spaces in names doesn't work with legacy replication and hasn't worked for quite some time. (https://redmine.ixsystems.com/issues/24310) The work-around listed in that ticket does not work on TrueNAS 11.1-U7.1.

I've tried to keep the commit as trivial as possible since this is legacy replication and has been replaced in 11.3+.

So this commit fixes 2 primary issues. 

1. properly escape the volume and filesystems appropriately (i.e. "zpool/dataset with space")
2. fix the regex that is replacing tabs with spaces which breaks the ability to compare the remote side with the local side.