### PR TITLE
NAS-102191 / 11.2 / Do not start LDAP or AD on passive controller if system dataset not o…

### DIFF
--- a/src/freenas/etc/directoryservice/ActiveDirectory/ctl
+++ b/src/freenas/etc/directoryservice/ActiveDirectory/ctl
@@ -77,6 +77,17 @@ adctl_start()
 {
 	local cifs_started=0	
 	local ad_started=0
+	local syspool=$(eval echo $(${notifier} call systemdataset.config | /usr/local/bin/jq .pool))
+	local is_freenas=$(${notifier} call system.is_freenas)
+	local failover_status='SINGLE'
+	if [ ${is_freenas} == 'False' ]; then
+		failover_status=$(${notifier} call notifier.failover_status)
+	fi
+
+	if [ \(${syspool} != "freenas-boot"\) -a \( ${failover_status} == "BACKUP" \) ]; then
+		return
+	fi
+
 	touch "${start_file}"
 
 	#56751 - verify that servers in /etc/directoryservice/ActiveDirectory/config

--- a/src/freenas/etc/directoryservice/ActiveDirectory/ctl
+++ b/src/freenas/etc/directoryservice/ActiveDirectory/ctl
@@ -85,7 +85,7 @@ adctl_start()
 	fi
 
 	if [ \(${syspool} != "freenas-boot"\) -a \( ${failover_status} == "BACKUP" \) ]; then
-		return
+		return 0
 	fi
 
 	touch "${start_file}"

--- a/src/freenas/etc/directoryservice/ActiveDirectory/ctl
+++ b/src/freenas/etc/directoryservice/ActiveDirectory/ctl
@@ -84,7 +84,7 @@ adctl_start()
 		failover_status=$(${notifier} call notifier.failover_status)
 	fi
 
-	if [ \(${syspool} != "freenas-boot"\) -a \( ${failover_status} == "BACKUP" \) ]; then
+	if [ ${syspool} != "freenas-boot" ] && [ ${failover_status} == "BACKUP" ]; then
 		return 0
 	fi
 

--- a/src/freenas/etc/directoryservice/LDAP/ctl
+++ b/src/freenas/etc/directoryservice/LDAP/ctl
@@ -107,7 +107,7 @@ ldapctl_start()
 		failover_status=$(${notifier} call notifier.failover_status)
 	fi
 
-	if [ \(${syspool} != "freenas-boot"\) -a \( ${failover_status} == "BACKUP" \) ]; then
+	if [ ${syspool} != "freenas-boot" ] && [ ${failover_status} == "BACKUP" ]; then
 		return 0
 	fi
 

--- a/src/freenas/etc/directoryservice/LDAP/ctl
+++ b/src/freenas/etc/directoryservice/LDAP/ctl
@@ -100,6 +100,16 @@ ldapctl_start()
 	local ldap_started=0
 	local realm
 	local keytab_principal
+	local syspool=$(eval echo $(${notifier} call systemdataset.config | /usr/local/bin/jq .pool))
+	local is_freenas=$(${notifier} call system.is_freenas)
+	local failover_status='SINGLE'
+	if [ ${is_freenas} == 'False' ]; then
+		failover_status=$(${notifier} call notifier.failover_status)
+	fi
+
+	if [ \(${syspool} != "freenas-boot"\) -a \( ${failover_status} == "BACKUP" \) ]; then
+		return
+	fi
 
 	# chicken & eggs
 	realm=$(LDAP_get_krb_realm)

--- a/src/freenas/etc/directoryservice/LDAP/ctl
+++ b/src/freenas/etc/directoryservice/LDAP/ctl
@@ -108,7 +108,7 @@ ldapctl_start()
 	fi
 
 	if [ \(${syspool} != "freenas-boot"\) -a \( ${failover_status} == "BACKUP" \) ]; then
-		return
+		return 0
 	fi
 
 	# chicken & eggs


### PR DESCRIPTION
…n boot device

When system dataset is on data pool in 11.2, we generate a stub config.
In this situation, the AD ctl script will fail to start and generate a UI alert about the passive controller.
Modify ctl scripts to check for this situation and return early.