### PR TITLE
NAS-101566 / 11.2 / Failover alerts fixes

### DIFF
--- a/src/middlewared/middlewared/alert/base.py
+++ b/src/middlewared/middlewared/alert/base.py
@@ -70,6 +70,7 @@ class AlertSource:
     onetime = False
     schedule = IntervalSchedule(timedelta())
 
+    failover_related = False
     run_on_backup_node = True
 
     def __init__(self, middleware):

--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -71,6 +71,8 @@ class AlertService(Service):
         self.blocked_sources = defaultdict(set)
         self.sources_locks = {}
 
+        self.blocked_failover_alerts_until = 0
+
     @private
     async def initialize(self):
         self.node = "A"
@@ -315,6 +317,7 @@ class AlertService(Service):
         master_node = "A"
         backup_node = "B"
         run_on_backup_node = False
+        run_failover_related = False
         if not await self.middleware.call("system.is_freenas"):
             if await self.middleware.call("notifier.failover_licensed"):
                 master_node = await self.middleware.call("failover.node")
@@ -331,6 +334,8 @@ class AlertService(Service):
                         if remote_system_state == "READY" and remote_failover_status == "BACKUP":
                             run_on_backup_node = True
 
+            run_failover_related = time.monotonic() > self.blocked_failover_alerts_until
+
         for k, source_lock in list(self.sources_locks.items()):
             if source_lock.expires_at <= time.monotonic():
                 await self.unblock_source(k)
@@ -339,7 +344,7 @@ class AlertService(Service):
             if not alert_source.schedule.should_run(datetime.utcnow(), self.alert_source_last_run[alert_source.name]):
                 continue
 
-            if alert_source.failover_related and not run_on_backup_node:
+            if alert_source.failover_related and not run_failover_related:
                 continue
 
             self.alert_source_last_run[alert_source.name] = datetime.utcnow()
@@ -441,6 +446,11 @@ class AlertService(Service):
     async def unblock_source(self, lock):
         source_lock = self.sources_locks.pop(lock)
         self.blocked_sources[source_lock.source_name].remove(lock)
+
+    @private
+    async def block_failover_alerts(self):
+        # This values come from observation from support of how long a M-series boot can take.
+        self.blocked_failover_alerts_until = time.monotonic() + 900
 
     async def __run_source(self, source_name):
         alert_source = ALERT_SOURCES[source_name]

--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -321,13 +321,14 @@ class AlertService(Service):
                 try:
                     backup_node = await self.middleware.call("failover.call_remote", "failover.node")
                     remote_version = await self.middleware.call("failover.call_remote", "system.version")
+                    remote_system_state = await self.middleware.call("failover.call_remote", "system.state")
                     remote_failover_status = await self.middleware.call("failover.call_remote",
                                                                         "notifier.failover_status")
                 except Exception:
                     pass
                 else:
                     if remote_version == await self.middleware.call("system.version"):
-                        if remote_failover_status == "BACKUP":
+                        if remote_system_state == "READY" and remote_failover_status == "BACKUP":
                             run_on_backup_node = True
 
         for k, source_lock in list(self.sources_locks.items()):

--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -339,6 +339,9 @@ class AlertService(Service):
             if not alert_source.schedule.should_run(datetime.utcnow(), self.alert_source_last_run[alert_source.name]):
                 continue
 
+            if alert_source.failover_related and not run_on_backup_node:
+                continue
+
             self.alert_source_last_run[alert_source.name] = datetime.utcnow()
 
             alerts_a = list(self.alerts["A"][alert_source.name].values())

--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -206,6 +206,13 @@ class AlertService(Service):
         for policy_name, policy in self.policies.items():
             gone_alerts, new_alerts = policy.receive_alerts(now, self.alerts)
 
+            for gone_alert in list(gone_alerts):
+                for new_alert in new_alerts:
+                    if gone_alert.source == new_alert.source and gone_alert.key == new_alert.key:
+                        gone_alerts.remove(gone_alert)
+                        new_alerts.remove(new_alert)
+                        break
+
             for alert_service_desc in await self.middleware.call("datastore.query", "system.alertservice"):
                 service_settings = dict(default_settings, **alert_service_desc["settings"])
 


### PR DESCRIPTION
So after failover the first e-mail will be:

```
New alerts:
* Active Controller - Enclosure 0 (iX 4024Sp c205) is HEALTHY
* Active Controller - Failed to check failover status with the other node: [EHOSTDOWN] Standby node is down

Gone alerts:
* Standby Controller - Enclosure 0 (iX 4024Ss c205) is HEALTHY
```

We get an alert about enclosure because it has different name on different systems, how do we want to handle that?

Also I've left one failover-related alert because how else will we know that other system is unavailable?

After other system gets ready, we get another e-mail:

```
Gone alerts:

* Active Controller - Failed to check failover status with the other node: [EHOSTDOWN] Standby node is down
```

Meaning that everything is back to normal