### PR TITLE
NAS-101633 / 11.3 / Set default ACL on dataset creation and fix misc issues with 'apply d…

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -309,11 +309,17 @@ class FilesystemService(Service):
     def getacl(self, path, simplified=True):
         """
         Return ACL of a given path.
+
         Simplified returns a shortened form of the ACL permset and flags
+
         - TRAVERSE = sufficient rights to traverse a directory, but not read contents.
+
         - READ = sufficient rights to traverse a directory, and read file contents.
+
         - MODIFIY = sufficient rights to traverse, read, write, and modify a file. Equivalent to modify_set.
+
         - FULL_CONTROL = all permissions.
+
         - OTHER = does not fit into any of the above categories without losing information.
 
         In all cases we replace USER_OBJ, GROUP_OBJ, and EVERYONE with owner@, group@, everyone@ for
@@ -388,7 +394,7 @@ class FilesystemService(Service):
                         Bool('WRITE_ACL'),
                         Bool('WRITE_OWNER'),
                         Bool('SYNCHRONIZE'),
-                        Str('BASIC', enum=['FULL_CONTROL', 'MODIFY', 'READ', 'OTHER']),
+                        Str('BASIC', enum=['FULL_CONTROL', 'MODIFY', 'READ', 'TRAVERSE']),
                     ),
                     Dict(
                         'flags',
@@ -397,7 +403,7 @@ class FilesystemService(Service):
                         Bool('NO_PROPAGATE_INHERIT'),
                         Bool('INHERIT_ONLY'),
                         Bool('INHERITED'),
-                        Str('BASIC', enum=['INHERIT', 'NOINHERIT', 'OTHER']),
+                        Str('BASIC', enum=['INHERIT', 'NOINHERIT']),
                     ),
                 )
             ],
@@ -414,12 +420,15 @@ class FilesystemService(Service):
     def setacl(self, job, path, dacl, options):
         """
         Set ACL of a given path. Takes the following parameters:
-        :path: realpath or relative path. We make a subsequent realpath call to resolve it.
-        :dacl: Accept a "simplified" ACL here or a full ACL. If the simplified ACL
-        contains ACE perms or flags that are "SPECIAL", then raise a validation error.
-        :recursive: apply the ACL recursively
-        :traverse: traverse filestem boundaries (ZFS datasets)
-        :strip: convert ACL to trivial. ACL is trivial if it can be expressed as a file mode without
+        `path` full path to directory or file.
+
+        `dacl` "simplified" ACL here or a full ACL.
+
+        `recursive` apply the ACL recursively
+
+        `traverse` traverse filestem boundaries (ZFS datasets)
+
+        `strip` convert ACL to trivial. ACL is trivial if it can be expressed as a file mode without
         losing any access rules.
 
         In all cases we replace USER_OBJ, GROUP_OBJ, and EVERYONE with owner@, group@, everyone@ for

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -460,7 +460,7 @@ class FilesystemService(Service):
                     'id': entry['id'],
                     'type': entry['type'],
                     'perms': self.__convert_to_adv_permset(entry['perms']['BASIC']) if 'BASIC' in entry['perms'] else entry['perms'],
-                    'flags': self.__convert_to_adv_flagset(entry['flags']['BASIC']) if 'BASIC' in entry['perms'] else entry['flags'],
+                    'flags': self.__convert_to_adv_flagset(entry['flags']['BASIC']) if 'BASIC' in entry['flags'] else entry['flags'],
                 }
                 if ace['tag'] == 'EVERYONE' and self.__convert_to_basic_permset(ace['perms']) == 'NOPERMS':
                     lockace_is_present = True

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -2643,12 +2643,14 @@ class PoolDatasetService(CRUDService):
                 'notifier.change_dataset_share_type', data['name'], data.get('share_type', 'UNIX').lower()
             )
             if data.get('share_type', 'UNIX') == 'WINDOWS':
-                dataset = await self.middleware.call('zfs.dataset.query', [('name', '=', data['name'])])
+                dataset = await self.middleware.call('zfs.dataset.query', [('id', '=', data['id'])])
                 setacl_job = await self.middleware.call('filesystem.setacl', dataset[0]['mountpoint'], [
                     {"tag": "owner@", "id": None, "type": "ALLOW", "perms": {"BASIC": "FULL_CONTROL"}, "flags": {"BASIC": "INHERIT"}},
                     {"tag": "group@", "id": None, "type": "ALLOW", "perms": {"BASIC": "FULL_CONTROL"}, "flags": {"BASIC": "INHERIT"}}
                 ])
                 await setacl_job.wait()
+                if setacl_job.error:
+                    raise CallError(setacl_job.error)
 
         return await self._get_instance(data['id'])
 

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -2642,6 +2642,13 @@ class PoolDatasetService(CRUDService):
             await self.middleware.call(
                 'notifier.change_dataset_share_type', data['name'], data.get('share_type', 'UNIX').lower()
             )
+            if data.get('share_type', 'UNIX') == 'WINDOWS':
+                dataset = await self.middleware.call('zfs.dataset.query', [('name', '=', data['name'])])
+                setacl_job = await self.middleware.call('filesystem.setacl', dataset[0]['mountpoint'], [
+                    {"tag": "owner@", "id": None, "type": "ALLOW", "perms": {"BASIC": "FULL_CONTROL"}, "flags": {"BASIC": "INHERIT"}},
+                    {"tag": "group@", "id": None, "type": "ALLOW", "perms": {"BASIC": "FULL_CONTROL"}, "flags": {"BASIC": "INHERIT"}}
+                ])
+                await setacl_job.wait()
 
         return await self._get_instance(data['id'])
 

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -905,9 +905,7 @@ class SharingSMBService(CRUDService):
                 },
             ])
 
-        job = await self.middleware.call('filesystem.setacl', path, acl, {'recursive': True, 'traverse': True})
-        if job.error:
-            raise CallError(job.error)
+        await self.middleware.call('filesystem.setacl', path, acl, {'recursive': True, 'traverse': True})
 
     @private
     async def generate_vuid(self, timemachine, vuid=""):

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -875,7 +875,7 @@ class SharingSMBService(CRUDService):
                     "id": None,
                     "type": "ALLOW",
                     "perms": {"BASIC": "MODIFY"},
-                    "flags": {'DIRECTORY_INHERIT': True, 'INHERIT_ONLY': True}
+                    "flags": {'DIRECTORY_INHERIT': True, 'INHERIT_ONLY': True, 'NO_PROPAGATE_INHERIT': True}
                 },
                 {
                     "tag": "everyone@",

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -809,17 +809,103 @@ class SharingSMBService(CRUDService):
 
     @private
     async def apply_default_perms(self, default_perms, path, is_home):
-        if default_perms:
-            try:
-                stat = await self.middleware.call('filesystem.stat', path)
-                owner = stat['user'] or 'root'
-                group = stat['group'] or 'wheel'
-            except Exception:
-                (owner, group) = ('root', 'wheel')
+        """
+        Reset permissions on an SMB share to "default". This is a recursive
+        operaton, and will replace any existing ACL on the share path and any
+        sub-datasets. The default ACLS depends on whether this is a `[homes]`
+        share. Shares that are not the special "homes" share have the
+        following ACL:
 
-            await self.middleware.call(
-                'notifier.winacl_reset', path, owner, group, None, not is_home
-            )
+        `owner@:full_set:fd:allow`
+
+        `group@:full_set:fd:allow`
+
+        The path to homes shares are dynamically generated via pam_mkhomedir
+        The final path (the user's actual home directory) will only have the
+        following ACE:
+
+        `owner@:full_set:fd:allow`
+
+        The actual ACL written on the path specified in the UI will vary for
+        homes shares depending on whether Active Directory is enabled. In all
+        cases, the ACL is written so that users have adequate permissions to
+        traverse to their home directory and the actual home directory is only
+        accessible by the user.
+
+        If an SMB admin group has been selected, then it will also be added to the
+        share's ACL.
+        """
+        if not default_perms:
+            return
+
+        acl = []
+        admin = None
+        smb = await self.middleware.call('smb.config')
+        if smb['admin_group']:
+            admin = await self.middleware.call('notifier.get_group_object', smb['admin_group'])
+            acl.append({
+                "tag": "GROUP",
+                "id": admin[2],
+                "type": "ALLOW",
+                "perms": {"BASIC": "FULL_CONTROL"},
+                "flags": {"BASIC": "INHERIT"}
+            })
+
+        acl.append({
+            "tag": "owner@",
+            "id": None,
+            "type": "ALLOW",
+            "perms": {"BASIC": "FULL_CONTROL"},
+            "flags": {"BASIC": "INHERIT"},
+        })
+
+        if not is_home:
+            acl.append({
+                "tag": "group@",
+                "id": None,
+                "type": "ALLOW",
+                "perms": {"BASIC": "FULL_CONTROL"},
+                "flags": {"BASIC": "INHERIT"},
+            })
+
+        elif await self.middleware.call('activedirectory.get_state') != 'DISABLED':
+            acl.extend([
+                {
+                    "tag": "group@",
+                    "id": None,
+                    "type": "ALLOW",
+                    "perms": {"BASIC": "MODIFY"},
+                    "flags": {"INHERIT_ONLY": True}
+                },
+                {
+                    "tag": "everyone@",
+                    "id": None,
+                    "type": "ALLOW",
+                    "perms": {"BASIC": "TRAVERSE"},
+                    "flags": {"BASIC": "NOINHERIT"}
+                },
+            ])
+
+        else:
+            acl.extend([
+                {
+                    "tag": "group@",
+                    "id": None,
+                    "type": "ALLOW",
+                    "perms": {"BASIC": "MODIFY"},
+                    "flags": {"BASIC": "NOINHERIT"}
+                },
+                {
+                    "tag": "everyone@",
+                    "id": None,
+                    "type": "ALLOW",
+                    "perms": {"BASIC": "TRAVERSE"},
+                    "flags": {"BASIC": "NOINHERIT"}
+                },
+            ])
+
+        job = await self.middleware.call('filesystem.setacl', path, acl, {'recursive': True, 'traverse': True})
+        await job.wait()
 
     @private
     async def generate_vuid(self, timemachine, vuid=""):

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -875,7 +875,7 @@ class SharingSMBService(CRUDService):
                     "id": None,
                     "type": "ALLOW",
                     "perms": {"BASIC": "MODIFY"},
-                    "flags": {"INHERIT_ONLY": True}
+                    "flags": {'DIRECTORY_INHERIT': True, 'INHERIT_ONLY': True}
                 },
                 {
                     "tag": "everyone@",


### PR DESCRIPTION
…efault permissions'

- Add more intelligent 'default' permissions
- Remove default 'everyone@' entry in most situations
- Apply ACL on dataset creation for "windows" permissions type (prep for GUI ACL editor).