### PR TITLE
NAS-101816 / 11.3 / Generate SSL certs after signing cert

### DIFF
--- a/src/middlewared/middlewared/plugins/crypto.py
+++ b/src/middlewared/middlewared/plugins/crypto.py
@@ -1928,6 +1928,8 @@ class CertificateAuthorityService(CRUDService):
             {'prefix': 'cert_'}
         )
 
+        await self.middleware.call('service.start', 'ssl')
+
         return await self.middleware.call(
             'certificate.query',
             [['id', '=', new_csr_id]],


### PR DESCRIPTION
This commit fixes a bug where we didn't generate the newly signed certificate after it is signed by the CA.