### PR TITLE
NAS-102220 / 11.3 / Pkg list should be a list in jail plugin

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -120,7 +120,7 @@ class JailService(CRUDService):
             "options",
             Str("release", required=True),
             Str("template"),
-            Str("pkglist"),
+            List("pkglist", default=[], items=[Str("pkg", empty=False)]),
             Str("uuid", required=True),
             Bool("basejail", default=False),
             Bool("empty", default=False),
@@ -186,9 +186,7 @@ class JailService(CRUDService):
             release = template
 
         if (
-                not os.path.isdir(f'{iocroot}/releases/{release}') and
-                not template and
-                not empty
+            not os.path.isdir(f'{iocroot}/releases/{release}') and not template and not empty
         ):
             job.set_progress(50, f'{release} missing, calling fetch')
             self.middleware.call_sync(


### PR DESCRIPTION
When a jail is created, pkg list can be supplied which indicate which packages should be installed in the system. Now if pkg list is a string, iocage expects it to be a path to file which does not conform to how our api should operate.