### PR TITLE
NAS-102062 / 11.3 / Prevent users from naming SMB shares 'printers' and 'homes'

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -760,10 +760,10 @@ class SharingSMBService(CRUDService):
                     f'The "noacl" VFS module is incompatible with the extended ACL on {data["path"]}.'
                 )
 
-        if data.get('name') and data['name'] == 'global':
+        if data.get('name') and data['name'].lower() in ['global', 'homes', 'printers']:
             verrors.add(
                 f'{schema_name}.name',
-                'Global is a reserved section name, please select another one'
+                f'{data["name"]} is a reserved section name, please select another one'
             )
 
     @private


### PR DESCRIPTION
Expand validation to include case insensitive check for samba's special reserved sections "global", "printers", and "homes". "global" is always present, "printers" isn't used in FreeNAS, and "homes" is controlled by flagging a share 