### PR TITLE
NAS-101562 / 11.3 / Register upgraded disks capacity

### DIFF
--- a/src/middlewared/middlewared/plugins/boot.py
+++ b/src/middlewared/middlewared/plugins/boot.py
@@ -202,6 +202,10 @@ class BootService(Service):
 
         await job.wrap(extend_pool_job)
 
+        # If the user is upgrading his disks, let's set expand to True to make sure that we
+        # register the new disks capacity which increase the size of the pool
+        await self.middleware.call('zfs.pool.online', 'freenas-boot', f'{dev}p2', True)
+
     @accepts(Str('dev'))
     async def detach(self, dev):
         """


### PR DESCRIPTION
This PR fixes a bug where when a user upgraded his boot pool with new disks to increase it's size, the pool didn't register the new size.
Ticket: #101562