### PR TITLE
NAS-100161 / 11.3 / Default for UPS Shutdown command

### DIFF
--- a/gui/services/migrations/0033_ups_shutdowncmd.py
+++ b/gui/services/migrations/0033_ups_shutdowncmd.py
@@ -1,0 +1,33 @@
+from django.db import migrations, models
+
+
+def set_default_for_ups_shutdowncmd(apps, schema_editor):
+    ups = apps.get_model('services.UPS').objects.latest('id')
+    if ups.ups_shutdowncmd == '/sbin/shutdown -p now':
+        ups.ups_shutdowncmd = None
+        ups.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('services', '0032_enabled'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='ups',
+            name='ups_shutdowncmd',
+            field=models.CharField(
+                blank=True,
+                help_text='The command used to shutdown the server. You can use a custom command here to perform '
+                          'other tasks before shutdown.default: /sbin/shutdown -p now',
+                max_length=255,
+                null=True,
+                verbose_name='Shutdown Command'
+            ),
+        ),
+        migrations.RunPython(
+            set_default_for_ups_shutdowncmd 
+        ),
+    ]

--- a/gui/services/models.py
+++ b/gui/services/models.py
@@ -1255,7 +1255,8 @@ class UPS(Model):
     ups_shutdowncmd = models.CharField(
         max_length=255,
         verbose_name=_("Shutdown Command"),
-        default='/sbin/shutdown -p now',
+        null=True,
+        blank=True,
         help_text=_(
             "The command used to shutdown the server. You can use "
             "a custom command here to perform other tasks before shutdown."

--- a/src/middlewared/middlewared/etc_files/local/nut/upsmon.conf
+++ b/src/middlewared/middlewared/etc_files/local/nut/upsmon.conf
@@ -13,6 +13,13 @@
 		ident = ups_config['identifier']
 	else:
 		ident = f'{ups_config["identifier"]}@{ups_config["remotehost"]}:{ups_config["remoteport"]}'
+	if not ups_config['shutdowncmd'] and not (
+		not (middleware.call_sync('system.is_freenas')) and (
+			middleware.call_sync('truenas.get_chassis_hardware')).startswith('TRUENAS-X')
+	):
+		shutdown_cmd = '/sbin/shutdown -p now'
+	else:
+		shutdown_cmd = ups_config['shutdowncmd'] or ''
 %>\
 MONITOR ${ident} 1 ${user} ${ups_config['monpwd']} ${ups_config['mode']}
 NOTIFYCMD "/usr/local/sbin/upssched"
@@ -25,7 +32,7 @@ NOTIFYFLAG REPLBATT SYSLOG+EXEC
 NOTIFYFLAG NOCOMM SYSLOG+EXEC
 NOTIFYFLAG FSD SYSLOG+EXEC
 NOTIFYFLAG SHUTDOWN SYSLOG+EXEC
-SHUTDOWNCMD "${ups_config['shutdowncmd']}"
+SHUTDOWNCMD "${shutdown_cmd}"
 POWERDOWNFLAG ${powerdown}
 HOSTSYNC ${ups_config['hostsync']}
 % if ups_config['nocommwarntime']:

--- a/src/middlewared/middlewared/plugins/ups.py
+++ b/src/middlewared/middlewared/plugins/ups.py
@@ -155,7 +155,7 @@ class UPSService(SystemServiceService):
             Str('port'),
             Str('remotehost'),
             Str('shutdown', enum=['LOWBATT', 'BATT']),
-            Str('shutdowncmd', empty=False),
+            Str('shutdowncmd', null=True),
             Str('subject'),
             List('toemail', items=[Str('email', validators=[Email()])]),
             update=True


### PR DESCRIPTION
This PR sets a default for UPS shutdown command in case user hasn't supplied and system is not a truenas x series model, in other case where the system is a truenas x series model and database has no shutdown command, we let the command be empty.