### PR TITLE
NAS-101592 / 11.2 / Bug fixes for legacy wizards (by sonicaj)

### DIFF
--- a/gui/system/forms.py
+++ b/gui/system/forms.py
@@ -69,7 +69,7 @@ from freenasUI.middleware.client import (ClientException, ValidationErrors,
 from freenasUI.middleware.exceptions import MiddlewareError
 from freenasUI.middleware.form import MiddlewareModelForm
 from freenasUI.middleware.notifier import notifier
-from freenasUI.services.models import (iSCSITarget,
+from freenasUI.services.models import (iSCSITarget, CIFS,
                                        iSCSITargetAuthorizedInitiator,
                                        iSCSITargetExtent, iSCSITargetGroups,
                                        iSCSITargetPortal, iSCSITargetPortalIP,
@@ -734,6 +734,11 @@ class InitialWizard(CommonWizard):
                     'ad_bindpw': cleaned_data.get('ds_ad_bindpw'),
                     'ad_enable': True,
                 })
+
+                cifs = CIFS.objects.latest('id')
+                addata['ad_netbiosname_a'] = cifs.cifs_srv_netbiosname
+                addata['ad_netbiosname_b'] = cifs.cifs_srv_netbiosname_b
+
                 adform = ActiveDirectoryForm(
                     data=addata,
                     instance=ad,

--- a/gui/system/forms.py
+++ b/gui/system/forms.py
@@ -690,6 +690,7 @@ class InitialWizard(CommonWizard):
                 'stg_kbdmap': cleaned_data.get('stg_kbdmap'),
                 'stg_timezone': cleaned_data.get('stg_timezone'),
             })
+            settingsdata['stg_guicertificate'] = settingsdata.pop('stg_guicertificate_id')
             settingsform = SettingsForm(
                 data=settingsdata,
                 instance=settingsm,
@@ -698,7 +699,7 @@ class InitialWizard(CommonWizard):
                 settingsform.save()
             else:
                 log.warn(
-                    'Active Directory data failed to validate: %r',
+                    'Settings form failed to validate: %r',
                     settingsform._errors,
                 )
         except Exception:


### PR DESCRIPTION
This PR aims to fix bugs in legacy wizard where settings weren't saved if a certificate was configured and AD values were not being retained in the db when specified in legacy Wizard even if the validation passed in the legacy wizard.

Ticket: NAS-101592