### PR TITLE
NAS-102258 / 11.3 / Update 'guest' help text for SMB shares

### DIFF
--- a/gui/sharing/models.py
+++ b/gui/sharing/models.py
@@ -85,7 +85,10 @@ class CIFS_Share(Model):
         verbose_name=_('Allow Guest Access'),
         help_text=_(
             'If true then no password is required to connect to the share. '
-            'Privileges will be those of the guest account.'
+            'Privileges will be those of the guest account. Guest access may '
+            'be disabled by default in Windows 10 and Windows Server starting with '
+            'versions 1709 and 1903. Additional client-side configuration may be '
+            'required to provide guest access to these clients. '
         ),
         default=False,
     )

--- a/gui/sharing/models.py
+++ b/gui/sharing/models.py
@@ -86,7 +86,7 @@ class CIFS_Share(Model):
         help_text=_(
             'If true then no password is required to connect to the share. '
             'Privileges are the same as the guest account. Guest access is '
-            'be disabled by default in Windows 10 and Windows Server starting with '
+            'disabled by default in Windows 10 version 1709 and Windows Server version 1903. '
             'versions 1709 and 1903. Additional client-side configuration may be '
             'required to provide guest access to these clients. '
         ),

--- a/gui/sharing/models.py
+++ b/gui/sharing/models.py
@@ -88,7 +88,7 @@ class CIFS_Share(Model):
             'Privileges are the same as the guest account. Guest access is '
             'disabled by default in Windows 10 version 1709 and Windows Server version 1903. '
             'Additional client-side configuration is required to provide '
-            'required to provide guest access to these clients. '
+            'guest access to these clients. See <url with instructions>.'
         ),
         default=False,
     )

--- a/gui/sharing/models.py
+++ b/gui/sharing/models.py
@@ -87,7 +87,7 @@ class CIFS_Share(Model):
             'If true then no password is required to connect to the share. '
             'Privileges are the same as the guest account. Guest access is '
             'disabled by default in Windows 10 version 1709 and Windows Server version 1903. '
-            'versions 1709 and 1903. Additional client-side configuration may be '
+            'Additional client-side configuration is required to provide '
             'required to provide guest access to these clients. '
         ),
         default=False,

--- a/gui/sharing/models.py
+++ b/gui/sharing/models.py
@@ -88,7 +88,7 @@ class CIFS_Share(Model):
             'Privileges are the same as the guest account. Guest access is '
             'disabled by default in Windows 10 version 1709 and Windows Server version 1903. '
             'Additional client-side configuration is required to provide '
-            'guest access to these clients. See <url with instructions>.'
+            'guest access to these clients.'
         ),
         default=False,
     )

--- a/gui/sharing/models.py
+++ b/gui/sharing/models.py
@@ -85,7 +85,7 @@ class CIFS_Share(Model):
         verbose_name=_('Allow Guest Access'),
         help_text=_(
             'If true then no password is required to connect to the share. '
-            'Privileges will be those of the guest account. Guest access may '
+            'Privileges are the same as the guest account. Guest access is '
             'be disabled by default in Windows 10 and Windows Server starting with '
             'versions 1709 and 1903. Additional client-side configuration may be '
             'required to provide guest access to these clients. '


### PR DESCRIPTION
- Recent versions of windows may not allow guest SMB2 sessions by
  default.