### PR TITLE
NAS-101778 / 11.2 / Allow getting disktemp for non-fatal smartctl exit statuses

### DIFF
--- a/src/freenas/usr/local/lib/collectd_pyplugins/disktemp.py
+++ b/src/freenas/usr/local/lib/collectd_pyplugins/disktemp.py
@@ -183,7 +183,7 @@ class DiskTemp(object):
             except Exception:
                 pass
         cp = subprocess.run(['/usr/local/sbin/smartctl', '-a', '-n', 'standby', f'/dev/{disk}'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        if (cp.returncode & 7) != 0:
+        if (cp.returncode & 0b11) != 0:
             collectd.info(f'Failed to run smartctl for {disk}: {cp.stdout.decode("utf8", "ignore")}')
             return None
 

--- a/src/freenas/usr/local/lib/collectd_pyplugins/disktemp.py
+++ b/src/freenas/usr/local/lib/collectd_pyplugins/disktemp.py
@@ -183,7 +183,7 @@ class DiskTemp(object):
             except Exception:
                 pass
         cp = subprocess.run(['/usr/local/sbin/smartctl', '-a', '-n', 'standby', f'/dev/{disk}'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        if cp.returncode != 0:
+        if (cp.returncode & 7) != 0:
             collectd.info(f'Failed to run smartctl for {disk}: {cp.stdout.decode("utf8", "ignore")}')
             return None
 


### PR DESCRIPTION
Fixes a problem where Freenas reports disk temperature "N/A" for one of my disks. The disk in question has smart errors which it got from a failed sata port but is otherwise fully functioning. smartctl reports an exit status of 64 for the disk and therefore the script doesn't fetch the disk temperature.

https://www.smartmontools.org/browser/trunk/smartmontools/smartctl.8.in#lbAH