### PR TITLE
NAS-101608 / 11.3 / Properly restart UPS

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nut/upsmon.conf
+++ b/src/middlewared/middlewared/etc_files/local/nut/upsmon.conf
@@ -25,7 +25,7 @@ NOTIFYFLAG REPLBATT SYSLOG+EXEC
 NOTIFYFLAG NOCOMM SYSLOG+EXEC
 NOTIFYFLAG FSD SYSLOG+EXEC
 NOTIFYFLAG SHUTDOWN SYSLOG+EXEC
-SHUTDOWN "${ups_config['shutdowncmd']}"
+SHUTDOWNCMD "${ups_config['shutdowncmd']}"
 POWERDOWNFLAG ${powerdown}
 HOSTSYNC ${ups_config['hostsync']}
 % if ups_config['nocommwarntime']:


### PR DESCRIPTION
When UPS service is restarted, upsmon daemon in some cases has not stopped it's multiple processes entirely and is in the process of doing so when we initiate a restart. Restart fails in this case as old process is still cleaning itself. This commit makes sure we properly wait for upsmon to die and then initiate a restart.