### PR TITLE
NAS-101685 / 11.3 / Disable fruit nfs aces by default

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf
@@ -31,6 +31,7 @@
             conf['guest_enabled'] = False
             conf['system_dataset'] = middleware.call_sync('systemdataset.config')
             conf['loglevel'] = LOGLEVEL_UNMAP.get(conf['cifs']['loglevel'])
+            conf['fruit_enabled'] = False
 
             conf['truenas_conf'] = {'is_truenas_ha': False, 'failover_status': 'DEFAULT', 'smb_ha_mode': 'LEGACY'}
             if not middleware.call_sync('system.is_freenas') and middleware.call_sync('failover.licensed'):
@@ -45,6 +46,11 @@
 
             if any(filter(lambda x: x['guestok'], conf['shares'])):
                 conf['guest_enabled'] = True
+
+            for share in conf['shares']:
+                if "fruit" in share['vfsobjects'] or share['timemachine']:
+                    conf['fruit_enabled'] = True
+                    break
 
             return conf
 
@@ -113,6 +119,8 @@
             if db['cifs']['dirmask']:
                 pc.update({'directory mask': db['cifs']['dirmask']})
             pc.update({'unix charset': db['cifs']['unixcharset']})
+            if db['fruit_enabled']:
+                pc.update({'fruit:nfs_aces': 'No'})
 
             return pc
 


### PR DESCRIPTION
- Posix mode bits do not reliably reflect actual filesystem permissions due to extended ACLs.
  Turn off support for nfs aces by default if fruit is enabled (this can be altered via aux parameter
  if user decides he/she needs them.