### PR TITLE
Fix typo in service name

### DIFF
--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -38,7 +38,7 @@ FIRST_INSTALL_SENTINEL = '/data/first-boot'
 LICENSE_FILE = '/data/license'
 
 
-class SytemAdvancedService(ConfigService):
+class SystemAdvancedService(ConfigService):
 
     class Config:
         datastore = 'system.advanced'


### PR DESCRIPTION
This commit fixes a typo in service's class name.