### PR TITLE
NAS-101922 / 11.3 / Migrate iocage mountpoint

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -359,7 +359,7 @@ class JailService(CRUDService):
     @private
     def check_dataset_existence(self):
         try:
-            IOCCheck()
+            IOCCheck(migrate=True)
         except ioc_exceptions.PoolNotActivated as e:
             raise CallError(e, errno=errno.ENOENT)
 


### PR DESCRIPTION
This commit makes sure that iocage dataset is mounted under the activated pool and is not somewhere else. This helps makes sure that it can be used with other system services easily like rsync tasks etc.