### PR TITLE
NAS-101720 / 11.3 / Add guard-rails for vfs_noacl

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4_share.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4_share.conf
@@ -37,12 +37,19 @@
             return ret
 
         def order_vfs_objects(vfs_objects):
-            vfs_objects_special = ('catia', 'zfs_space', 'zfsacl', 'fruit', 'streams_xattr', 'crossrename', 'recycle')
+            vfs_objects_special = ('catia', 'zfs_space', 'noacl', 'zfsacl',
+                                   'fruit', 'streams_xattr', 'crossrename', 'recycle')
             vfs_objects_ordered = []
 
             if 'fruit' in vfs_objects:
                 if 'streams_xattr' not in vfs_objects:
                     vfs_objects.append('streams_xattr')
+
+            if 'noacl' in vfs_objects:
+                if 'zfsacl' not in vfs_objects:
+                    vfs_objects.append('zfsacl')
+                if 'ixnas' in vfs_objects:
+                    vfs_objects.pop('ixnas')
 
             for obj in vfs_objects:
                 if obj not in vfs_objects_special:


### PR DESCRIPTION
- smbd won't let users connect to the share if it has an extended ACL.
  Add middleware validation error to shift confusion.
- Take steps to ensure that noacl is properly stacked with zfsacl
- Prevent 'apply default permissions' from clobbering a share with noacl enabled.