### PR TITLE
NAS-102122 / 11.3 / feat(usage): Add system_hash

### DIFF
--- a/src/middlewared/middlewared/plugins/usage.py
+++ b/src/middlewared/middlewared/plugins/usage.py
@@ -5,6 +5,7 @@ import json
 import asyncio
 import random
 import aiohttp
+import hashlib
 
 
 class UsageService(Service):
@@ -165,6 +166,9 @@ class UsageService(Service):
 
         usage_version = 1
         version = system['version']
+        system_hash = hashlib.sha256((await self.middleware.call(
+            'systemdataset.config'
+        ))['uuid'].encode()).hexdigest()
         datasets = await self.middleware.call(
             'zfs.dataset.query', [('type', '!=', 'VOLUME')], {'count': True}
         )
@@ -180,6 +184,7 @@ class UsageService(Service):
 
         return {
             'gather_system': [
+                {'system_hash': system_hash},
                 {'platform': platform},
                 {'usage_version': usage_version},
                 {'version': version},


### PR DESCRIPTION
We use the freenas-boot’s UUID to generate an sha256sum to avoid duplicate entries.

NAS-102122

Signed-off-by: Brandon Schneider <brandon@ixsystems.com>