### PR TITLE
NAS-102206 / 11.2 / fix(rc): only run rc.conf.local script as root

### DIFF
--- a/src/freenas/etc/rc.conf.local
+++ b/src/freenas/etc/rc.conf.local
@@ -894,7 +894,7 @@ _gen_conf()
 # However this solution could not deal with backward date changes
 _NEWSUM=$(md5 -q ${FREENAS_CONFIG})
 _OLDSUM=$(cat ${FREENAS_CONFIG_MD5} 2> /dev/null)
-if [ ! "${_NEWSUM}" = "${_OLDSUM}" -a ! -f "${NEED_UPDATE_SENTINEL}" ]; then
+if [ "$(id -u)" -eq 0 -a ! "${_NEWSUM}" = "${_OLDSUM}" -a ! -f "${NEED_UPDATE_SENTINEL}" ]; then
 	# There are some circunstances which make concurrent runs of
 	# this script possible, e.g. devd carp script
 	# To make it atomic generate to a tmp file first then move it.


### PR DESCRIPTION
/usr/libexec/save-entropy cron run as operator and sources
rc.conf.local, causing permission denied messages to be logged.

Ticket:	NAS-102206