### PR TITLE
NAS-101743 / 11.3 / fix(jail/setup): Supply interactive as False

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -108,7 +108,7 @@ class JailService(CRUDService):
                     jails.append(jail)
         except ioc_exceptions.JailMisconfigured as e:
             self.logger.error(e, exc_info=True)
-        except BaseException:
+        except Exception:
             # Brandon is working on fixing this generic except, till then I
             # am not going to make the perfect the enemy of the good enough!
             self.logger.debug('Failed to get list of jails', exc_info=True)
@@ -375,7 +375,7 @@ class JailService(CRUDService):
             else:
                 iocage = ioc.IOCage(skip_jails=skip, jail=jail)
             jail, path = iocage.__check_jail_existence__()
-        except (SystemExit, RuntimeError):
+        except RuntimeError:
             raise CallError(f"jail '{jail}' not found!")
 
         return jail, path, iocage
@@ -723,7 +723,7 @@ class JailService(CRUDService):
                 iocage.stop()
             else:
                 iocage.restart()
-        except BaseException as e:
+        except Exception as e:
             raise CallError(str(e))
 
         return True
@@ -738,7 +738,7 @@ class JailService(CRUDService):
         if not status:
             try:
                 iocage.start()
-            except BaseException as e:
+            except Exception as e:
                 raise CallError(str(e))
 
         return True
@@ -753,7 +753,7 @@ class JailService(CRUDService):
         if status:
             try:
                 iocage.stop(force=force)
-            except BaseException as e:
+            except Exception as e:
                 raise CallError(str(e))
 
             return True
@@ -768,12 +768,12 @@ class JailService(CRUDService):
         if status:
             try:
                 iocage.stop()
-            except BaseException as e:
+            except Exception as e:
                 raise CallError(str(e))
 
         try:
             iocage.start()
-        except BaseException as e:
+        except Exception as e:
             raise CallError(str(e))
 
         return True
@@ -968,7 +968,7 @@ class JailService(CRUDService):
             msg = iocage.exec(
                 command, host_user, jail_user, start_jail=True, msg_return=True
             )
-        except BaseException as e:
+        except Exception as e:
             raise CallError(str(e))
 
         return '\n'.join(msg)
@@ -1257,3 +1257,4 @@ async def setup(middleware):
     await middleware.call('pool.dataset.register_attachment_delegate', JailFSAttachmentDelegate(middleware))
     middleware.register_hook('pool.pre_lock', jail_pool_pre_lock)
     middleware.event_subscribe('system', __event_system)
+    ioc_common.set_interactive(False)


### PR DESCRIPTION
This will give us the correct exceptions instead of SystemExit.

Also remove the old checks for that.

NAS-101743

Signed-off-by: Brandon Schneider <brandon@ixsystems.com>