### PR TITLE
Bug fix for account plugin str schema

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -147,7 +147,7 @@ class UserService(CRUDService):
         Bool('locked', default=False),
         Bool('microsoft_account', default=False),
         Bool('sudo', default=False),
-        Str('sshpubkey', null=True),
+        Str('sshpubkey', null=True, max_length=None),
         List('groups', default=[]),
         Dict('attributes', additional_attrs=True),
         register=True,


### PR DESCRIPTION
This commit fixes a regression for max length attribute of str schema in account plugin.