### PR TITLE
NAS-101604 / 11.3 / feat(jail/list_resource): Allow avoiding the cache on the remote plug…

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -501,9 +501,12 @@ class JailService(CRUDService):
 
         return fetch_output
 
-    @accepts(Str("resource", enum=["RELEASE", "TEMPLATE", "PLUGIN"]),
-             Bool("remote", default=False))
-    def list_resource(self, resource, remote):
+    @accepts(
+        Str("resource", enum=["RELEASE", "TEMPLATE", "PLUGIN"]),
+        Bool("remote", default=False),
+        Bool('want_cache'), default=True
+    )
+    def list_resource(self, resource, remote, want_cache):
         """Returns a JSON list of the supplied resource on the host"""
         self.check_dataset_existence()  # Make sure our datasets exist.
         iocage = ioc.IOCage(skip_jails=True)
@@ -511,13 +514,14 @@ class JailService(CRUDService):
 
         if resource == "plugin":
             if remote:
-                try:
-                    resource_list = self.middleware.call_sync(
-                        'cache.get', 'iocage_remote_plugins')
+                if want_cache:
+                    try:
+                        resource_list = self.middleware.call_sync(
+                            'cache.get', 'iocage_remote_plugins')
 
-                    return resource_list
-                except KeyError:
-                    pass
+                        return resource_list
+                    except KeyError:
+                        pass
 
                 resource_list = iocage.fetch(list=True, plugins=True,
                                              header=False)

--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -504,7 +504,7 @@ class JailService(CRUDService):
     @accepts(
         Str("resource", enum=["RELEASE", "TEMPLATE", "PLUGIN"]),
         Bool("remote", default=False),
-        Bool('want_cache'), default=True
+        Bool('want_cache', default=True)
     )
     def list_resource(self, resource, remote, want_cache):
         """Returns a JSON list of the supplied resource on the host"""


### PR DESCRIPTION
…in resource

This will allow the UI to request a cache busting call with a button to get up to date INDEX information for plugins.

NAS-101604

Signed-off-by: Brandon Schneider <brandon@ixsystems.com>