### PR TITLE
NAS-101894 / 11.3 / Do not apply default permissions on new SMB shares by default

### DIFF
--- a/gui/sharing/forms.py
+++ b/gui/sharing/forms.py
@@ -58,13 +58,6 @@ class CIFS_ShareForm(MiddlewareModelForm, ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(CIFS_ShareForm, self).__init__(*args, **kwargs)
-        if self.instance.id:
-            self.fields['cifs_default_permissions'].initial = False
-            self._original_cifs_vfsobjects = self.instance.cifs_vfsobjects
-        else:
-            self.fields['cifs_default_permissions'].initial = True
-            self._original_cifs_vfsobjects = []
-
         key_order(self, 4, 'cifs_default_permissions', instance=True)
 
         self.fields['cifs_guestok'].widget.attrs['onChange'] = (

--- a/gui/sharing/models.py
+++ b/gui/sharing/models.py
@@ -129,7 +129,7 @@ class CIFS_Share(Model):
         verbose_name=_('VFS Objects'),
         max_length=255,
         blank=True,
-        default='zfs_space,zfsacl,streams_xattr',
+        default='ixnas,streams_xattr',
         choices=list(choices.CIFS_VFS_OBJECTS())
     )
     cifs_vuid = models.CharField(

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -613,7 +613,7 @@ class SharingSMBService(CRUDService):
         List('vfsobjects', default=['zfs_space', 'zfsacl', 'streams_xattr']),
         Bool('shadowcopy', default=False),
         Str('auxsmbconf'),
-        Bool('default_permissions'),
+        Bool('default_permissions', default=False),
         Bool('enabled', default=True),
         register=True
     ))


### PR DESCRIPTION
Now that we have an ACL editor, this should not be the default behavior for new SMB shares. It is inherently unsafe.