### PR TITLE
NAS-101244 / 11.2 / Point to System version documentation

### DIFF
--- a/gui/freeadmin/site.py
+++ b/gui/freeadmin/site.py
@@ -224,7 +224,9 @@ class FreeAdminSite(object):
         sw_version = get_sw_version()
         version = get_sw_version(strip_build_num=True)
         sw_version_footer = version.split('-', 1)[-1]
-        sw_version_major = version.split('-')[1]
+        sw_version_complete = version.split('-', 1)[1]
+        if any(k in sw_version_complete.lower() for k in ('master', 'release')):
+            sw_version_complete = sw_version_complete.split('-')[0]
 
         return render(request, 'freeadmin/index.html', {
             'consolemsg': console,
@@ -233,7 +235,7 @@ class FreeAdminSite(object):
             'sw_year': get_sw_year(),
             'sw_version': sw_version,
             'sw_version_footer': sw_version_footer,
-            'sw_version_major': sw_version_major,
+            'sw_version_complete': sw_version_complete,
             'cache_hash': hashlib.md5(sw_version.encode('utf8')).hexdigest(),
             'css_hook': appPool.get_base_css(request),
             'js_hook': appPool.get_base_js(request),

--- a/gui/templates/freeadmin/index.html
+++ b/gui/templates/freeadmin/index.html
@@ -27,7 +27,7 @@ menuSetURLs = function() {
     Menu.urlSharing = '{% url "sharing_home" %}';
     Menu.urlStorage = '{% url "storage_home" %}';
     Menu.urlSupport = '{% url "support_home" %}';
-    Menu.urlDocumentation = 'https://www.ixsystems.com/documentation/{{ sw_name|lower }}/{{ sw_version_major }}{% if sw_name|lower == "freenas" %}-legacy{% endif %}/';
+    Menu.urlDocumentation = 'https://www.ixsystems.com/documentation/{{ sw_name|lower }}/{{ sw_version_complete }}{% if sw_name|lower == "freenas" %}-legacy{% endif %}/';
     Menu.urlSystem = '{% url "system_home" %}';
     Menu.urlTasks = '{% url "tasks_home" %}';
     Menu.urlVM = '{% url "vm_home" %}';


### PR DESCRIPTION
This commit introduces changes which make sure that we always point to the current system's documentation and not load the latest documentation. For nightlies we point to 11.VERSION-RELEASE docs.
Ticket: #NAS-101244