### PR TITLE
Set maxlength attribute for replication schema

### DIFF
--- a/src/middlewared/middlewared/plugins/crypto.py
+++ b/src/middlewared/middlewared/plugins/crypto.py
@@ -1340,9 +1340,9 @@ class CertificateService(CRUDService):
     @accepts(
         Dict(
             'create_imported_csr',
-            Str('CSR', required=True),
+            Str('CSR', required=True, max_length=None),
             Str('name'),
-            Str('privatekey', required=True),
+            Str('privatekey', required=True, max_length=None),
             Str('passphrase')
         )
     )

--- a/src/middlewared/middlewared/plugins/keychain.py
+++ b/src/middlewared/middlewared/plugins/keychain.py
@@ -107,8 +107,8 @@ class SSHKeyPair(KeychainCredentialType):
     title = "SSH Key Pair"
 
     credentials_schema = [
-        Str("private_key", null=True, default=None),
-        Str("public_key", null=True, default=None),
+        Str("private_key", null=True, default=None, max_length=None),
+        Str("public_key", null=True, default=None, max_length=None),
     ]
 
     used_by_delegates = [


### PR DESCRIPTION
This commit adds max length attribute to certain schemas so they allow a string of more then 1024 chars.