### PR TITLE
NAS-101566 / 11.3 / Failover alerts fixes (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/alert/base.py
+++ b/src/middlewared/middlewared/alert/base.py
@@ -176,6 +176,7 @@ class Alert:
 class AlertSource:
     schedule = IntervalSchedule(timedelta())
 
+    failover_related = False
     run_on_backup_node = True
 
     def __init__(self, middleware):

--- a/src/middlewared/middlewared/alert/base.py
+++ b/src/middlewared/middlewared/alert/base.py
@@ -234,7 +234,11 @@ class AlertService:
     async def _format_alerts(self, alerts, gone_alerts, new_alerts):
         product_name = await self.middleware.call("system.product_name")
         hostname = (await self.middleware.call("system.info"))["hostname"]
-        return format_alerts(product_name, hostname, alerts, gone_alerts, new_alerts)
+        if not await self.middleware.call("system.is_freenas"):
+            node_map = await self.middleware.call("alert.node_map")
+        else:
+            node_map = None
+        return format_alerts(product_name, hostname, node_map, alerts, gone_alerts, new_alerts)
 
 
 class ThreadedAlertService(AlertService):
@@ -278,23 +282,23 @@ class ProThreadedAlertService(ThreadedAlertService):
         raise NotImplementedError
 
 
-def format_alerts(product_name, hostname, alerts, gone_alerts, new_alerts):
+def format_alerts(product_name, hostname, node_map, alerts, gone_alerts, new_alerts):
     text = f"{product_name} @ {hostname}\n\n"
 
     if new_alerts:
-        text += "New alerts:\n" + "".join(["* %s\n" % format_alert(alert) for alert in new_alerts]) + "\n"
+        text += "New alerts:\n" + "".join(["* %s\n" % format_alert(alert, node_map) for alert in new_alerts]) + "\n"
 
     if gone_alerts:
-        text += "Gone alerts:\n" + "".join(["* %s\n" % format_alert(alert) for alert in gone_alerts]) + "\n"
+        text += "Gone alerts:\n" + "".join(["* %s\n" % format_alert(alert, node_map) for alert in gone_alerts]) + "\n"
 
     if alerts:
-        text += "Current alerts:\n" + "".join(["* %s\n" % format_alert(alert) for alert in alerts]) + "\n"
+        text += "Current alerts:\n" + "".join(["* %s\n" % format_alert(alert, node_map) for alert in alerts]) + "\n"
 
     return text
 
 
-def format_alert(alert):
-    return alert.formatted + (f" (on node {alert.node})" if alert.node != "A" else "")
+def format_alert(alert, node_map):
+    return (f"{node_map[alert.node]} - " if node_map else None) + alert.formatted
 
 
 def ellipsis(s, l):

--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -430,6 +430,9 @@ class AlertService(Service):
             if not alert_source.schedule.should_run(datetime.utcnow(), self.alert_source_last_run[alert_source.name]):
                 continue
 
+            if alert_source.failover_related and not run_on_backup_node:
+                continue
+
             self.alert_source_last_run[alert_source.name] = datetime.utcnow()
 
             alerts_a = [alert

--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -412,13 +412,14 @@ class AlertService(Service):
                 try:
                     backup_node = await self.middleware.call("failover.call_remote", "failover.node")
                     remote_version = await self.middleware.call("failover.call_remote", "system.version")
+                    remote_system_state = await self.middleware.call("failover.call_remote", "system.state")
                     remote_failover_status = await self.middleware.call("failover.call_remote",
                                                                         "failover.status")
                 except Exception:
                     pass
                 else:
                     if remote_version == await self.middleware.call("system.version"):
-                        if remote_failover_status == "BACKUP":
+                        if remote_system_state == "READY" and remote_failover_status == "BACKUP":
                             run_on_backup_node = True
 
         for k, source_lock in list(self.sources_locks.items()):

--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -321,6 +321,12 @@ class AlertService(Service):
                         classes.get(alert.klass.name, {}).get("policy", DEFAULT_POLICY) == policy_name
                     )
                 ]
+                for gone_alert in list(service_gone_alerts):
+                    for new_alert in service_new_alerts:
+                        if gone_alert.klass == new_alert.klass and gone_alert.key == new_alert.key:
+                            service_gone_alerts.remove(gone_alert)
+                            service_new_alerts.remove(new_alert)
+                            break
 
                 if not service_gone_alerts and not service_new_alerts:
                     continue


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x b2fc74d45bc79905eb3a1114f6c23fdc53b592d7
    git cherry-pick -x bb953f6fa666f348088b15fd390caec09db65ce0
    git cherry-pick -x d3c949609964b0d4a41c6e167df051dbfd44636e
    git cherry-pick -x da774cea0fe7e68491aa2c2328599ff3c0974c75
    git cherry-pick -x 14ef11ec29fe4e84f4b3a1aae5ccae16095e9c93

So after failover the first e-mail will be:

```
New alerts:
* Active Controller - Enclosure 0 (iX 4024Sp c205) is HEALTHY
* Active Controller - Failed to check failover status with the other node: [EHOSTDOWN] Standby node is down

Gone alerts:
* Standby Controller - Enclosure 0 (iX 4024Ss c205) is HEALTHY
```

We get an alert about enclosure because it has different name on different systems, how do we want to handle that?

Also I've left one failover-related alert because how else will we know that other system is unavailable?

After other system gets ready, we get another e-mail:

```
Gone alerts:

* Active Controller - Failed to check failover status with the other node: [EHOSTDOWN] Standby node is down
```

Meaning that everything is back to normal