### PR TITLE
NAS-101817 / 11.3 / fix(vm/devices): Validate a long zvol path

### DIFF
--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -1341,6 +1341,14 @@ class VMDeviceService(CRUDService):
             elif path and not os.path.exists(path):
                 verrors.add('attributes.path', f'Disk path {path} does not exist.', errno.ENOENT)
 
+            if path and len(path) > 63:
+                # SPECNAMELEN is not long enough (63) in 12, 13 will be 255
+                verrors.add(
+                    'attributes.path',
+                    f'Disk path {path} is too long, reduce to less than 63'
+                    ' characters',
+                    errno.ENAMETOOLONG
+                )
         elif device.get('dtype') == 'RAW':
             path = device['attributes'].get('path')
             exists = device['attributes'].pop('exists', True)


### PR DESCRIPTION
We now throw a validation error when the path for the zvol is too long.

NAS-101817

Signed-off-by: Brandon Schneider <brandon@ixsystems.com>