### PR TITLE
NAS-100103 / 11.3 / Store share ACL information persistently

### DIFF
--- a/gui/middleware/notifier.py
+++ b/gui/middleware/notifier.py
@@ -337,24 +337,6 @@ class notifier(metaclass=HookMetaclass):
 
         return ret
 
-    def sharesec_delete(self, share):
-        if not share:
-            return False
-
-        log.debug("sharesec_delete: deleting ACL on %s", share)
-
-        sharesec = "/usr/local/bin/sharesec"
-        delete_cmd = "%s %s -D" % (sharesec, share)
-
-        ret = True
-        try:
-            self._pipeopen(delete_cmd).communicate()
-        except Exception:
-            log.debug("sharesec_delete: %s failed", delete_cmd)
-            ret = False
-
-        return ret
-
     def change_upload_location(self, path):
         vardir = "/var/tmp/firmware"
 

--- a/gui/sharing/migrations/0017_add_share_acl.py
+++ b/gui/sharing/migrations/0017_add_share_acl.py
@@ -1,0 +1,18 @@
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sharing', '0016_enabled'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='cifs_share',
+            name='cifs_share_acl',
+            field=models.TextField(default=False, verbose_name='SMB Share ACL'),
+        ),
+    ]

--- a/gui/sharing/models.py
+++ b/gui/sharing/models.py
@@ -138,6 +138,11 @@ class CIFS_Share(Model):
         blank=True,
         editable=False,
     )
+    cifs_share_acl = models.TextField(
+        verbose_name=_('SMB Share ACL'),
+        blank=True,
+        editable=False,
+    )
     cifs_auxsmbconf = models.TextField(
         verbose_name=_("Auxiliary Parameters"),
         blank=True,

--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -919,8 +919,6 @@ class ServiceService(CRUDService):
         except Exception as e:
             raise CallError(e)
 
-        await self._service("ix-post-samba", "start", quiet=True, **kwargs)
-
     async def _stop_cifs(self, **kwargs):
         await self._service("samba_server", "stop", force=True, **kwargs)
 

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 from middlewared.common.attachment import FSAttachmentDelegate
 from middlewared.schema import Bool, Dict, IPAddr, List, Str, Int, Patch
 from middlewared.service import (SystemServiceService, ValidationErrors,
@@ -1095,7 +1094,7 @@ class ShareSec(Service):
     async def getacl(self, share_name, options):
         """
         View the ACL information for `share_name`. The share ACL is distinct from filesystem
-        ACLs which can be viewed by calling `filesystem,.getacl`. `ae_who_name` will appear
+        ACLs which can be viewed by calling `filesystem.getacl`. `ae_who_name` will appear
         as `None` if the SMB service is stopped or if winbind is unable  to resolve the SID
         to a name.
 
@@ -1264,9 +1263,7 @@ class ShareSec(Service):
             rc_info = (list(filter(lambda x: s['name'] == x['share_name'], rc)))[0]
             rc_acl = ' '.join([(await self._ae_to_string(i)) for i in rc_info['share_acl']])
             if rc_acl != s['share_acl']:
-                self.logger.debug(
-                    'updating stored ACL on %s to %s' % (s['name'], rc_acl)
-                )
+                self.logger.debug('updating stored ACL on %s to %s', s['name'], rc_acl)
                 await self.middleware.call(
                     'datastore.update',
                     'sharing.cifs_share',

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1177,7 +1177,6 @@ class ShareSec(Service):
         `ae_type` can be ALLOWED or DENIED.
         """
         ae_list = []
-        cleaned_acl = []
         data['share_name'] = data['share_name'].upper()
         for entry in data['share_acl']:
             ae_list.append(await self._ae_to_string(entry))


### PR DESCRIPTION
This ACL is stored in /var/db/samba4/share_info.tdb, and is used by many users to control share visibility in browse lists with the parameter "access based share enumeration". Make middleware aware of its presence and set up periodic task to synchronize the share ACL information with the freenas configuration database (if needed).