### PR TITLE
NAS-101916 / 11.3 / Multiple fixes in AD and idmap plugins

### DIFF
--- a/gui/freeadmin/forms.py
+++ b/gui/freeadmin/forms.py
@@ -100,7 +100,7 @@ class UserField(forms.ChoiceField):
         from freenasUI.account.forms import FilteredSelectJSON
         try:
             with client as c:
-                users = c.call('dscache.query', 'USERS', '', {'order_by': ['pw_name']})
+                users = c.call('users.query', {'extra': {'search_dscache': True}})
         except:
             users = []
         kwargs = {
@@ -175,7 +175,7 @@ class GroupField(forms.ChoiceField):
         from freenasUI.account.forms import FilteredSelectJSON
         try:
             with client as c:
-                groups = c.call('dscache.query', 'GROUPS', '', {'order_by': ['gr_name']})
+                groups = c.call('groups.query', {'extra': {'search_dscache': True}})
         except:
             groups = []
         kwargs = {

--- a/src/middlewared/middlewared/plugins/idmap.py
+++ b/src/middlewared/middlewared/plugins/idmap.py
@@ -42,7 +42,7 @@ class IdmapService(Service):
 
         backend_entry = await self.middleware.call(
             f'idmap.{my_domain[0]["idmap_backend"].lower()}.query',
-            [('domain', '=', domain)]
+            [('domain.idmap_domain_name', '=', domain)]
         )
         if backend_entry:
             return backend_entry[0]
@@ -83,7 +83,7 @@ class IdmapService(Service):
         if ds_type not in ['DS_TYPE_ACTIVEDIRECTORY', 'DS_TYPE_LDAP', 'DS_TYPE_DEFAULT_DOMAIN']:
             raise CallError(f'idmap backends are not supported for {ds_type}')
 
-        res = await self.middleware.call(f'idmap.{idmap_type}.query', [('domain', '=', ds_type)])
+        res = await self.middleware.call(f'idmap.{idmap_type}.query', [('domain.idmap_domain_name', '=', ds_type)])
         if res:
             return {
                 'idmap_id': res[0]['id'],
@@ -197,7 +197,7 @@ class IdmapService(Service):
         except Exception as e:
             self.logger.debug("Failed to remove winbindd_cache.tdb: %s" % e)
 
-        await self.middleware.call('service.start', 'smb')
+        await self.middleware.call('service.start', 'cifs')
         gencache_flush = await run(['net', 'cache', 'flush'], check=False)
         if gencache_flush.returncode != 0:
             raise CallError(f'Attempt to flush gencache failed with error: {gencache_flush.stderr.decode().strip()}')


### PR DESCRIPTION
- Use ‘user.query ‘ and ‘group.query’ to populate dropdowns in legacy UI
- Raise validation error if user selects key tab and password auth
- kinit prior to attempting to validate with key tab.
- Fix case in various places
- Sort AD users and groups prior to storing
- Fix filters for idmap plugin.