### PR TITLE
NAS-101014 / 11.3 / Retrieve interface choices for jails

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -395,6 +395,17 @@ class JailService(CRUDService):
 
         return pool
 
+    @accepts()
+    async def interface_choices(self):
+        """
+        Returns a dictionary of interface choices which can be used with creating/updating jails.
+        """
+        return await self.middleware.call(
+            'interface.choices', {
+                'exclude': ['lo', 'pflog', 'pfsync', 'tun', 'tap', 'epair', 'vnet', 'bridge']
+            }
+        )
+
     @accepts(
         Dict(
             'options',


### PR DESCRIPTION
This commit adds a new method which returns sane choices for interface selection wrt creating/update jails.