### PR TITLE
NAS-102151 / 11.2 / More fixes for creating/deleting huge pools

### DIFF
--- a/gui/storage/models.py
+++ b/gui/storage/models.py
@@ -439,10 +439,10 @@ class Volume(Model):
             systemdataset.save()
             n.restart('system_datasets')
 
-        # Refresh the fstab
-        n.reload("disk")
-        # For scrub tasks
-        n.restart("cron")
+        bulk = [["service.reload", [["disk"]]],
+                ["service.restart", [["cron"]]]]
+        with client as c:
+            c.call("core.bulk", "core.bulk", bulk)
 
         # Django signal could have been used instead
         # Do it this way to make sure its ran in the time we want


### PR DESCRIPTION
This time we are facing race condition between S.M.A.R.T. restart that is issued by `disk.sync_all` under certain conditions and S.M.A.R.T. restart that is issued after pool creation. Restarting S.M.A.R.T. daemon that is still initializing can take a lot of time and that's what times out. Also fixed volume wizard and pool deletion which suffer from the same issue.