### PR TITLE
NAS-101661 / 11.3 / feat(jail/create): Allow specifying https fetching with create

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -114,7 +114,8 @@ class JailService(CRUDService):
             Bool("basejail", default=False),
             Bool("empty", default=False),
             Bool("short", default=False),
-            List("props", default=[])
+            List("props", default=[]),
+            Bool('https', default=True)
         )
     )
     async def do_create(self, options):
@@ -168,6 +169,7 @@ class JailService(CRUDService):
         props = options["props"]
         pool = IOCJson().json_get_value("pool")
         iocroot = IOCJson(pool).json_get_value("iocroot")
+        https = options.get('https', True)
 
         if template:
             release = template
@@ -179,7 +181,7 @@ class JailService(CRUDService):
         ):
             job.set_progress(50, f'{release} missing, calling fetch')
             self.middleware.call_sync(
-                'jail.fetch', {"release": release}, job=True
+                'jail.fetch', {"release": release, "https": https}, job=True
             )
 
         err, msg = iocage.create(


### PR DESCRIPTION
If the requested RELEASE does not exist, create will fetch it. This bool will be passed along to the fetch method

NAS-101661

Signed-off-by: Brandon Schneider <brandon@ixsystems.com>