### PR TITLE
Return job result

### DIFF
--- a/src/middlewared/middlewared/client/client.py
+++ b/src/middlewared/middlewared/client/client.py
@@ -263,6 +263,7 @@ class Job(object):
             if job['exc_info'] and job['exc_info']['type'] == 'VALIDATION':
                 raise ValidationErrors(job['exc_info']['extra'])
             raise ClientException(job['error'], trace=job['exception'])
+        return job['result']
 
 
 class ErrnoMixin:


### PR DESCRIPTION
This commit fixes a bug where we did not return a result of a job with middlewared client.