### PR TITLE
NAS-102162 / 11.2 / Bug fix for validation errors

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -680,7 +680,8 @@ class JailService(CRUDService):
                     'Index cannot be "None" when replacing an fstab entry.'
                 )
 
-        verrors.check()
+        if verrors:
+            raise verrors
 
         source = options.get('source')
         if action in ('add', 'replace') and not os.path.exists(source):


### PR DESCRIPTION
This commit fixes a backporting issue where check attribute for validation errors doesn't exist in 11.2