### PR TITLE
NAS-101762 / 11.2 / Move cachetool to middleware job

### DIFF
--- a/src/freenas/etc/directoryservice/ActiveDirectory/ctl
+++ b/src/freenas/etc/directoryservice/ActiveDirectory/ctl
@@ -150,7 +150,7 @@ adctl_start()
 	cifs_restart
 
 	adctl_cmd ${service} ix-pam quietstart
-	adctl_cmd "${service} ix-cache quietstart &"
+	adctl_cmd ${python} ${notifier} call notifier.cachetool fill > /dev/null
 
 	touch "${status_file}"
 	rm "${start_file}"

--- a/src/freenas/etc/directoryservice/LDAP/ctl
+++ b/src/freenas/etc/directoryservice/LDAP/ctl
@@ -185,7 +185,7 @@ ldapctl_start()
 	fi
 
 	ldapctl_cmd ${service} ix-pam quietstart
-	ldapctl_cmd "${service} ix-cache quietstart &"
+	ldapctl_cmd ${python} ${notifier} call notifier.cachetool fill > /dev/null
 	touch "${status_file}"
 
 	return 0

--- a/src/freenas/etc/directoryservice/NIS/ctl
+++ b/src/freenas/etc/directoryservice/NIS/ctl
@@ -7,7 +7,7 @@ status_file="/var/run/directoryservice.nis"
 
 nisctl_cache_fill()
 {
-	LD_LIBRARY_PATH=/usr/local/lib /usr/local/www/freenasUI/tools/cachetool.py fill &
+	LD_LIBRARY_PATH=/usr/local/lib /usr/local/bin/midclt call notifier.cachetool fill > /dev/null
 }
 
 nisctl_cache_expire()

--- a/src/freenas/etc/ix.rc.d/ix-cache
+++ b/src/freenas/etc/ix.rc.d/ix-cache
@@ -14,7 +14,7 @@ populate_cache()
 		dirsrv_enabled nis ||
 		dirsrv_enabled ldap
 	then
-		/usr/local/www/freenasUI/tools/cachetool.py fill
+		LD_LIBRARY_PATH=/usr/local/lib /usr/local/bin/midclt call notifier.cachetool fill > /dev/null
 	fi
 }
 

--- a/src/freenas/etc/ix.rc.d/ix-nis
+++ b/src/freenas/etc/ix.rc.d/ix-nis
@@ -11,7 +11,7 @@ nis_start()
 {
         if dirsrv_enabled nis
         then
-                LD_LIBRARY_PATH=/usr/local/lib /usr/local/www/freenasUI/tools/cachetool.py fill
+		LD_LIBRARY_PATH=/usr/local/lib /usr/local/bin/midclt call notifier.cachetool fill > /dev/null
         fi
 }
 

--- a/src/middlewared/middlewared/plugins/notifier.py
+++ b/src/middlewared/middlewared/plugins/notifier.py
@@ -44,7 +44,7 @@ from freenasUI.directoryservice.models import (
 )
 from freenasUI.directoryservice.utils import get_idmap_object
 
-from middlewared.utils import Popen, django_modelobj_serialize
+from middlewared.utils import django_modelobj_serialize
 
 
 logger = logging.getLogger('plugins.notifier')

--- a/src/middlewared/middlewared/plugins/notifier.py
+++ b/src/middlewared/middlewared/plugins/notifier.py
@@ -246,7 +246,7 @@ class NotifierService(Service):
         if cachetool_job.error:
             raise CallError(f'cachetool expire failed with error {cachetool_job.error}')
 
-        self.middleware.call('notifier.cachetool', 'fill')
+        await self.middleware.call('notifier.cachetool', 'fill')
 
     def samba4(self, name, args=None):
         """Temporary wrapper to use Samba4 over middlewared"""


### PR DESCRIPTION
Cachetool fill can very long-running and cause middleware timeouts. Change this to a job.