### PR TITLE
NAS-101879 / 11.2 / Make sure webdav conf files are generated

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-apache
+++ b/src/freenas/etc/ix.rc.d/ix-apache
@@ -165,31 +165,10 @@ __EOF__
 
 }
 
-generate_webdav_conf ()
-{
-    # First check if the webdav service is enabled or not.
-    # We do this here as executing a django query just for this one value
-    # would be expensive.
-    if checkyesno apache24_enable; then
-        # The service is enabled so call its python-based config generator
-        /usr/local/bin/python /usr/local/libexec/nas/generate_webdav_conf.py
-    else
-        # webdav is disabled, we now write blanks to the webdav config files
-        echo "" > /etc/local/apache24/Includes/webdav.conf
-        echo "" > /etc/local/apache24/Includes/webdav-ssl.conf
-        # Note: This (below) is a hack. We bind apache to some random port when webdav shares are absent
-        # The purpose of this is to facilitate apache to run even in the absence of a secondary config
-        # file. Else, it will try to bind to port 80 and fail as nginx is using it and thus spit out a
-        # mesaage stating that unable to bind to port, cannot create logs.
-        echo "Listen 8080" >> /etc/local/apache24/httpd.conf
-    fi
-
-}
-
 ix_apache_start()
 {
     generate_httpd_conf
-    generate_webdav_conf
+    /usr/local/bin/python /usr/local/libexec/nas/generate_webdav_conf.py
 }
 
 name="ix-apache"


### PR DESCRIPTION
This commit makes sure that webdav configuration files are always generated irrespective of it's setting to start at boot as the user can still use the service without setting that option.
Ticket: #NAS-101879