### PR TITLE
NAS-101171 / 11.3 / Add parameter to disable DS cache for LDAP

### DIFF
--- a/gui/directoryservice/forms.py
+++ b/gui/directoryservice/forms.py
@@ -310,6 +310,7 @@ class LDAPForm(MiddlewareModelForm, ModelForm):
 
     advanced_fields = [
         'ldap_anonbind',
+        'ldap_disable_freenas_cache',
         'ldap_usersuffix',
         'ldap_groupsuffix',
         'ldap_passwordsuffix',
@@ -430,9 +431,7 @@ class KerberosKeytabCreateForm(ModelForm):
 
     def save(self):
         super(KerberosKeytabCreateForm, self).save()
-        keytab = self.cleaned_data.get("keytab_file")
         with client as c:
-            c.call('kerberos.keytab.create', keytab)
             c.call('kerberos.start')
 
 

--- a/gui/directoryservice/migrations/0012_add_disable_freenas_cache_to_ldap.py
+++ b/gui/directoryservice/migrations/0012_add_disable_freenas_cache_to_ldap.py
@@ -1,0 +1,28 @@
+import django.core.validators
+from django.db import migrations, models
+import freenasUI.freeadmin.models.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('directoryservice', '0011_add_new_idmap_model'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='LDAP',
+            name='ldap_disable_freenas_cache',
+            field=models.BooleanField(
+                verbose_name='Disable LDAP user/group cache',
+                default=False,
+                help_text=(
+                    "Set this if you want to disable caching LDAP users "
+                    "and groups. This is an optimization for large LDAP  "
+                    "Environments. If caching is disabled, then LDAP users "
+                    "and groups will not appear in dropdown menus, but will "
+                    "still be accepted if manually entered.",
+                )
+            )
+        )
+    ]

--- a/gui/directoryservice/migrations/0013_add_disable_freenas_cache_to_ldap.py
+++ b/gui/directoryservice/migrations/0013_add_disable_freenas_cache_to_ldap.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
                 verbose_name='Disable LDAP user/group cache',
                 default=False,
                 help_text=(
-                    "Set this if you want to disable caching LDAP users "
+                    "Set to disable caching LDAP users "
                     "and groups. This is an optimization for large LDAP "
                     "Environments. When caching is disabled, LDAP users "
                     "and groups do not appear in dropdown menus, but are "

--- a/gui/directoryservice/migrations/0013_add_disable_freenas_cache_to_ldap.py
+++ b/gui/directoryservice/migrations/0013_add_disable_freenas_cache_to_ldap.py
@@ -6,7 +6,7 @@ import freenasUI.freeadmin.models.fields
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('directoryservice', '0011_add_new_idmap_model'),
+        ('directoryservice', '0012_remove_unix_extensions'),
     ]
 
     operations = [
@@ -18,10 +18,10 @@ class Migration(migrations.Migration):
                 default=False,
                 help_text=(
                     "Set this if you want to disable caching LDAP users "
-                    "and groups. This is an optimization for large LDAP  "
-                    "Environments. If caching is disabled, then LDAP users "
-                    "and groups will not appear in dropdown menus, but will "
-                    "still be accepted if manually entered.",
+                    "and groups. This is an optimization for large LDAP "
+                    "Environments. When caching is disabled, LDAP users "
+                    "and groups do not appear in dropdown menus, but are "
+                    "still accepted in relevant form fields if manually entered."
                 )
             )
         )

--- a/gui/directoryservice/migrations/0013_add_disable_freenas_cache_to_ldap.py
+++ b/gui/directoryservice/migrations/0013_add_disable_freenas_cache_to_ldap.py
@@ -17,11 +17,9 @@ class Migration(migrations.Migration):
                 verbose_name='Disable LDAP user/group cache',
                 default=False,
                 help_text=(
-                    "Set to disable caching LDAP users "
-                    "and groups. This is an optimization for large LDAP "
-                    "Environments. When caching is disabled, LDAP users "
-                    "and groups do not appear in dropdown menus, but are "
-                    "still accepted in relevant form fields if manually entered."
+                    "Set to disable caching LDAP users and groups in large LDAP environments. "
+                    "When caching is disabled, LDAP users and groups do not appear in dropdown "
+                    "menus, but are still accepted when manually entered."
                 )
             )
         )

--- a/gui/directoryservice/models.py
+++ b/gui/directoryservice/models.py
@@ -1099,6 +1099,17 @@ class LDAP(DirectoryServiceBase):
         null=True,
         limit_choices_to={'cert_certificate__isnull': False, 'cert_privatekey__isnull': False}
     )
+    ldap_disable_freenas_cache = models.BooleanField(
+        verbose_name=_("Disable LDAP user/group cache"),
+        help_text=_(
+            "Set this if you want to disable caching LDAP users "
+            "and groups. This is an optimization for large LDAP  "
+            "Environments. If caching is disabled, then LDAP users "
+            "and groups will not appear in dropdown menus, but will "
+            "still be accepted if manually entered.",
+        ),
+        default=False
+    )
     ldap_timeout = models.IntegerField(
         verbose_name=_("LDAP timeout"),
         help_text=_("Timeout for LDAP related commands."),

--- a/gui/directoryservice/models.py
+++ b/gui/directoryservice/models.py
@@ -1102,7 +1102,7 @@ class LDAP(DirectoryServiceBase):
     ldap_disable_freenas_cache = models.BooleanField(
         verbose_name=_("Disable LDAP user/group cache"),
         help_text=_(
-            "Set this if you want to disable caching LDAP users "
+            "Set to disable caching LDAP users "
             "and groups. This is an optimization for large LDAP "
             "Environments. When caching is disabled, LDAP users "
             "and groups do not appear in dropdown menus, but are "

--- a/gui/directoryservice/models.py
+++ b/gui/directoryservice/models.py
@@ -1103,10 +1103,10 @@ class LDAP(DirectoryServiceBase):
         verbose_name=_("Disable LDAP user/group cache"),
         help_text=_(
             "Set this if you want to disable caching LDAP users "
-            "and groups. This is an optimization for large LDAP  "
-            "Environments. If caching is disabled, then LDAP users "
-            "and groups will not appear in dropdown menus, but will "
-            "still be accepted if manually entered.",
+            "and groups. This is an optimization for large LDAP "
+            "Environments. When caching is disabled, LDAP users "
+            "and groups do not appear in dropdown menus, but are "
+            "still accepted in relevant form fields if manually entered."
         ),
         default=False
     )

--- a/gui/directoryservice/models.py
+++ b/gui/directoryservice/models.py
@@ -1102,11 +1102,9 @@ class LDAP(DirectoryServiceBase):
     ldap_disable_freenas_cache = models.BooleanField(
         verbose_name=_("Disable LDAP user/group cache"),
         help_text=_(
-            "Set to disable caching LDAP users "
-            "and groups. This is an optimization for large LDAP "
-            "Environments. When caching is disabled, LDAP users "
-            "and groups do not appear in dropdown menus, but are "
-            "still accepted in relevant form fields if manually entered."
+            "Set to disable caching LDAP users and groups in large LDAP environments. "
+            "When caching is disabled, LDAP users and groups do not appear in dropdown "
+            "menus, but are still accepted when manually entered."
         ),
         default=False
     )

--- a/src/middlewared/middlewared/etc_files/local/nslcd.conf
+++ b/src/middlewared/middlewared/etc_files/local/nslcd.conf
@@ -32,6 +32,9 @@
     binddn 	${ldap['ldap_binddn']}
     bindpw 	${ldap['ldap_bindpw']}
   % endif
+  % if ldap['ldap_disable_freenas_cache']:
+    nss_disable_enumeration yes
+  % endif
   % if ldap['ldap_kerberos_principal'] and ldap['ldap_kerberos_realm']:
     sasl_mech 	GSSAPI
     sasl_realm ${ldap['ldap_kerberos_realm']}


### PR DESCRIPTION
Mirror what we have in AD plugin. If cache is disabled,
then don't fill the cache with ldap users. Also disable
enumeration in the nslcd.conf file.