### PR TITLE
Bug fix for str schema

### DIFF
--- a/src/middlewared/middlewared/schema.py
+++ b/src/middlewared/middlewared/schema.py
@@ -343,6 +343,9 @@ class Time(Str):
             except TypeError:
                 raise ValueError('Time should be in 24 hour format like "18:00"')
 
+    def validate(self, value):
+        return super().validate(str(value))
+
 
 class UnixPerm(Str):
 


### PR DESCRIPTION
This commit fixes an issue where time schema's validation would raise an exception as we would be checking length of datetime.time object. We convert the type to string before checking for length in str schema validation now.