### PR TITLE
NAS-102115 / 11.2 / Don't perform AD monitoring checks on passive storage controller

### DIFF
--- a/src/middlewared/middlewared/plugins/service_monitor.py
+++ b/src/middlewared/middlewared/plugins/service_monitor.py
@@ -164,6 +164,14 @@ class ServiceMonitorThread(threading.Thread):
 
         return False
 
+    @private
+    def isPassive(self):
+        if not self.middleware.call_sync('notifier.is_freenas'):
+            if self.middleware.call_sync('notifier.failover_status') == 'BACKUP':
+                return True
+
+        return False
+
     def run(self):
         ntries = 0
 
@@ -179,6 +187,9 @@ class ServiceMonitorThread(threading.Thread):
                 # Thread.cancel() takes a while to propagate here
                 ServiceMonitorThread.reset_alerts(service)
                 return
+
+            if self.isPassive():
+                continue
 
             if os.path.exists('/tmp/.ad_start'):
                 """


### PR DESCRIPTION
We shouldn't perform these checks on the passive, but we should also be ready in case we fail over, and so don't exit the monitor loop.