### PR TITLE
NAS-101887 / 11.3 / Remove nut_upsshut from rc.conf

### DIFF
--- a/src/middlewared/middlewared/etc_files/rc.conf.py
+++ b/src/middlewared/middlewared/etc_files/rc.conf.py
@@ -279,7 +279,6 @@ def nut_config(middleware, context):
     ups = middleware.call_sync('ups.config')
     if ups['mode'] == 'MASTER':
         yield 'nut_enable="YES"'
-        yield 'nut_upsshut="NO"'
         yield f'nut_upslog_ups="{ups["identifier"]}"'
     else:
         yield f'nut_upslog_ups="{ups["identifier"]}@{ups["remotehost"]}:{ups["remoteport"]}"'


### PR DESCRIPTION
This commit removes nut_upsshut rc var from rc.conf as it is no longer needed and upstream has fixed it by adding a reasonable default to nut rc script which wasn't there before.
Ticket: #NAS-101887