### PR TITLE
NAS-100329 / 11.3 / feat(vm/logging): Keep individual logs for each VM

### DIFF
--- a/src/middlewared/middlewared/logger.py
+++ b/src/middlewared/middlewared/logger.py
@@ -187,57 +187,61 @@ class ErrorProneRotatingFileHandler(logging.handlers.RotatingFileHandler):
 
 class Logger(object):
     """Pseudo-Class for Logger - Wrapper for logging module"""
-    DEFAULT_LOGGING = {
-        'version': 1,
-        'disable_existing_loggers': False,
-        'loggers': {
-            '': {
-                'level': 'NOTSET',
-                'handlers': ['file'],
-            },
-            'zettarepl': {
-                'level': 'NOTSET',
-                'handlers': ['zettarepl_file'],
-                'propagate': False,
-            },
-        },
-        'handlers': {
-            'file': {
-                'level': 'DEBUG',
-                'class': 'middlewared.logger.ErrorProneRotatingFileHandler',
-                'filename': LOGFILE,
-                'mode': 'a',
-                'maxBytes': 10485760,
-                'backupCount': 5,
-                'encoding': 'utf-8',
-                'formatter': 'file',
-            },
-            'zettarepl_file': {
-                'level': 'DEBUG',
-                'class': 'middlewared.logger.ErrorProneRotatingFileHandler',
-                'filename': ZETTAREPL_LOGFILE,
-                'mode': 'a',
-                'maxBytes': 10485760,
-                'backupCount': 5,
-                'encoding': 'utf-8',
-                'formatter': 'zettarepl_file',
-            },
-        },
-        'formatters': {
-            'file': {
-                'format': '[%(asctime)s] (%(levelname)s) %(name)s.%(funcName)s():%(lineno)d - %(message)s',
-                'datefmt': '%Y/%m/%d %H:%M:%S',
-            },
-            'zettarepl_file': {
-                'format': '[%(asctime)s] %(levelname)-8s [%(threadName)s] [%(name)s] %(message)s',
-                'datefmt': '%Y/%m/%d %H:%M:%S',
-            },
-        },
-    }
-
-    def __init__(self, application_name, debug_level=None):
+    def __init__(
+        self, application_name, debug_level=None,
+        log_format='[%(asctime)s] (%(levelname)s) %(name)s.%(funcName)s():%(lineno)d - %(message)s'
+    ):
         self.application_name = application_name
         self.debug_level = debug_level or 'DEBUG'
+        self.log_format = log_format
+
+        DEFAULT_LOGGING = {
+            'version': 1,
+            'disable_existing_loggers': False,
+            'loggers': {
+                '': {
+                    'level': 'NOTSET',
+                    'handlers': ['file'],
+                },
+                'zettarepl': {
+                    'level': 'NOTSET',
+                    'handlers': ['zettarepl_file'],
+                    'propagate': False,
+                },
+            },
+            'handlers': {
+                'file': {
+                    'level': 'DEBUG',
+                    'class': 'middlewared.logger.ErrorProneRotatingFileHandler',
+                    'filename': LOGFILE,
+                    'mode': 'a',
+                    'maxBytes': 10485760,
+                    'backupCount': 5,
+                    'encoding': 'utf-8',
+                    'formatter': 'file',
+                },
+                'zettarepl_file': {
+                    'level': 'DEBUG',
+                    'class': 'middlewared.logger.ErrorProneRotatingFileHandler',
+                    'filename': ZETTAREPL_LOGFILE,
+                    'mode': 'a',
+                    'maxBytes': 10485760,
+                    'backupCount': 5,
+                    'encoding': 'utf-8',
+                    'formatter': 'zettarepl_file',
+                },
+            },
+            'formatters': {
+                'file': {
+                    'format': self.log_format,
+                    'datefmt': '%Y/%m/%d %H:%M:%S',
+                },
+                'zettarepl_file': {
+                    'format': '[%(asctime)s] %(levelname)-8s [%(threadName)s] [%(name)s] %(message)s',
+                    'datefmt': '%Y/%m/%d %H:%M:%S',
+                },
+            },
+        }
 
     def getLogger(self):
         return logging.getLogger(self.application_name)
@@ -274,10 +278,8 @@ class Logger(object):
 
         console_handler = logging.StreamHandler()
         logging.root.setLevel(getattr(logging, self.debug_level))
-
-        log_format = "[%(asctime)s] (%(levelname)s) %(name)s.%(funcName)s():%(lineno)d - %(message)s"
         time_format = "%Y/%m/%d %H:%M:%S"
-        console_handler.setFormatter(LoggerFormatter(log_format, datefmt=time_format))
+        console_handler.setFormatter(LoggerFormatter(self.log_format, datefmt=time_format))
 
         logging.root.addHandler(console_handler)
 

--- a/src/middlewared/middlewared/logger.py
+++ b/src/middlewared/middlewared/logger.py
@@ -195,7 +195,7 @@ class Logger(object):
         self.debug_level = debug_level or 'DEBUG'
         self.log_format = log_format
 
-        DEFAULT_LOGGING = {
+        self.DEFAULT_LOGGING = {
             'version': 1,
             'disable_existing_loggers': False,
             'loggers': {

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -753,15 +753,19 @@ class Middleware(LoadPluginsMixin):
     def __init__(
         self, loop_debug=False, loop_monitor=True, overlay_dirs=None, debug_level=None,
         log_handler=None, startup_seq_path=None,
+        log_format='[%(asctime)s] (%(levelname)s) %(name)s.%(funcName)s():%(lineno)d - %(message)s'
     ):
         super().__init__(overlay_dirs)
-        self.logger = logger.Logger('middlewared', debug_level).getLogger()
+        self.logger = logger.Logger(
+            'middlewared', debug_level, log_format
+        ).getLogger()
         self.crash_reporting = logger.CrashReporting()
         self.crash_reporting_semaphore = asyncio.Semaphore(value=2)
         self.loop_debug = loop_debug
         self.loop_monitor = loop_monitor
         self.debug_level = debug_level
         self.log_handler = log_handler
+        self.log_format = log_format
         self.startup_seq = 0
         self.startup_seq_path = startup_seq_path
         self.app = None

--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -89,9 +89,7 @@ class VMSupervisor(object):
     def __init__(self, manager, vm):
         self.manager = manager
 
-        if not os.path.exists('/var/log/vm'):
-            os.makedirs('/var/log/vm', exist_ok=True)
-
+        os.makedirs('/var/log/vm', exist_ok=True)
         self.logger = self.manager.logger.getChild(f'vm_{vm["id"]}')
 
         handler = middlewared.logger.ErrorProneRotatingFileHandler(

--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -97,12 +97,10 @@ class VMSupervisor(object):
             maxBytes=10485760,
             backupCount=5,
         )
-        handler.setFormatter(logging.Formatter(
-            '[%(asctime)s] (%(levelname)s) %(name)s.%(funcName)s():%(lineno)d'
-            ' - %(message)s'
-        ))
-        self.logger.addHandler(handler)  # main log + vm specific log
         self.middleware = self.manager.service.middleware
+
+        handler.setFormatter(logging.Formatter(self.middleware.log_format))
+        self.logger.addHandler(handler)  # main log + vm specific log
         self.logger.setLevel(self.middleware.debug_level)
 
         self.vm = vm

--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -90,11 +90,9 @@ class VMSupervisor(object):
         self.manager = manager
 
         if not os.path.exists('/var/log/vm'):
-            os.makedirs('/var/log/vm')
+            os.makedirs('/var/log/vm', exist_ok=True)
 
-        self.logger = middlewared.logger.Logger(
-            f'VM: {vm["name"]}_{vm["id"]}'
-        ).getLogger()
+        self.logger = self.manager.logger.getChild(f'vm_{vm["id"]}')
 
         handler = middlewared.logger.ErrorProneRotatingFileHandler(
             f'/var/log/vm/{vm["name"]}_{vm["id"]}',
@@ -106,9 +104,9 @@ class VMSupervisor(object):
             ' - %(message)s'
         ))
         self.logger.addHandler(handler)  # main log + vm specific log
-        self.logger.setLevel(logging.DEBUG)
-
         self.middleware = self.manager.service.middleware
+        self.logger.setLevel(self.middleware.debug_level)
+
         self.vm = vm
         self.proc = None
         self.grub_proc = None


### PR DESCRIPTION
They will remain in the main middlewared.log, but we also should break them out to their own log file.  This aids in debugging, and sorts out some noise.

NAS-100329

Signed-off-by: Brandon Schneider <brandon@ixsystems.com>