### PR TITLE
NAS-101662 / 11.3 / Correct syslog level case

### DIFF
--- a/src/middlewared/middlewared/etc_files/syslogd.py
+++ b/src/middlewared/middlewared/etc_files/syslogd.py
@@ -35,7 +35,7 @@ def generate_syslog_conf(middleware):
             host, port = config["syslogserver"], "514"
 
         syslog_conf += f'destination loghost {{ udp("{host}" port({port}) localport(514)); }};\n'
-        syslog_conf += f'log {{ source(src); filter({config["sysloglevel"]}); destination(loghost); }};'
+        syslog_conf += f'log {{ source(src); filter({config["sysloglevel"].lower()}); destination(loghost); }};\n'
 
     with open("/etc/local/syslog-ng.conf", "w") as f:
         f.write(syslog_conf)


### PR DESCRIPTION
This commit fixes a bug where we did not change the syslog level to lowercase which resulted in the level not being a valid filter as levels are defined in lowercase for filters in syslog-ng conf file.