### PR TITLE
NAS-101739 / 11.3 / fix(vm): We also need to respect arc_meta_limit

### DIFF
--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -725,7 +725,7 @@ class VMService(CRUDService):
         arc_min = sysctl.filter('vfs.zfs.arc_min')[0].value
         arc_meta = sysctl.filter('vfs.zfs.arc_meta_limit')[0].value
 
-        if arc_max > arc_min and arc_max > arc_meta :
+        if arc_max > arc_min and arc_max > arc_meta:
             new_arc_max = max(arc_min, arc_max - memory_bytes)
             self.logger.info(f'===> Setting ARC FROM: {arc_max} TO: {new_arc_max}')
             sysctl.filter('vfs.zfs.arc_max')[0].value = new_arc_max

--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -723,7 +723,9 @@ class VMService(CRUDService):
 
         arc_max = sysctl.filter('vfs.zfs.arc_max')[0].value
         arc_min = sysctl.filter('vfs.zfs.arc_min')[0].value
-        if arc_max > arc_min:
+        arc_meta = sysctl.filter('vfs.zfs.arc_meta_limit')[0].value
+
+        if arc_max > arc_min and arc_max > arc_meta :
             new_arc_max = max(arc_min, arc_max - memory_bytes)
             self.logger.info(f'===> Setting ARC FROM: {arc_max} TO: {new_arc_max}')
             sysctl.filter('vfs.zfs.arc_max')[0].value = new_arc_max

--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -725,10 +725,13 @@ class VMService(CRUDService):
         arc_min = sysctl.filter('vfs.zfs.arc_min')[0].value
         arc_meta = sysctl.filter('vfs.zfs.arc_meta_limit')[0].value
 
-        if arc_max > arc_min and arc_max > arc_meta:
+        if arc_max > arc_min:
             new_arc_max = max(arc_min, arc_max - memory_bytes)
-            self.logger.info(f'===> Setting ARC FROM: {arc_max} TO: {new_arc_max}')
-            sysctl.filter('vfs.zfs.arc_max')[0].value = new_arc_max
+            if new_arc_max > arc_meta:
+                self.logger.info(
+                    f'===> Setting ARC FROM: {arc_max} TO: {new_arc_max}'
+                )
+                sysctl.filter('vfs.zfs.arc_max')[0].value = new_arc_max
         return True
 
     async def __init_guest_vmemory(self, vm, overcommit):


### PR DESCRIPTION
Without doing so, if arc_max goes below arc_meta_limit, we will get an invalid argument from sysctl.

NAS-101739

Signed-off-by: Brandon Schneider <brandon@ixsystems.com>