### PR TITLE
NAS-101773 / 11.3 / fix(jail/list_resource): Allow specifying branch

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -514,9 +514,10 @@ class JailService(CRUDService):
     @accepts(
         Str("resource", enum=["RELEASE", "TEMPLATE", "PLUGIN"]),
         Bool("remote", default=False),
-        Bool('want_cache', default=True)
+        Bool('want_cache', default=True),
+        Str('branch', default=None)
     )
-    def list_resource(self, resource, remote, want_cache):
+    def list_resource(self, resource, remote, want_cache, branch):
         """Returns a JSON list of the supplied resource on the host"""
         self.check_dataset_existence()  # Make sure our datasets exist.
         iocage = ioc.IOCage(skip_jails=True)
@@ -534,7 +535,7 @@ class JailService(CRUDService):
                         pass
 
                 resource_list = iocage.fetch(list=True, plugins=True,
-                                             header=False)
+                                             header=False, branch=branch)
             else:
                 resource_list = iocage.list("all", plugin=True)
                 pool = IOCJson().json_get_value("pool")
@@ -1038,6 +1039,8 @@ class JailService(CRUDService):
             return ['N/A', '1']
         elif pkg == 'sickrage':
             return ['Git branch - master', '1']
+        elif pkg == 'asigra':
+            return ['14.1-20190301', '1']
 
         try:
             primary_pkg = r_plugins[pkg]['primary_pkg'].split('/', 1)[-1]


### PR DESCRIPTION
This PR allows specifying the branch for the remote plugin resource. In addition some special handling for asigra’s version as it is not a package

NAS-101773

Signed-off-by: Brandon Schneider <brandon@ixsystems.com>