### PR TITLE
fix initialization of passdb.tdb

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -9,7 +9,6 @@ import asyncio
 import binascii
 import codecs
 import enum
-import errno
 import os
 import re
 import subprocess


### PR DESCRIPTION
Slightly alter usage of python binding. New usage ensures that
passdb.tdb is created if it doesn't exist.