### PR TITLE
NAS-102077 / 11.3 / Fix regression in APIv1 caused by ACL changes

### DIFF
--- a/gui/api/resources.py
+++ b/gui/api/resources.py
@@ -399,11 +399,19 @@ class PermissionResource(DojoResource):
             request.body,
             format=request.META.get('CONTENT_TYPE', 'application/json'),
         )
+        mp_acl = deserialized.get('mp_acl', None)
+        acl_action = None
+        if mp_acl is not None and mp_acl.lower() in ['unix', 'mac', 'windows']:
+            acl_action = 'applydefault' if mp_acl.lower() == 'windows' else 'noaction'
+
         deserialized.update({
             'mp_group_en': deserialized.get('mp_group_en', True),
             'mp_mode_en': deserialized.get('mp_mode_en', True),
             'mp_user_en': deserialized.get('mp_user_en', True),
         })
+        if acl_action is not None:
+            deserialized.update({'mp_acl': acl_action})
+
         form = MountPointAccessForm(data=deserialized)
         if form.is_valid():
             if form.commit(deserialized.get('mp_path')):


### PR DESCRIPTION
Old behavior: ACL was string with three choices "UNIX, Mac, Windows".
New behavior in legacy UI is to present users with three options related to ACL:
- (1) no action / preserve what's there,
- (2) remove extended ACL,
- (3) apply default.

Fix in this case is to map "Windows" to "applydefault", and remaining legacy options to "noaction". This behavior is mostly identical to prior behavior.vWith the exception that changing permissions type from Windows to Unix would yield inconsistent results depending on FreeNAS version. In this case, fail safe (no change) as opposed to trying to replicate undefined behavior.