### PR TITLE
NAS-101573 / 11.3 / Provide a UEFI startup script as a fallback

### DIFF
--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -418,9 +418,10 @@ install_loader()
 	    echo "Stamping EFI loader on: ${_disk}"
 	    mkdir -p /tmp/efi
 	    mount -t msdosfs /dev/${_disk}p1 /tmp/efi
-	    # Copy the .efi file
+	    # Copy the .efi file and create a fallback startup script
 	    mkdir -p /tmp/efi/efi/boot
 	    cp ${_mnt}/boot/boot1.efi /tmp/efi/efi/boot/BOOTx64.efi
+	    echo "BOOTx64.efi" > /tmp/efi/efi/boot/startup.nsh
 	    umount /tmp/efi
 	else
 	    echo "Stamping GPT loader on: ${_disk}"

--- a/src/freenas-installer/etc/installer12.sh
+++ b/src/freenas-installer/etc/installer12.sh
@@ -399,9 +399,10 @@ install_loader()
 	    echo "Stamping EFI loader on: ${_disk}"
 	    mkdir -p /tmp/efi
 	    mount -t msdosfs /dev/${_disk}p1 /tmp/efi
-	    # Copy the .efi file
+	    # Copy the .efi file and create a fallback startup script
 	    mkdir -p /tmp/efi/efi/boot
 	    cp ${_mnt}/boot/boot1.efi /tmp/efi/efi/boot/BOOTx64.efi
+	    echo "BOOTx64.efi" > /tmp/efi/efi/boot/startup.nsh
 	    umount /tmp/efi
 	else
 	    echo "Stamping GPT loader on: ${_disk}"


### PR DESCRIPTION
It may improve reliability of boot with some buggy UEFI firmwares to have a startup.nsh script that runs the boot program. FreeBSD does this now.

Jira issue: NAS-101573