### PR TITLE
NAS-101260 / 11.3 / Remove unnecessary mdnsd restarts and simplify mdns plugin

### DIFF
--- a/src/middlewared/middlewared/plugins/mdns.py
+++ b/src/middlewared/middlewared/plugins/mdns.py
@@ -2,17 +2,11 @@ import threading
 import time
 import os
 import pybonjour
-import queue
 import select
 import socket
 import subprocess
 
 from bsd.threading import set_thread_name
-from pybonjour import (
-    kDNSServiceFlagsMoreComing,
-    kDNSServiceFlagsAdd,
-    kDNSServiceErr_NoError
-)
 
 from middlewared.service import Service, private
 

--- a/src/middlewared/middlewared/plugins/mdns.py
+++ b/src/middlewared/middlewared/plugins/mdns.py
@@ -95,23 +95,6 @@ class mDNSDaemonMonitor(threading.Thread):
         return p.returncode == 0
 
 
-class mDNSObject(object):
-    def __init__(self, **kwargs):
-        self.sdRef = kwargs.get('sdRef')
-        self.flags = kwargs.get('flags')
-        self.interface = kwargs.get('interface')
-        self.name = kwargs.get('name')
-
-    def to_dict(self):
-        return {
-            'type': 'mDNSObject',
-            'sdRef': memoryview(self.sdRef).tobytes().decode('utf-8'),
-            'flags': self.flags,
-            'interface': self.interface,
-            'name': self.name
-        }
-
-
 class mDNSThread(threading.Thread):
     def __init__(self, **kwargs):
         super(mDNSThread, self).__init__()

--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -517,7 +517,7 @@ class ServiceService(CRUDService):
         await self.middleware.call('etc.generate', 'hostname')
         await self.middleware.call('etc.generate', 'rc')
         await self._service("hostname", "start", quiet=True, **kwargs)
-        await self._service("mdnsd", "restart", quiet=True, **kwargs)
+        await self.middleware.call('mdnsadvertise.restart')
         await self._restart_collectd(**kwargs)
 
     async def _reload_resolvconf(self, **kwargs):
@@ -895,20 +895,12 @@ class ServiceService(CRUDService):
     async def _reload_cifs(self, **kwargs):
         await self.middleware.call("etc.generate", "smb_share")
         await self._service("samba_server", "reload", force=True, **kwargs)
-        await self._service("mdnsd", "restart", **kwargs)
-        # After mdns is restarted we need to reload netatalk to have it rereregister
-        # with mdns. Ticket #7133
-        await self._service("netatalk", "reload", **kwargs)
 
     async def _restart_cifs(self, **kwargs):
         await self.middleware.call("etc.generate", "smb")
         await self.middleware.call("etc.generate", "smb_share")
         await self._service("samba_server", "stop", force=True, **kwargs)
         await self._service("samba_server", "restart", quiet=True, **kwargs)
-        await self._service("mdnsd", "restart", **kwargs)
-        # After mdns is restarted we need to reload netatalk to have it rereregister
-        # with mdns. Ticket #7133
-        await self._service("netatalk", "reload", **kwargs)
 
     async def _start_cifs(self, **kwargs):
         await self.middleware.call("etc.generate", "smb")


### PR DESCRIPTION
- In testing, _smb._tcp. SRV records are automatically updated when samba is restarted.
  Removing the mdnsd restart removes need to restart netatalk, which reduces risk of unintended service disruption.
- Remove some remaining bits and pieces of mdnsbrowser code