### PR TITLE
NAS-101961 / 11.3 / Improve permissions handling

### DIFF
--- a/gui/choices.py
+++ b/gui/choices.py
@@ -902,7 +902,7 @@ SAMBA4_FOREST_LEVEL_CHOICES = (
 )
 
 SHARE_TYPE_CHOICES = (
-    ('GENERAL', 'General'),
+    ('GENERIC', 'Generic'),
     ('SMB', 'SMB'),
 )
 

--- a/gui/choices.py
+++ b/gui/choices.py
@@ -306,6 +306,11 @@ VLAN_PCP_CHOICES = (
     (7, _('Network control (highest)')),
 )
 
+ZFS_AclmodeChoices = (
+    ('passthrough', _('Passthrough')),
+    ('restricted', _('Restricted')),
+)
+
 ZFS_AtimeChoices = (
     ('inherit', _('Inherit')),
     ('on', _('On')),
@@ -897,9 +902,8 @@ SAMBA4_FOREST_LEVEL_CHOICES = (
 )
 
 SHARE_TYPE_CHOICES = (
-    ('unix', 'UNIX'),
-    ('windows', 'Windows'),
-    ('mac', 'Mac')
+    ('GENERAL', 'General'),
+    ('SMB', 'SMB'),
 )
 
 CASE_SENSITIVITY_CHOICES = (

--- a/gui/freeadmin/static/lib/js/freeadmin.js
+++ b/gui/freeadmin/static/lib/js/freeadmin.js
@@ -721,23 +721,6 @@ require([
         editbtn.placeAt(td);
     }
 
-    mpAclChange = function(acl) {
-      var mode_en = registry.byId("id_mp_mode_en");
-      var mode = registry.byId("id_mp_mode");
-      if(acl.get('value') === false) {
-        // do noting
-      } else if(acl.get('value') == 'unix') {
-        mode_en.set('disabled', false);
-        mode.set('disabled', false);
-      } else if(acl.get('value') == 'mac') {
-        mode_en.set('disabled', false);
-        mode.set('disabled', false);
-      } else {
-        mode_en.set('disabled', true);
-        mode.set('disabled', true);
-      }
-    }
-
     genericSelectFields = function(selectid, map) {
       /*
        * Show and hide fields base on the value of a single widget.

--- a/gui/freeadmin/static/lib/js/freeadmin.js
+++ b/gui/freeadmin/static/lib/js/freeadmin.js
@@ -727,7 +727,6 @@ require([
       if(acl.get('value') === false) {
         // do nothing
       } else if(acl.get('value') == 'remove') {
-        console.log("remove");
         mode_en.set('disabled', false);
         mode.set('disabled', false);
       } else {

--- a/gui/freeadmin/static/lib/js/freeadmin.js
+++ b/gui/freeadmin/static/lib/js/freeadmin.js
@@ -721,6 +721,21 @@ require([
         editbtn.placeAt(td);
     }
 
+    mpAclChange = function(acl) {
+      var mode_en = registry.byId("id_mp_mode_en");
+      var mode = registry.byId("id_mp_mode");
+      if(acl.get('value') === false) {
+        // do nothing
+      } else if(acl.get('value') == 'remove') {
+        console.log("remove");
+        mode_en.set('disabled', false);
+        mode.set('disabled', false);
+      } else {
+        mode_en.set('disabled', true);
+        mode.set('disabled', true);
+      }
+    }
+
     genericSelectFields = function(selectid, map) {
       /*
        * Show and hide fields base on the value of a single widget.

--- a/gui/middleware/notifier.py
+++ b/gui/middleware/notifier.py
@@ -67,9 +67,6 @@ if not apps.app_configs:
 from django.utils.translation import ugettext as _
 
 from freenasUI.common.pipesubr import SIG_SETMASK
-from freenasUI.common.system import (
-    exclude_path,
-)
 from freenasUI.freeadmin.hook import HookMetaclass
 from freenasUI.middleware import zfs
 from freenasUI.middleware.client import client
@@ -422,18 +419,18 @@ class notifier(metaclass=HookMetaclass):
                     ],
                     uid,
                     gid,
-                    {'recursive':True, 'traverse': recursive}
+                    {'recursive': True, 'traverse': recursive}
                 )
 
         else:
             with client as c:
                 c.call(
-                     'filesystem.setperm',
-                     path,
-                     kwargs['mode'],
-                     uid,
-                     gid,
-                     {'recursive':True, 'traverse': recursive}
+                    'filesystem.setperm',
+                    path,
+                    mode,
+                    uid,
+                    gid,
+                    {'recursive': True, 'traverse': recursive}
                 )
                 return True
 

--- a/gui/storage/forms.py
+++ b/gui/storage/forms.py
@@ -1717,7 +1717,7 @@ class MountPointAccessForm(Form):
             kwargs['user'] = self.cleaned_data['mp_user']
 
         if self.cleaned_data.get('mp_group_en'):
-            kwargs['mode'] = str(self.cleaned_data['mp_group'])
+            kwargs['group'] = str(self.cleaned_data['mp_group'])
 
         if self.cleaned_data.get('mp_mode_en'):
             kwargs['mode'] = str(self.cleaned_data['mp_mode'])

--- a/gui/storage/forms.py
+++ b/gui/storage/forms.py
@@ -1750,7 +1750,7 @@ class MountPointAccessForm(Form):
                     ],
                     uid,
                     gid,
-                    {'recursive':True, 'traverse': kwargs['traverse']}
+                    {'recursive': True, 'traverse': kwargs['traverse']}
                 )
                 return True
 
@@ -1758,16 +1758,16 @@ class MountPointAccessForm(Form):
             with client as c:
                 try:
                     c.call(
-                         'filesystem.setperm',
-                         path,
-                         kwargs.get('mode', None),
-                         uid,
-                         gid,
-                         {
-                             'recursive':True,
-                             'traverse': kwargs['traverse'],
-                             'stripacl': True if action == 'remove' else False
-                         }
+                        'filesystem.setperm',
+                        path,
+                        kwargs.get('mode', None),
+                        uid,
+                        gid,
+                        {
+                            'recursive': True,
+                            'traverse': kwargs['traverse'],
+                            'stripacl': True if action == 'remove' else False
+                        }
                     )
                     return True
                 except Exception as e:

--- a/gui/storage/forms.py
+++ b/gui/storage/forms.py
@@ -1656,16 +1656,6 @@ class MountPointAccessForm(Form):
             "of the dataset, but not extend to child datasets."
         )
     )
-    mp_traverse = forms.BooleanField(
-        initial=False,
-        required=False,
-        label=_('Apply to child datasets'),
-        help_text=_(
-            "Apply changes to dataset permissions to child datasets. "
-            "When this is unchecked, changes will be restricted to the "
-            "contents of the referenced dataset."
-        )
-    )
     mp_acl = forms.ChoiceField(
         label=_('Modify Access Control List'),
         choices=(
@@ -1681,9 +1671,18 @@ class MountPointAccessForm(Form):
             "form field is disabled when an ACL is present on the dataset. The "
             "'Remove' option will remove the ACL from the dataset, and enable "
             "the 'Mode' form field. The 'Apply Default' option will apply a default "
-            "ACL granting Owner 'Full Control', Group 'Full Control', and "
-            "everyone else 'Read Only' permissions to the dataset. Changes are committed "
-            "when the 'Change' button is clicked."
+            "ACL granting Owner 'Full Control', and Group 'Full Control'. "
+            "Changes are committed when the 'Change' button is clicked."
+        )
+    )
+    mp_traverse = forms.BooleanField(
+        initial=False,
+        required=False,
+        label=_('Apply to child datasets'),
+        help_text=_(
+            "Apply changes to dataset permissions to child datasets. "
+            "When this is unchecked, changes will be restricted to the "
+            "contents of the referenced dataset."
         )
     )
 

--- a/gui/storage/forms.py
+++ b/gui/storage/forms.py
@@ -1760,7 +1760,7 @@ class MountPointAccessForm(Form):
                     c.call(
                          'filesystem.setperm',
                          path,
-                         kwargs['mode'],
+                         kwargs.get('mode', None),
                          uid,
                          gid,
                          {

--- a/gui/storage/forms.py
+++ b/gui/storage/forms.py
@@ -1617,8 +1617,7 @@ class MountPointAccessForm(Form):
         initial=True,
         required=False,
         help_text=_(
-            "Recursively change the owner (user) of the contents of the ZFS "
-            "dataset. By default, changes will not extend to child datasets."
+            "Recursively change the user ownership of the ZFS dataset contents. "
         )
     )
     mp_user = UserField(label=_('Owner (user)'))
@@ -1627,8 +1626,7 @@ class MountPointAccessForm(Form):
         initial=True,
         required=False,
         help_text=_(
-            "Recursively change the owner (group) of the contents of the ZFS "
-            "dataset. By default, changes will not extend to child datasets."
+            "Recursively change the group ownership of the ZFS dataset contents. "
         )
     )
     mp_group = GroupField(label=_('Owner (group)'))
@@ -1638,21 +1636,20 @@ class MountPointAccessForm(Form):
         required=False,
         help_text=_(
             "Recursively apply the selected mode to the contents of "
-            "the referenced ZFS dataset. By default, changes to the "
-            "mode will not extend to child datasets."
+            "the referenced ZFS dataset."
         )
     )
     mp_mode = UnixPermissionField(
         label=_('Mode'),
         required=False,
         help_text=_(
-            "Graphical representation of the posix mode (permissions) "
+            "Graphical representation of the POSIX mode (permissions) "
             "at the root of the referenced dataset. This mode may not "
             "be representative of the contents of the dataset. This box "
             "is disabled when an Access Control List (ACL) is present on "
             "the dataset. In this situation, the ACL must be removed if "
             "a new posix mode is to be applied on the dataset. By default, "
-            "changes to the posix mode will recursively apply to the contents "
+            "changes to the POSIX mode will recursively apply to the contents "
             "of the dataset, but not extend to child datasets."
         )
     )
@@ -1670,9 +1667,8 @@ class MountPointAccessForm(Form):
             "typical use case where setting an ACL may be desireable. The 'Mode' "
             "form field is disabled when an ACL is present on the dataset. The "
             "'Remove' option will remove the ACL from the dataset, and enable "
-            "the 'Mode' form field. The 'Apply Default' option will apply a default "
-            "ACL granting Owner 'Full Control', and Group 'Full Control'. "
-            "Changes are committed when the 'Change' button is clicked."
+            "'Mode'. 'Apply Default' sets a default ACL granting Owner 'Full "
+            "Control' and Group 'Full Control'."
         )
     )
     mp_traverse = forms.BooleanField(
@@ -1680,9 +1676,9 @@ class MountPointAccessForm(Form):
         required=False,
         label=_('Apply to child datasets'),
         help_text=_(
-            "Apply changes to dataset permissions to child datasets. "
-            "When this is unchecked, changes will be restricted to the "
-            "contents of the referenced dataset."
+            "Apply dataset permissions changes to child datasets. "
+            "Unset for changes to be restricted to the contents of the "
+            "referenced dataset."
         )
     )
 
@@ -1699,6 +1695,7 @@ class MountPointAccessForm(Form):
                 """
                 if stat['acl']:
                     self.fields['mp_mode'].widget.attrs['disabled'] = 'disabled'
+                    self.fields['mp_mode_en'].widget.attrs['disabled'] = 'disabled'
 
                 self.fields['mp_mode'].initial = "%.3o" % stat['mode']
                 self.fields['mp_user'].initial = stat['user']

--- a/gui/system/forms.py
+++ b/gui/system/forms.py
@@ -818,7 +818,7 @@ class InitialWizard(CommonWizard):
             if share_purpose == 'cifs':
                 kwargs['mode'] = None
             else:
-                kwargs['acl'] = [] 
+                kwargs['acl'] = []
 
             with client as c:
                 dataset = c.call('pool.dataset.query', [['mountpoint', '=', f'/mnt/{volume_name}/{share_name}']], {'get': True})

--- a/gui/system/forms.py
+++ b/gui/system/forms.py
@@ -475,6 +475,7 @@ class InitialWizard(CommonWizard):
                             c.call('pool.dataset.create', {
                                 'name': dataset_name,
                                 'type': 'FILESYSTEM',
+                                'share_type': 'SMB' if share_purpose == 'cifs' else 'GENERIC',
                             })
                     except ClientException as e:
                         raise MiddlewareError(
@@ -814,12 +815,10 @@ class InitialWizard(CommonWizard):
             if share_purpose == 'iscsitarget':
                 continue
 
-            if share_purpose == 'afp':
-                share_acl = 'mac'
-            elif share_purpose == 'cifs':
-                share_acl = 'windows'
+            if share_purpose == 'cifs':
+                share_acl = True
             else:
-                share_acl = 'unix'
+                share_acl = False
 
             _n.mp_change_permission(
                 path='/mnt/%s/%s' % (volume_name, share_name),

--- a/gui/system/forms.py
+++ b/gui/system/forms.py
@@ -481,13 +481,6 @@ class InitialWizard(CommonWizard):
                             _('Failed to create ZFS dataset: %s.') % e
                         )
 
-                    if share_purpose == 'afp':
-                        _n.change_dataset_share_type(dataset_name, 'mac')
-                    elif share_purpose == 'cifs':
-                        _n.change_dataset_share_type(dataset_name, 'windows')
-                    elif share_purpose == 'nfs':
-                        _n.change_dataset_share_type(dataset_name, 'unix')
-
                     qs = bsdGroups.objects.filter(bsdgrp_group=share_group)
                     if not qs.exists():
                         if share_groupcreate:

--- a/gui/system/forms.py
+++ b/gui/system/forms.py
@@ -466,7 +466,6 @@ class InitialWizard(CommonWizard):
                 share_userpw = share.get('share_userpw')
                 share_group = share.get('share_group')
                 share_groupcreate = share.get('share_groupcreate')
-                share_mode = share.get('share_mode')
 
                 dataset_name = '%s/%s' % (volume_name, share_name)
                 if share_purpose != 'iscsitarget':
@@ -817,8 +816,9 @@ class InitialWizard(CommonWizard):
                 continue
 
             if share_purpose == 'cifs':
-                kwargs['option']['apply_default_acl'] = True
                 kwargs['mode'] = None
+            else:
+                kwargs['acl'] = [] 
 
             with client as c:
                 dataset = c.call('pool.dataset.query', [['mountpoint', '=', f'/mnt/{volume_name}/{share_name}']], {'get': True})

--- a/src/middlewared/middlewared/etc_files/local/smb4_share.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4_share.conf
@@ -49,7 +49,7 @@
                 if 'zfsacl' not in vfs_objects:
                     vfs_objects.append('zfsacl')
                 if 'ixnas' in vfs_objects:
-                    vfs_objects.remove('ixnas')
+                    vfs_objects.pop('ixnas')
 
             for obj in vfs_objects:
                 if obj not in vfs_objects_special:
@@ -175,7 +175,6 @@
 
                 pc[share["name"]].update({"nfs4:chown": "true"})
                 pc[share["name"]].update({"nfs4:acedup": "merge"})
-                pc[share["name"]].update({"veto files": "/.windows/.mac/"})
 
                 for param in share['auxsmbconf'].splitlines():
                     if not param.strip():

--- a/src/middlewared/middlewared/etc_files/local/smb4_share.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4_share.conf
@@ -49,7 +49,7 @@
                 if 'zfsacl' not in vfs_objects:
                     vfs_objects.append('zfsacl')
                 if 'ixnas' in vfs_objects:
-                    vfs_objects.pop('ixnas')
+                    vfs_objects.remove('ixnas')
 
             for obj in vfs_objects:
                 if obj not in vfs_objects_special:

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -341,7 +341,6 @@ class FilesystemService(Service):
             if winacl.returncode != 0:
                 raise CallError(f"Failed to recursively change ownership: {winacl.stderr.decode()}")
 
-
     @accepts(
         Dict(
             'filesystem_permission',

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -10,7 +10,7 @@ import shutil
 import subprocess
 
 from middlewared.main import EventSource
-from middlewared.schema import Bool, Dict, Int, Ref, List, Str, accepts
+from middlewared.schema import Bool, Dict, Int, Ref, List, Str, UnixPerm, accepts
 from middlewared.service import private, CallError, Service, job
 from middlewared.utils import filter_list
 
@@ -299,7 +299,7 @@ class FilesystemService(Service):
 
     @accepts(
         Str('path'),
-        Str('mode', null=True),
+        UnixPerm('mode', null=True),
         Int('uid', default=-1),
         Int('gid', default=-1),
         Dict(

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -303,7 +303,8 @@ class FilesystemService(Service):
             Str('path', required=True),
             Int('uid', null=True, default=None),
             Int('gid', null=True, default=None),
-            Dict('options',
+            Dict(
+                'options',
                 Bool('recursive', default=False),
                 Bool('traverse', default=False)
             )
@@ -334,11 +335,10 @@ class FilesystemService(Service):
             chown = subprocess.run([
                 '/usr/sbin/chown',
                 '-R' if options['traverse'] else '-Rx',
-                f'{uid}:{gid}', data['path'],], check=False
+                f'{uid}:{gid}', data['path']], check=False
             )
             if chown.returncode != 0:
                 raise CallError(f"Failed to recursively change ownership: {chown.stderr.decode()}")
-
 
     @accepts(
         Dict(

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -341,7 +341,7 @@ class FilesystemService(Service):
                 f'Non-trivial ACL present on [{path}]. Option "stripacl" required to change permission'
             )
         if mode is not None:
-            mode = int(mode,8)
+            mode = int(mode, 8)
 
         a = acl.ACL(file=path)
         a.strip()

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -324,10 +324,9 @@ class FilesystemService(Service):
         If `traverse` and `recursive` are specified, then the chown
         operation will traverse filesystem mount points.
         """
-        self.logger.debug(f'chown: {data}')
         uid = -1 if data['uid'] is None else data['uid']
         gid = -1 if data['gid'] is None else data['gid']
-        options = data.get('options')
+        options = data['options']
 
         if not options['recursive']:
             os.chown(data['path'], uid, gid)
@@ -342,7 +341,6 @@ class FilesystemService(Service):
             if winacl.returncode != 0:
                 raise CallError(f"Failed to recursively change ownership: {winacl.stderr.decode()}")
 
-        self.logger.debug('got here')
 
     @accepts(
         Dict(
@@ -382,7 +380,7 @@ class FilesystemService(Service):
         expressed as a file mode without losing any access rules.
 
         """
-        options = data.get('options')
+        options = data['options']
         mode = data.get('mode', None)
 
         uid = -1 if data['uid'] is None else data['uid']
@@ -392,7 +390,7 @@ class FilesystemService(Service):
             raise CallError('Path not found.', errno.ENOENT)
 
         acl_is_trivial = self.middleware.call_sync('filesystem.acl_is_trivial', data['path'])
-        if not acl_is_trivial and not options.get('stripacl', False):
+        if not acl_is_trivial and not options['stripacl']:
             raise CallError(
                 f'Non-trivial ACL present on [{data["path"]}]. Option "stripacl" required to change permission.'
             )
@@ -578,7 +576,7 @@ class FilesystemService(Service):
         expectations regarding permissions inheritance. This entry is removed from NT ACL returned
         to SMB clients when 'ixnas' samba VFS module is enabled.
         """
-        options = data.get('options')
+        options = data['options']
         dacl = data.get('dacl', [])
         if not os.path.exists(data['path']):
             raise CallError('Path not found.', errno.ENOENT)

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -2728,7 +2728,7 @@ class PoolDatasetService(CRUDService):
                 verrors.add(f'{schema}.volsize', 'This field is required for VOLUME')
 
             for i in (
-                'aclmode', 'atime', 'casesensitivity', 'quota', 'refquota', 'recordsize', 'optimize_for_smb',
+                'aclmode', 'atime', 'casesensitivity', 'quota', 'refquota', 'recordsize', 'share_type',
             ):
                 if i in data:
                     verrors.add(f'{schema}.{i}', 'This field is not valid for VOLUME')

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -2939,9 +2939,10 @@ class PoolDatasetService(CRUDService):
             verrors.add('pool_dataset_permissions.acl',
                         'Simultaneously setting and removing ACL is not permitted.')
 
-        if mode and not await self.middleware.call('filesystem.acl_is_trivial'):
-            verrors.add('pool_dataset_permissions.options',
-                        f'{path} has an extended ACL. The option "stripacl" must be selected.')
+        if mode and not options['stripacl']:
+            if not await self.middleware.call('filesystem.acl_is_trivial', path):
+                verrors.add('pool_dataset_permissions.options',
+                            f'{path} has an extended ACL. The option "stripacl" must be selected.')
 
         if verrors:
             raise verrors

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -2836,7 +2836,7 @@ class PoolDatasetService(CRUDService):
                         Int('id', null=True),
                         Str('type', enum=['ALLOW', 'DENY']),
                         Dict(
-                        'perms',
+                            'perms',
                             Bool('READ_DATA'),
                             Bool('WRITE_DATA'),
                             Bool('APPEND_DATA'),

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -2610,7 +2610,7 @@ class PoolDatasetService(CRUDService):
         ('rm', {'name': 'name'}),
         ('rm', {'name': 'type'}),
         ('rm', {'name': 'casesensitivity'}),  # Its a readonly attribute
-        ('rm', {'name': 'share_type'}), # This is something we should only do at create time
+        ('rm', {'name': 'share_type'}),  # This is something we should only do at create time
         ('rm', {'name': 'sparse'}),  # Create time only attribute
         ('rm', {'name': 'volblocksize'}),  # Create time only attribute
         ('edit', _add_inherit('atime')),

--- a/src/middlewared/middlewared/plugins/s3.py
+++ b/src/middlewared/middlewared/plugins/s3.py
@@ -96,11 +96,13 @@ class S3Service(SystemServiceService):
         if (await self.middleware.call('filesystem.stat', new['disks']))['user'] != 'minio':
             await self.middleware.call(
                 'filesystem.setperm',
-                new['disks'],
-                str(775),
-                (await self.middleware.call('dscache.get_uncached_user', 'minio'))['pw_uid'],
-                (await self.middleware.call('dscache.get_uncached_group', 'minio'))['pw_gid'],
-                {'recursive': True, 'traverse': False}
+                {
+                    'path': new['disks'],
+                    'mode': str(775),
+                    'uid': (await self.middleware.call('dscache.get_uncached_user', 'minio'))['pw_uid'],
+                    'gid': (await self.middleware.call('dscache.get_uncached_group', 'minio'))['pw_gid'],
+                    'options': {'recursive': True, 'traverse': False}
+                }
             )
 
         return await self.config()

--- a/src/middlewared/middlewared/plugins/s3.py
+++ b/src/middlewared/middlewared/plugins/s3.py
@@ -100,7 +100,7 @@ class S3Service(SystemServiceService):
                 str(775),
                 (await self.middleware.call('dscache.get_uncached_user', 'minio'))['pw_uid'],
                 (await self.middleware.call('dscache.get_uncached_group', 'minio'))['pw_gid'],
-                {'recursive':True, 'traverse': False}
+                {'recursive': True, 'traverse': False}
             )
 
         return await self.config()

--- a/src/middlewared/middlewared/plugins/s3.py
+++ b/src/middlewared/middlewared/plugins/s3.py
@@ -95,12 +95,12 @@ class S3Service(SystemServiceService):
 
         if (await self.middleware.call('filesystem.stat', new['disks']))['user'] != 'minio':
             await self.middleware.call(
-                 'filesystem.setperm',
-                 path,
-                 str(775),
-                 (await self.middleware.call('dscache.get_uncached_user', 'minio'))['pw_uid'],
-                 (await self.middleware.call('dscache.get_uncached_group', 'minio'))['pw_gid'],
-                 {'recursive':True, 'traverse': False}
+                'filesystem.setperm',
+                new['disks'],
+                str(775),
+                (await self.middleware.call('dscache.get_uncached_user', 'minio'))['pw_uid'],
+                (await self.middleware.call('dscache.get_uncached_group', 'minio'))['pw_gid'],
+                {'recursive':True, 'traverse': False}
             )
 
         return await self.config()

--- a/src/middlewared/middlewared/plugins/s3.py
+++ b/src/middlewared/middlewared/plugins/s3.py
@@ -94,6 +94,13 @@ class S3Service(SystemServiceService):
         await self._update_service(old, new)
 
         if (await self.middleware.call('filesystem.stat', new['disks']))['user'] != 'minio':
-            await self.middleware.call('notifier.winacl_reset', new['disks'], 'minio', 'minio')
+            await self.middleware.call(
+                 'filesystem.setperm',
+                 path,
+                 str(775),
+                 (await self.middleware.call('dscache.get_uncached_user', 'minio'))['pw_uid'],
+                 (await self.middleware.call('dscache.get_uncached_group', 'minio'))['pw_gid'],
+                 {'recursive':True, 'traverse': False}
+            )
 
         return await self.config()

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -919,7 +919,13 @@ class SharingSMBService(CRUDService):
                 },
             ])
 
-        await self.middleware.call('filesystem.setacl', path, acl, -1, -1, {'recursive': True, 'traverse': True})
+        await self.middleware.call('filesystem.setacl', {
+            'path': path,
+            'dacl': acl,
+            'uid': None,
+            'gid': None,
+            'options': {'recursive': True, 'traverse': True}
+        })
 
     @private
     async def generate_vuid(self, timemachine, vuid=""):

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -919,7 +919,7 @@ class SharingSMBService(CRUDService):
                 },
             ])
 
-        await self.middleware.call('filesystem.setacl', path, acl, {'recursive': True, 'traverse': True})
+        await self.middleware.call('filesystem.setacl', path, acl, -1, -1, {'recursive': True, 'traverse': True})
 
     @private
     async def generate_vuid(self, timemachine, vuid=""):

--- a/src/winacl/winacl.c
+++ b/src/winacl/winacl.c
@@ -503,7 +503,7 @@ make_acls(struct windows_acl_info *w)
 		err(EX_OSERR, "acl_dup() failed");
 	}
 
-	for (i=0; i<=MAX_ACL_DEPTH; i++){
+	for (i=0; i<MAX_ACL_DEPTH; i++){
 		/* create a directory acl */
 		if ((w->acls[i].dacl = acl_dup(acl)) == NULL) {
 			err(EX_OSERR, "acl_dup() failed");

--- a/src/winacl/winacl.c
+++ b/src/winacl/winacl.c
@@ -41,7 +41,6 @@
 #include <sysexits.h>
 #include <unistd.h>
 
-struct windows_acl_info {
 
 #define	WA_NULL			0x00000000	/* nothing */
 #define	WA_RECURSIVE		0x00000001	/* recursive */
@@ -55,14 +54,20 @@ struct windows_acl_info {
 /* default ACL entries if none are specified */
 #define	WA_DEFAULT_ACL		"owner@:rwxpDdaARWcCos:fd:allow,group@:rwxpDdaARWcCos:fd:allow,everyone@:rxaRc:fd:allow"
 
-#define	WA_OP_SET	(WA_CLONE|WA_RESET)
+#define	WA_OP_SET	(WA_CLONE|WA_RESET|WA_STRIP)
 #define	WA_OP_CHECK(flags, bit) ((flags & ~bit) & WA_OP_SET)
+#define	MAX_ACL_DEPTH		2
 
+struct inherited_acls{
+	acl_t dacl;
+	acl_t facl;
+};
+
+struct windows_acl_info {
 	char *source;
 	char *path;
 	acl_t source_acl;
-	acl_t dacl;
-	acl_t facl;
+	struct inherited_acls acls[MAX_ACL_DEPTH];
 	uid_t uid;
 	gid_t gid;
 	int	flags;
@@ -77,7 +82,6 @@ struct {
 	{	"strip",	WA_STRIP	},
 	{	"reset",	WA_RESET	}
 };
-
 
 size_t actions_size = sizeof(actions) / sizeof(actions[0]);
 
@@ -142,6 +146,7 @@ static struct windows_acl_info *
 new_windows_acl_info(void)
 {
 	struct windows_acl_info *w;
+	int i;
 
 	if ((w = malloc(sizeof(*w))) == NULL)
 		err(EX_OSERR, "malloc() failed");
@@ -149,11 +154,14 @@ new_windows_acl_info(void)
 	w->source = NULL;
 	w->path = NULL;
 	w->source_acl = NULL;
-	w->dacl = NULL;
-	w->facl = NULL;
 	w->uid = -1;
 	w->gid = -1;
 	w->flags = 0;
+
+	for (i=0; i<=MAX_ACL_DEPTH; i++){
+		w->acls[i].dacl = NULL;
+		w->acls[i].facl = NULL;
+	}
 
 	return (w);
 }
@@ -164,12 +172,15 @@ free_windows_acl_info(struct windows_acl_info *w)
 {
 	if (w == NULL)
 		return;
+	int i;
 
 	free(w->source);
 	free(w->path);
 	acl_free(w->source_acl);
-	acl_free(w->dacl);
-	acl_free(w->facl);
+	for (i=0; i<MAX_ACL_DEPTH; i++){
+		acl_free(w->acls[i].dacl);
+		acl_free(w->acls[i].facl);
+	}
 	free(w);
 }
 
@@ -320,6 +331,8 @@ set_acl(struct windows_acl_info *w, FTSENT *fts_entry)
 	char *path;
 	char *buf;
 	acl_t acl_new;
+	int acl_depth = 0;
+
 	if (fts_entry == NULL) 
 		path = w->path;
 	else
@@ -329,11 +342,17 @@ set_acl(struct windows_acl_info *w, FTSENT *fts_entry)
 		fprintf(stdout, "%s\n", path);
 
 	/* don't set inherited flag on root dir. This is required for zfsacl:map_dacl_protected */
-        if (fts_entry->fts_level == FTS_ROOTLEVEL) {
-                acl_new = w->source_acl;
-        }
-        else {
-                acl_new = ((fts_entry->fts_statp->st_mode & S_IFDIR) == 0) ? w->facl : w->dacl;
+	if (fts_entry->fts_level == FTS_ROOTLEVEL) {
+		acl_new = w->source_acl;
+	}
+	else {
+		if ((fts_entry->fts_level -1) >= MAX_ACL_DEPTH) {
+			acl_depth = MAX_ACL_DEPTH-1;
+		}
+		else {
+			acl_depth = fts_entry->fts_level -1;
+		}
+                acl_new = ((fts_entry->fts_statp->st_mode & S_IFDIR) == 0) ? w->acls[acl_depth].facl : w->acls[acl_depth].dacl;
         }
 
 	/* write out the acl to the file */
@@ -445,24 +464,31 @@ usage_check(struct windows_acl_info *w)
 		errx(EX_USAGE, "no path specified");
 
 	if (!WA_OP_CHECK(w->flags, ~WA_OP_SET) &&
-		w->dacl == NULL && w->facl == NULL)
+		w->acls[0].dacl == NULL && w->acls[0].facl == NULL)
 		errx(EX_USAGE, "nothing to do");
 
 	if (WA_OP_CHECK(w->flags, ~WA_OP_SET) &&
-		w->dacl == NULL && w->facl == NULL && !(w->flags & WA_RESET)) {
+		w->acls[0].dacl == NULL && w->acls[0].facl == NULL && !(w->flags & WA_RESET)) {
 		errx(EX_USAGE, "no entries specified and not resetting");
 	}
 }
 
 
-/* create directory and file ACL's */
 static void
 make_acls(struct windows_acl_info *w)
 {
+	/*
+	 * Legacy winacl behavior for setting ACL
+	 * Applies following "default" ACL
+	 * - owner@:rwxpDdaARWcCos:fd:allow
+	 * - group@:rwxpDdaARWcCos:fd:allow
+	 * - everyone@:rxaRc:fd:allow"
+	 */
 	char *ptr;
 	char buf[8192];
 	acl_t acl;
 	char *default_acl = WA_DEFAULT_ACL;
+	int i;
 
 	/* create an acl string */
 	ptr = &buf[0];
@@ -477,23 +503,38 @@ make_acls(struct windows_acl_info *w)
 		err(EX_OSERR, "acl_dup() failed");
 	}
 
-	/* create a directory acl */
-	if ((w->dacl = acl_dup(acl)) == NULL)
-		err(EX_OSERR, "acl_dup() failed");
-	set_inherited_flag(&w->dacl);	
+	for (i=0; i<=MAX_ACL_DEPTH; i++){
+		/* create a directory acl */
+		if ((w->acls[i].dacl = acl_dup(acl)) == NULL) {
+			err(EX_OSERR, "acl_dup() failed");
+		}
+		set_inherited_flag(&w->acls[i].dacl);
 
-	/* create a file acl */
-	if ((w->facl = acl_dup(acl)) == NULL)
-		err(EX_OSERR, "acl_dup() failed");
-	remove_inherit_flags(&w->facl);
-	set_inherited_flag(&w->facl);	
+		/* create a file acl */
+		if ((w->acls[i].facl = acl_dup(acl)) == NULL) {
+			err(EX_OSERR, "acl_dup() failed");
+		}
+		remove_inherit_flags(&w->acls[i].facl);
+		set_inherited_flag(&w->acls[i].facl);
+	}
 
 	acl_free(acl);
 }
 
 static int
-clone_acls(struct windows_acl_info *w)
+calculate_inherited_acl(struct windows_acl_info *w, acl_t *parent_acl, int level)
 {
+	/*
+	 * Generates an inherited directory ACL and file ACL based
+	 * on the ACL specified in the parent_acl. Behavior in the absence of
+	 * inheriting aces in the parent ACL is as follows: if the parent_acl
+	 * is trivial (i.e. can be expressed as posix mode without
+	 * information loss), then apply the mode recursively. If the ACL
+	 * is non-trivial, then user intention is less clear and so error
+	 * out.
+	 * 
+	 * Currently, nfsv41 inheritance is not implemented.
+	 */
 	int trivial = 0;
 	acl_t tmp_acl;
 	acl_entry_t entry, file_entry, dir_entry;
@@ -504,28 +545,34 @@ clone_acls(struct windows_acl_info *w)
 	entry_id = f_entry_id = d_entry_id = ACL_FIRST_ENTRY;
 	must_set_facl = must_set_dacl = true;
 
+	if (w->acls[level].dacl != NULL) {
+		acl_free(w->acls[level].dacl);
+	}
+	if (w->acls[level].facl != NULL) {
+		acl_free(w->acls[level].facl);
+	}
 	/*
 	 * Short-circuit for trivial ACLs. If ACL is trivial,
 	 * assume that user does not want to apply ACL inheritance rules.
 	 */
-	if (acl_is_trivial_np(w->source_acl, &trivial) != 0) {
+	if (acl_is_trivial_np(parent_acl, &trivial) != 0) {
 		err(EX_OSERR, "acl_is_trivial_np() failed");
 	}
 	if (trivial) {
-		w->dacl = acl_dup(w->source_acl);
-		w->facl = acl_dup(w->source_acl);
+		w->acls[level].dacl = acl_dup(parent_acl);
+		w->acls[level].facl = acl_dup(parent_acl);
 		return ret;
 	}
 
 	/* initialize separate directory and file ACLs */
-	if ((w->dacl = acl_init(ACL_MAX_ENTRIES)) == NULL) {
+	if ((w->acls[level].dacl = acl_init(ACL_MAX_ENTRIES)) == NULL) {
 		err(EX_OSERR, "failed to initialize directory ACL");
 	}
-	if ((w->facl = acl_init(ACL_MAX_ENTRIES)) == NULL) {
+	if ((w->acls[level].facl = acl_init(ACL_MAX_ENTRIES)) == NULL) {
 		err(EX_OSERR, "failed to initialize file ACL");
 	}
 
-	tmp_acl = acl_dup(w->source_acl);
+	tmp_acl = acl_dup(parent_acl);
 
 	if (tmp_acl == NULL) {
 		err(EX_OSERR, "acl_dup() failed");
@@ -545,14 +592,6 @@ clone_acls(struct windows_acl_info *w)
 			continue;
 		}
 
-		/*
-		 * FIXME: for now we will bail if NO_PROPAGATE is set. Proper handling of this
-		 * inheritance bit will require a significant restructuring of winacl.
-		 */
-		if (*flagset & ACL_ENTRY_NO_PROPAGATE_INHERIT) {
-			continue;
-		} 
-
 		/* Skip if the ACE has NO_PROPAGATE flag set and does not have INHERIT_ONLY flag. */
 		if ((*flagset & ACL_ENTRY_NO_PROPAGATE_INHERIT) &&
 		    (*flagset & ACL_ENTRY_INHERIT_ONLY) == 0) {
@@ -564,8 +603,8 @@ clone_acls(struct windows_acl_info *w)
 		 * Strip inherit only from the flagset and set ACL_ENTRY_INHERITED.
 		 */
 
-		*flagset |= ACL_ENTRY_INHERITED;
 		*flagset &= ~ACL_ENTRY_INHERIT_ONLY;
+		*flagset |= ACL_ENTRY_INHERITED;
 
 		if ((*flagset & ACL_ENTRY_FILE_INHERIT) == 0) {
 			must_set_facl = false;
@@ -577,7 +616,7 @@ clone_acls(struct windows_acl_info *w)
 		 * to modify the flagset of the new ACEs.
 		 */
 		if (must_set_facl) {
-			if (acl_create_entry_np(&w->facl, &file_entry, f_entry_id) == -1) {
+			if (acl_create_entry_np(&w->acls[level].facl, &file_entry, f_entry_id) == -1) {
 				err(EX_OSERR, "acl_create_entry() failed");
 			}
 			if (acl_copy_entry(file_entry, entry) == -1) {
@@ -586,11 +625,11 @@ clone_acls(struct windows_acl_info *w)
 			if (acl_get_flagset_np(file_entry, &file_flag)) {
 				err(EX_OSERR, "acl_get_flagset_np() failed");
 			}
-			*file_flag &= ~(ACL_ENTRY_DIRECTORY_INHERIT|ACL_ENTRY_FILE_INHERIT);
+			*file_flag &= ~(ACL_ENTRY_DIRECTORY_INHERIT|ACL_ENTRY_FILE_INHERIT|ACL_ENTRY_NO_PROPAGATE_INHERIT);
 			f_entry_id ++;
 		}
 		if (must_set_dacl) {
-			if (acl_create_entry_np(&w->dacl, &dir_entry, d_entry_id) == -1) {
+			if (acl_create_entry_np(&w->acls[level].dacl, &dir_entry, d_entry_id) == -1) {
 				err(EX_OSERR, "acl_create_entry() failed");
 			}
 			if (acl_copy_entry(dir_entry, entry) == -1) {
@@ -600,10 +639,22 @@ clone_acls(struct windows_acl_info *w)
 				err(EX_OSERR, "acl_get_flagset_np() failed");
 			}
 			/*
+			 * Special handling for NO_PROPAGATE_INHERIT. Original flags at
+			 * this point would have been fdin, din, or fin. In the case of
+			 * fin, the acl entry must not be added to the dacl (since it only
+			 * applies to files).
+			 */
+			if (*flagset & ACL_ENTRY_NO_PROPAGATE_INHERIT) {
+				if ((*flagset & ACL_ENTRY_DIRECTORY_INHERIT) == 0) {
+					continue;
+				}
+				*dir_flag &= ~(ACL_ENTRY_DIRECTORY_INHERIT|ACL_ENTRY_FILE_INHERIT|ACL_ENTRY_NO_PROPAGATE_INHERIT);
+			}
+			/*
 			 * If only FILE_INHERIT is set then turn on INHERIT_ONLY
 			 * on directories. This is to prevent ACE from applying to directories.
 			 */
-			if ((*flagset & ACL_ENTRY_DIRECTORY_INHERIT) == 0) {
+			else if ((*flagset & ACL_ENTRY_DIRECTORY_INHERIT) == 0) {
 				*dir_flag |= ACL_ENTRY_INHERIT_ONLY;
 			}
 			d_entry_id ++;
@@ -623,7 +674,7 @@ clone_acls(struct windows_acl_info *w)
 int
 main(int argc, char **argv)
 {
-	int 	ch, ret;
+	int 	ch, ret, i;
 	struct 	windows_acl_info *w;
 	acl_t	source_acl;
 	char *p = argv[0];
@@ -739,8 +790,11 @@ main(int argc, char **argv)
 		}
 
 		w->source_acl = acl_dup(source_acl);
-		acl_free(source_acl);
-		if (clone_acls(w) != 0) {
+		if (calculate_inherited_acl(w, w->source_acl, 0) != 0) {
+			free_windows_acl_info(w);
+			return (1);
+		}
+		if (calculate_inherited_acl(w, w->acls[0].dacl, 1) != 0) {
 			free_windows_acl_info(w);
 			return (1);
 		}

--- a/tests/api2/pool_dataset.py
+++ b/tests/api2/pool_dataset.py
@@ -46,7 +46,7 @@ def test_04_update_dataset_description():
 def test_05_set_permissions_for_dataset():
     result = POST(
         f'/pool/dataset/id/{dataset_url}/permission/', {
-            'acl': 'UNIX',
+            'acl': [],
             'mode': '777',
             'group': 'nobody',
             'user': 'nobody'
@@ -61,8 +61,58 @@ def test_06_promoting_dataset():
     # THIS TEST CAN BE COMPLETED THEN
     pass
 
+# Test 07 through 11 verify basic ACL functionality. A default ACL is
+# set, verified, stat output checked for its presence. Then ACL is removed
+# and stat output confirms its absence.
 
-def test_07_delete_dataset():
+def test_07_set_acl_for_dataset():
+    result = POST(
+        f'/pool/dataset/id/{dataset_url}/permission/', {
+            'acl': default_acl,
+            'group': 'nobody',
+            'user': 'nobody'
+        }
+    )
+
+    assert result.status_code == 200, result.text
+
+
+def test_08_filesystem_getacl():
+    results = POST('/filesystem/getacl/', {'path': f'/mnt/{dataset}', 'simplified': True})
+    assert results.status_code == 200, results.text
+    for key in ['tag', 'type', 'perms', 'flags']:
+        assert results.json()['acl'][0][key] == default_acl[0][key], results.text
+        assert results.json()['acl'][1][key] == default_acl[1][key], results.text
+
+
+def test_09_filesystem_acl_is_present():
+    results = POST('/filesystem/stat/', f'/mnt/{dataset}')
+    assert results.status_code == 200, results.text
+    assert results.json()['acl'] == True, results.text
+
+
+def test_10_strip_acl_from_dataset():
+    result = POST(
+        f'/pool/dataset/id/{dataset_url}/permission/', {
+            'acl': [],
+            'mode': '777',
+            'group': 'nobody',
+            'user': 'nobody',
+            'options': {'stripacl': True}
+        }
+    )
+
+    assert result.status_code == 200, result.text
+
+
+def test_11_filesystem_acl_is_removed():
+    results = POST('/filesystem/stat/', f'/mnt/{dataset}')
+    assert results.status_code == 200, results.text
+    assert results.json()['acl'] == False, results.text
+    assert oct(results.json()['mode']) == '0o40777', results.text
+
+
+def test_12_delete_dataset():
     result = DELETE(
         f'/pool/dataset/id/{dataset_url}/'
     )


### PR DESCRIPTION
- Add support for the full set of different ACL entry inheritance bits to winacl (as well as more comments).
- Create new middleware API call that `filesystem.setperm` that has essentially same arguments as `filesystem.setacl` except that it sets the posix mode.
- Have all permissions changes go through winacl with default not to apply to child datasets.
- Expose option in old UI to remove ACLs and apply default one in dataset permissions editor.
- Expose ZFS aclmode property to end-users.
- Remove 'share_type' from dataset, but allow for share type optimization at dataset creation (case insensitive, and restricted aclmode on SMB shares).
- Add tooltips to dataset permissions.
- Plumb new permissions work into all the things.