### PR TITLE
NAS-101556 / 11.3 / Correctly start/stop jails on export

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -939,13 +939,13 @@ class JailService(CRUDService):
         started = False
 
         if status:
-            self.stop(jail)
+            self.middleware.call_sync('jail.stop', jail, job=True)
             started = True
 
         IOCImage().export_jail(uuid, path)
 
         if started:
-            self.start(jail)
+            self.middleware.call_sync('jail.start', jail, job=True)
 
         return True
 


### PR DESCRIPTION
This commit fixes a bug where we did not wait correctly start/stop jails while exporting a jail.