### PR TITLE
NAS-101249 / 11.3 / Bug fix for spaces in path names for fstab

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -949,7 +949,7 @@ class JailService(CRUDService):
             )
 
             for i in _list:
-                fstab_entry = i[1].split()
+                fstab_entry = i[1]
                 _fstab_type = 'SYSTEM' if fstab_entry[0].endswith(
                     system_mounts) else 'USER'
 


### PR DESCRIPTION
This commit fixes an issue where if spaces were defined in src/destination paths, we could not cleanly interpret where to split.