### PR TITLE
NAS-101595 / 11.3 / Use Middlewared for cronjob tasks

### DIFF
--- a/src/middlewared/middlewared/etc_files/crontab
+++ b/src/middlewared/middlewared/etc_files/crontab
@@ -14,7 +14,7 @@ ${system_crontab}
 ## Redmine 55908
 % if middleware.call_sync("system.is_freenas") or middleware.call_sync("failover.status") != "BACKUP":
     % for job in middleware.call_sync("cronjob.query", [["enabled", "=", True]]):
-${' '.join(middleware.call_sync('cronjob.construct_cron_command', job["schedule"], job["user"], job["command"], job["stdout"], job["stderr"]))}
+${' '.join(middleware.call_sync('cronjob.construct_cron_command', job["schedule"], "root", f"midclt call cronjob.run {job['id']}"))}
     % endfor
 
     % for job in middleware.call_sync("rsynctask.query", [["enabled", "=", True]]):


### PR DESCRIPTION
This PR introduces changes to make sure that we use middlewared instead of crontab for executing cronjob tasks.