### PR TITLE
NAS-101531 / 11.3 / fix(jail/fstab): Add more validation

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -670,7 +670,10 @@ class JailService(CRUDService):
         Str("jail"),
         Dict(
             "options",
-            Str("action", enum=["ADD", "EDIT", "REMOVE", "REPLACE", "LIST"], required=True),
+            Str(
+                "action", enum=["ADD", "EDIT", "REMOVE", "REPLACE", "LIST"],
+                required=True
+            ),
             Str("source"),
             Str("destination"),
             Str("fstype", default='nullfs'),
@@ -680,10 +683,11 @@ class JailService(CRUDService):
             Int("index", default=None),
         ))
     def fstab(self, jail, options):
-        """Adds an fstab mount to the jail"""
+        """Manipulate a jails fstab"""
         uuid, _, iocage = self.check_jail_existence(jail, skip=False)
         status, jid = IOCList.list_get_jid(uuid)
         action = options['action'].lower()
+        index = options.get('index')
 
         if status and action != 'list':
             raise CallError(
@@ -698,10 +702,16 @@ class JailService(CRUDService):
                     'options.source',
                     'Provided path for source does not exist'
                 )
+        elif (not source and index is None) and action != 'list':
+            verrors.add(
+                'options.source',
+                'Provide a source path'
+            )
 
         destination = options.get('destination')
         if destination:
-            destination = f'/{destination}' if destination[0] != '/' else destination
+            destination = f'/{destination}' if destination[0] != '/' else \
+                destination
             dst = f'{self.get_iocroot()}/jails/{jail}/root'
             if dst not in destination:
                 destination = f'{dst}{destination}'
@@ -710,7 +720,8 @@ class JailService(CRUDService):
                 if not os.path.isdir(destination):
                     verrors.add(
                         'options.destination',
-                        'Destination is not a directory, please provide a valid destination'
+                        'Destination is not a directory, please provide a'
+                        ' valid destination'
                     )
                 elif os.listdir(destination):
                     verrors.add(
@@ -719,6 +730,16 @@ class JailService(CRUDService):
                     )
             else:
                 os.makedirs(destination)
+        elif (not destination and index is None) and action != 'list':
+            verrors.add(
+                'options.destination',
+                'Provide a destination path'
+            )
+
+        if index is not None:
+            # Setup defaults for library
+            source = ''
+            destination = ''
 
         if action != 'list':
             for f in options:
@@ -732,7 +753,6 @@ class JailService(CRUDService):
         fsoptions = options.get('fsoptions')
         dump = options.get('dump')
         _pass = options.get('pass')
-        index = options.get('index')
 
         if action == 'replace' and index is None:
             verrors.add(


### PR DESCRIPTION
FreeNAS side for https://github.com/iocage/iocage/pull/923

If an index is not supplied and the action isn’t LIST, we expect a source and destination. In addition we supply a default for source and destination if an index is supplied.

NAS-101531

Signed-off-by: Brandon Schneider <brandon@ixsystems.com>