### PR TITLE
NAS-101999 / 11.3 / Fix several issues discovered in testing AD plugin

### DIFF
--- a/src/middlewared/middlewared/etc_files/krb5.conf
+++ b/src/middlewared/middlewared/etc_files/krb5.conf
@@ -5,6 +5,7 @@
 <%
         import logging
         logger = logging.getLogger(__name__)
+        from middlewared.utils import filter_list
 
         def parse_defaults(section_name, section_conf, db_def=None):
             default_section = "krb5_main"
@@ -100,7 +101,8 @@
         """
         if db['ad']['enable'] and db['ad']['kerberos_realm']:
             environment_is_kerberized = True
-            krb_default_realm = db['ad']['kerberos_realm']['krb_realm']
+            c_realm = db['ad']['kerberos_realm']
+            krb_default_realm = (filter_list(db_realms, [('id', '=', c_realm)]))[0]['realm']
         elif db['ad']['enable']:
             environment_is_kerberized = True
             krb_default_realm = db['ad']['domainname']
@@ -192,13 +194,13 @@
             ${f'{realm["realm"]}'} = {
                    default_domain = ${realm["realm"]}
                 % if realm["kdc"]:
-                   kdc = ${realm["kdc"]}
+                   kdc = ${' '.join(realm["kdc"])}
                 % endif
                 % if realm["admin_server"]:
-                   admin_server = ${realm["admin_server"]}
+                   admin_server = ${' '.join(realm["admin_server"])}
                 % endif
                 % if realm["kpasswd_server"]:
-                   kpasswd_server = ${realm["kpasswd_server"]}
+                   kpasswd_server = ${' '.join(realm["kpasswd_server"])}
                 % endif
             }
 % endfor

--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -95,7 +95,7 @@ class KerberosService(ConfigService):
                     {'get': True}
                 )
                 bind_cn = (ldap['binddn'].split(','))[0].strip("cn=")
-                principal = f'{bind_cn}@krb_realm["realm"]'
+                principal = f'{bind_cn}@{krb_realm["realm"]}'
                 ad_kinit = await Popen(
                     ['/usr/bin/kinit', '--renewable', '--password-file=STDIN', principal],
                     stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE

--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -265,6 +265,10 @@ class LDAPService(ConfigService):
         for key in ["ssl", "idmap_backend", "schema"]:
             data[key] = data[key].upper()
 
+        for key in ["certificate", "kerberos_realm"]:
+            if data[key] is not None:
+                data[key] = data[key]["id"]
+
         return data
 
     @private
@@ -298,18 +302,11 @@ class LDAPService(ConfigService):
         Str('machinesuffix'),
         Str('sudosuffix'),
         Str('ssl', default='OFF', enum=['OFF', 'ON', 'START_TLS']),
-        Int('certificate'),
+        Int('certificate', null=True),
         Int('timeout', default=30),
         Int('dns_timeout', default=5),
         Str('idmap_backend', default='LDAP', enum=['SCRIPT', 'LDAP']),
-        Dict(
-            'kerberos_realm',
-            Int('id'),
-            Str('krb_realm'),
-            List('krb_kdc'),
-            List('krb_admin_server'),
-            List('krb_kpasswd_server'),
-        ),
+        Int('kerberos_realm', null=True),
         Str('kerberos_principal'),
         Bool('has_samba_schema', default=False),
         Str('auxiliary_parameters', default=False),

--- a/src/middlewared/middlewared/plugins/nis.py
+++ b/src/middlewared/middlewared/plugins/nis.py
@@ -1,6 +1,8 @@
 import asyncio
 import enum
 import errno
+import pwd
+import grp
 import subprocess
 
 from middlewared.schema import accepts, Bool, Dict, List, Str


### PR DESCRIPTION
- Make sure we're consistently treating kerberos_realm as Int.
- Add new API call 'activedirectory.leave' to allow FreeNAS server to gracefully leave AD domain.
- Fix issues in krb5.conf generation and updates
- import pwd and grp in NIS plugin