### PR TITLE
NAS-102237 / 11.3 / Expose method to restart UI

### DIFF
--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -1003,6 +1003,14 @@ class SystemGeneralService(ConfigService):
         return await self.config()
 
     @accepts()
+    async def ui_restart(self):
+        """
+        Restart HTTP server to use latest UI settings.
+        """
+        await self.middleware.call('service.restart', 'http')
+        await self.middleware.call('service.restart', 'django')
+
+    @accepts()
     async def local_url(self):
         """
         Returns configured local url in the format of protocol://host:port


### PR DESCRIPTION
This commit exposes a method in system.general service which can be used to restart UI after changes in UI have been made like cert changes etc. The method restarts nginx and django as soon as it is called.