### PR TITLE
NAS-100718 / 11.3 / Misc improvements to mDNS plugin

### DIFF
--- a/gui/sharing/migrations/0017_add_share_acl.py
+++ b/gui/sharing/migrations/0017_add_share_acl.py
@@ -13,6 +13,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='cifs_share',
             name='cifs_share_acl',
-            field=models.TextField(default=False, verbose_name='SMB Share ACL'),
+            field=models.TextField(default='', verbose_name='SMB Share ACL'),
+            blank=True
         ),
     ]

--- a/gui/sharing/migrations/0018_add_vuid_to_afp_tm.py
+++ b/gui/sharing/migrations/0018_add_vuid_to_afp_tm.py
@@ -1,0 +1,33 @@
+from __future__ import unicode_literals
+from django.db import migrations, models
+import uuid
+
+
+def add_vuid(apps, schema_editor):
+    AFP_Share = apps.get_model('sharing', 'afp_share')
+    for row in AFP_Share.objects.all():
+        row.afp_vuid = str(uuid.uuid4()) if row.afp_timemachine else ''
+        row.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sharing', '0017_add_share_acl'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='afp_share',
+            name='afp_vuid',
+            field=models.CharField(
+                blank=True,
+                help_text='Volume UUID for _adisk._tcp. mDNS advertisment',
+                max_length=36,
+                verbose_name='Volume UUID'
+            )
+        ),
+        migrations.RunPython(
+            add_vuid
+        ),
+    ]

--- a/gui/sharing/migrations/0018_add_vuid_to_afp_tm.py
+++ b/gui/sharing/migrations/0018_add_vuid_to_afp_tm.py
@@ -27,7 +27,5 @@ class Migration(migrations.Migration):
                 verbose_name='Volume UUID'
             )
         ),
-        migrations.RunPython(
-            add_vuid
-        ),
+        migrations.RunPython(add_vuid, reverse_code=migrations.RunPython.noop),
     ]

--- a/gui/sharing/models.py
+++ b/gui/sharing/models.py
@@ -30,7 +30,6 @@ from django.utils.translation import ugettext_lazy as _
 from freenasUI import choices
 from freenasUI.freeadmin.models import Model, UserField, GroupField, PathField
 from freenasUI.freeadmin.models.fields import MultiSelectField
-from freenasUI.middleware.notifier import notifier
 
 
 class CIFS_Share(Model):
@@ -295,6 +294,12 @@ class AFP_Share(Model):
         max_length=120,
         help_text=_("Deny listed hosts and/or networks access to this volume"),
         verbose_name=_("Hosts Deny")
+    )
+    afp_vuid = models.CharField(
+        max_length=36,
+        verbose_name=_('vuid for Time Machine'),
+        blank=True,
+        editable=False,
     )
 
     afp_auxparams = models.TextField(

--- a/src/middlewared/middlewared/etc_files/local/smb4_share.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4_share.conf
@@ -126,7 +126,7 @@
                 if any(filter(lambda x: f"{x['path']}/" in f"{share['path']}/" or f"{share['path']}/" in f"{x['path']}/", db['afp_shares'])):
                     logger.debug(f"SMB share ({share['name']}) is also an AFP share. Appling parameters for mixed-protocol share.")
                     pc[share["name"]].update({
-                        "fruit:locking": "yes",
+                        "fruit:locking": "netatalk",
                         "strict locking": "auto",
                         "streams_xattr:prefix": "user.",
                         "streams_xattr:store_stream_type": "no"

--- a/src/middlewared/middlewared/plugins/mdns.py
+++ b/src/middlewared/middlewared/plugins/mdns.py
@@ -310,7 +310,6 @@ class mDNSServiceThread(threading.Thread):
             )
 
         self.finished.wait()
-        self.logger.trace("we're finished")
         for srv in mDNSServices.keys():
             self.logger.trace('Unregistering %s %s.',
                               mDNSServices[srv].name, mDNSServices[srv].regtype)

--- a/src/middlewared/middlewared/plugins/mdns.py
+++ b/src/middlewared/middlewared/plugins/mdns.py
@@ -1,14 +1,62 @@
 import threading
 import time
+import enum
 import os
 import pybonjour
 import select
-import socket
 import subprocess
 
 from bsd.threading import set_thread_name
 
 from middlewared.service import Service, private
+from middlewared.utils import filter_list
+
+
+class DevType(enum.Enum):
+    AIRPORT = 'AirPort'
+    APPLETV = 'AppleTv1,1'
+    MACPRO = 'MacPro'
+    RACKMAC = 'RackMac'
+    TIMECAPSULE = 'TimeCapsule6,106'
+    XSERVE = 'Xserve'
+
+    def __str__(self):
+        return self.value
+
+
+class ServiceType(enum.Enum):
+    ADISK = ('_adisk._tcp.', 9)
+    AFPOVERTCP = ('_afpovertcp._tcp.', 548)
+    DEV_INFO = ('_device-info._tcp.', 9)
+    FTP = ('_ftp._tcp.', 21)
+    HTTP = ('_http._tcp.', 80)
+    HTTPS = ('_https._tcp.', 443)
+    ISCSI = ('_iscsi._tcp.', 3260)
+    MIDDLEWARE = ('_middleware._tcp.', 6000)
+    MIDDLEWARE_SSL = ('_middleware-ssl._tcp.', 443)
+    NFS = ('_nfs._tcp.', 2049)
+    SSH = ('_ssh._tcp.', 22)
+    SFTP_SSH = ('_sftp-ssh._tcp.', 22)
+    SMB = ('_smb._tcp.', 445)
+
+
+class SrvToThread(enum.Enum):
+    ADISK = 'mDNSServiceAdiskThread'
+    AFP = 'mDNSServiceAFPThread'
+    DEV_INFO = 'mDNSServiceDevInfoThread'
+    FTP = 'mDNSServiceFTPThread'
+    HTTP = 'mDNSServiceHTTPThread'
+    HTTPS = 'mDNSServiceHTTPSThread'
+    ISCSI = 'mDNSServiceISCSIThread'
+    MIDDLEWARE = 'mDNSServiceMiddlewareThread'
+    MIDDLEWARE_SSL = 'mDNSServiceMiddlewareSSLThread'
+    NFS = 'mDNSServiceNFSThread'
+    SSH = 'mDNSServiceSSHThread'
+    SFTP_SSH = 'mDNSServiceSFTP_SSHThread'
+    SMB = 'mDNSServiceSMBThread'
+
+    def __str__(self):
+        return self.value
 
 
 class mDNSDaemonMonitor(threading.Thread):
@@ -89,18 +137,6 @@ class mDNSDaemonMonitor(threading.Thread):
         return p.returncode == 0
 
 
-class mDNSThread(threading.Thread):
-    def __init__(self, **kwargs):
-        super(mDNSThread, self).__init__()
-        self.setDaemon(True)
-        self.middleware = kwargs.get('middleware')
-        self.logger = self.middleware.logger
-        self.timeout = kwargs.get('timeout', 30)
-
-    def active(self, sdRef):
-        return (bool(sdRef) and sdRef.fileno() != -1)
-
-
 class mDNSServiceThread(threading.Thread):
     def __init__(self, **kwargs):
         super(mDNSServiceThread, self).__init__()
@@ -111,27 +147,35 @@ class mDNSServiceThread(threading.Thread):
         self.hostname = kwargs.get('hostname')
         self.service = kwargs.get('service')
         self.regtype = kwargs.get('regtype')
+        self.is_running = kwargs.get('is_running', True)
+        self.txtrecord = kwargs.get('txtrecord', '')
         self.port = kwargs.get('port')
         self.finished = threading.Event()
 
-    def _register(self, name, regtype, port):
+    def _register(self, name, regtype, port, txtrecord, is_running):
         """
         An instance of DNSServiceRef (sdRef) represents an active connection to mdnsd.
 
         DNSServiceRef class supports the context management protocol, sdRef
         is closed automatically when block is exited.
         """
-        if not (name and regtype and port):
+        if not is_running:
             return
 
-        sdRef = pybonjour.DNSServiceRegister(name=name, regtype=regtype, port=port, callBack=None)
+        sdRef = pybonjour.DNSServiceRegister(
+            name=name,
+            regtype=regtype,
+            port=port,
+            txtRecord=txtrecord,
+            callBack=None
+        )
         with sdRef:
             self.finished.wait()
             self.logger.trace(f'Unregistering {name} {regtype}')
 
     def register(self):
         if self.hostname and self.regtype and self.port:
-            self._register(self.hostname, self.regtype, self.port)
+            self._register(self.hostname, self.regtype, self.port, self.txtrecord, self.is_running)
 
     def run(self):
         set_thread_name(f'mdns_svc_{self.service}')
@@ -147,37 +191,155 @@ class mDNSServiceThread(threading.Thread):
         self.finished.set()
 
 
+class mDNSServiceSMBThread(mDNSServiceThread):
+    def __init__(self, **kwargs):
+        if 'service' not in kwargs:
+            kwargs['service'] = 'smb'
+        super(mDNSServiceSMBThread, self).__init__(**kwargs)
+        self.is_running = any(filter_list(
+            kwargs.get('services'), [('service', '=', 'cifs'), ('state', '=', 'RUNNING')]
+        ))
+
+    def setup(self):
+        self.regtype, self.port = ServiceType.SMB.value
+
+
+class mDNSServiceFTPThread(mDNSServiceThread):
+    def __init__(self, **kwargs):
+        if 'service' not in kwargs:
+            kwargs['service'] = 'ftp'
+        super(mDNSServiceFTPThread, self).__init__(**kwargs)
+        self.is_running = any(filter_list(
+            kwargs.get('services'), [('service', '=', 'ftp'), ('state', '=', 'RUNNING')]
+        ))
+
+    def setup(self):
+        self.regtype, self.port = ServiceType.FTP.value
+
+
+class mDNSServiceISCSIThread(mDNSServiceThread):
+    def __init__(self, **kwargs):
+        if 'service' not in kwargs:
+            kwargs['service'] = 'iscsi'
+        super(mDNSServiceISCSIThread, self).__init__(**kwargs)
+        self.is_running = any(filter_list(
+            kwargs.get('services'), [('service', '=', 'iscsitarget'), ('state', '=', 'RUNNING')]
+        ))
+
+    def setup(self):
+        self.regtype, self.port = ServiceType.ISCSI.value
+
+
+class mDNSServiceAFPThread(mDNSServiceThread):
+    def __init__(self, **kwargs):
+        if 'service' not in kwargs:
+            kwargs['service'] = 'afp'
+        super(mDNSServiceAFPThread, self).__init__(**kwargs)
+        self.is_running = any(filter_list(
+            kwargs.get('services'), [('service', '=', 'afp'), ('state', '=', 'RUNNING')]
+        ))
+
+    def setup(self):
+        self.regtype, self.port = ServiceType.AFPOVERTCP.value
+
+
+class mDNSServiceDevInfoThread(mDNSServiceThread):
+    def __init__(self, **kwargs):
+        if 'service' not in kwargs:
+            kwargs['service'] = 'dev_info'
+        super(mDNSServiceDevInfoThread, self).__init__(**kwargs)
+
+    def setup(self):
+        self.regtype, self.port = ServiceType.DEV_INFO.value
+        self.txtrecord = pybonjour.TXTRecord()
+        self.txtrecord['model'] = DevType.RACKMAC
+
+
+class mDNSServiceAdiskThread(mDNSServiceThread):
+    def __init__(self, **kwargs):
+        if 'service' not in kwargs:
+            kwargs['service'] = 'adisk'
+        super(mDNSServiceAdiskThread, self).__init__(**kwargs)
+
+    def setup(self):
+        """
+        sys=adVF=0x100 -- this is required when ._adisk._tcp is present on device. When it is
+        set, the MacOS client will send a NetShareEnumAll IOCTL and shares will be visible.
+        Otherwise, Finder will only see the Time Machine share. In the absence of ._adisk._tcp
+        MacOS will _always_ send NetShareEnumAll IOCTL.
+
+        waMa=0 -- MacOS server uses waMa=0, while embedded devices have it set to their Mac Address.
+        Speculation in Samba-Technical indicates that this stands for "Wireless ADisk Mac Address".
+
+        adVU -- ADisk Volume UUID.
+
+        dk(n)=adVF=
+        0xa1, 0x81 - AFP support
+        0xa2, 0x82 - SMB support
+        0xa3, 0x83 - AFP and SMB support
+
+        adVN -- AirDisk Volume Name. We set this to the share name.
+        network analysis indicates that current MacOS Time Machine shares set the port for adisk to 311.
+        """
+        afp_shares = self.middleware.call_sync('sharing.afp.query', [('timemachine', '=', True)])
+        smb_shares = self.middleware.call_sync('sharing.smb.query', [('timemachine', '=', True)])
+        afp = set([(x['name'], x['path']) for x in afp_shares])
+        smb = set([(x['name'], x['path']) for x in smb_shares])
+        mixed_shares = afp & smb
+        afp.difference_update(mixed_shares)
+        smb.difference_update(mixed_shares)
+        if afp_shares or smb_shares:
+            dkno = 0
+            self.regtype, self.port = ServiceType.ADISK.value
+            self.txtrecord = pybonjour.TXTRecord()
+            self.txtrecord['sys'] = 'waMa=0,adVF=0x100'
+            for i in mixed_shares:
+                smb_advu = (list(filter(lambda x: i[0] == x['name'], smb_shares)))[0]['vuid']
+                self.txtrecord[f'dk{dkno}'] = f'adVN={i[0]},adVF=0x83,adVU={smb_advu}'
+                dkno += 1
+
+            for i in smb:
+                smb_advu = (list(filter(lambda x: i[0] == x['name'], smb_shares)))[0]['vuid']
+                self.txtrecord[f'dk{dkno}'] = f'adVN={i[0]},adVF=0x82,adVU={smb_advu}'
+                dkno += 1
+
+            for i in afp:
+                afp_advu = (list(filter(lambda x: i[0] == x['name'], afp_shares)))[0]['vuid']
+                self.txtrecord[f'dk{dkno}'] = f'adVN={i[0]},adVF=0x81,adVU={afp_advu}'
+                dkno += 1
+
+
 class mDNSServiceSSHThread(mDNSServiceThread):
     def __init__(self, **kwargs):
         if 'service' not in kwargs:
             kwargs['service'] = 'ssh'
         super(mDNSServiceSSHThread, self).__init__(**kwargs)
+        self.is_running = any(filter_list(
+            kwargs.get('services'), [('service', '=', 'ssh'), ('state', '=', 'RUNNING')]
+        ))
 
     def setup(self):
-        ssh_service = self.middleware.call_sync(
-            'datastore.query',
-            'services.services', [('srv_service', '=', 'ssh'), ('srv_enable', '=', True)])
-        if ssh_service:
+        if self.is_running:
+            self.regtype, self.port = ServiceType.SSH.value
             response = self.middleware.call_sync('datastore.query', 'services.ssh', [], {'get': True})
             if response:
                 self.port = response['ssh_tcpport']
-                self.regtype = "_ssh._tcp."
 
 
-class mDNSServiceSFTPThread(mDNSServiceThread):
+class mDNSServiceSFTP_SSHThread(mDNSServiceThread):
     def __init__(self, **kwargs):
         kwargs['service'] = 'sftp'
-        super(mDNSServiceSFTPThread, self).__init__(**kwargs)
+        super(mDNSServiceSFTP_SSHThread, self).__init__(**kwargs)
+        self.is_running = any(filter_list(
+            kwargs.get('services'), [('service', '=', 'ssh'), ('state', '=', 'RUNNING')]
+        ))
 
     def setup(self):
-        ssh_service = self.middleware.call_sync(
-            'datastore.query',
-            'services.services', [('srv_service', '=', 'ssh'), ('srv_enable', '=', True)])
-        if ssh_service:
+        if self.is_running:
+            self.regtype, self.port = ServiceType.SFTP_SSH.value
             response = self.middleware.call_sync('datastore.query', 'services.ssh', [], {'get': True})
             if response:
                 self.port = response['ssh_tcpport']
-                self.regtype = "_sftp-ssh._tcp."
 
 
 class mDNSServiceHTTPThread(mDNSServiceThread):
@@ -186,9 +348,9 @@ class mDNSServiceHTTPThread(mDNSServiceThread):
         super(mDNSServiceHTTPThread, self).__init__(**kwargs)
 
     def setup(self):
+        self.regtype, self.port = ServiceType.HTTP.value
         webui = self.middleware.call_sync('datastore.query', 'system.settings')
-        self.port = int(webui[0]['stg_guiport'] or 80)
-        self.regtype = '_http._tcp.'
+        self.port = int(webui[0]['stg_guiport'] or self.port)
 
 
 class mDNSServiceHTTPSThread(mDNSServiceThread):
@@ -197,9 +359,9 @@ class mDNSServiceHTTPSThread(mDNSServiceThread):
         super(mDNSServiceHTTPSThread, self).__init__(**kwargs)
 
     def setup(self):
+        self.regtype, self.port = ServiceType.HTTPS.value
         webui = self.middleware.call_sync('datastore.query', 'system.settings')
-        self.port = int(webui[0]['stg_guihttpsport'] or 443)
-        self.regtype = '_https._tcp.'
+        self.port = int(webui[0]['stg_guihttpsport'] or self.port)
 
 
 class mDNSServiceMiddlewareThread(mDNSServiceThread):
@@ -209,19 +371,18 @@ class mDNSServiceMiddlewareThread(mDNSServiceThread):
         set_thread_name(f'mdns_{self.service}')
 
     def setup(self):
-        self.port = 6000
-        self.regtype = "_middleware._tcp."
+        self.regtype, self.port = ServiceType.MIDDLEWARE.value
 
 
 class mDNSServiceMiddlewareSSLThread(mDNSServiceThread):
     def __init__(self, **kwargs):
-        kwargs['service'] = 'middleware-ssl'
+        kwargs['service'] = 'middleware_ssl'
         super(mDNSServiceMiddlewareSSLThread, self).__init__(**kwargs)
 
     def setup(self):
+        self.regtype, self.port = ServiceType.MIDDLEWARE_SSL.value
         webui = self.middleware.call_sync('datastore.query', 'system.settings')
-        self.port = int(webui[0]['stg_guihttpsport'] or 443)
-        self.regtype = '_middleware-ssl._tcp.'
+        self.port = int(webui[0]['stg_guihttpsport'] or self.port)
 
 
 class mDNSAdvertiseService(Service):
@@ -232,6 +393,24 @@ class mDNSAdvertiseService(Service):
         self.lock = threading.Lock()
 
     @private
+    async def get_hostname(self):
+        """
+        Return virtual hostname if the server is HA and this is the active controller.
+        Return None if this is the passive controller.
+        In all other cases return the hostname_local.
+        This is to ensure that the correct hostname is used for mdns advertisements.
+        """
+        ngc = await self.middleware.call('network.configuration.config')
+        if not await self.middleware.call('system.is_freenas') and await self.middleware.call('notfier.failover_licensed'):
+            failover_status = await self.middleware.call('notifier.failover_status')
+            if failover_status == 'MASTER':
+                return ngc['virtual_hostname']
+            elif failover_status == 'BACKUP':
+                return None
+        else:
+            return ngc['hostname_local']
+
+    @private
     def start(self):
         with self.lock:
             if self.initialized:
@@ -240,14 +419,20 @@ class mDNSAdvertiseService(Service):
         if not mDNSDaemonMonitor.instance.mdnsd_running.wait(timeout=10):
             return
 
-        try:
-            hostname = socket.gethostname().split('.')[0]
-        except IndexError:
-            hostname = socket.gethostname()
+        services = self.middleware.call_sync('service.query')
+        hostname = self.middleware.call_sync('mdnsadvertise.get_hostname')
+        if hostname is None:
+            return
 
         mdns_advertise_services = [
+            mDNSServiceAdiskThread,
+            mDNSServiceAFPThread,
+            mDNSServiceDevInfoThread,
+            mDNSServiceFTPThread,
+            mDNSServiceISCSIThread,
             mDNSServiceSSHThread,
-            mDNSServiceSFTPThread,
+            mDNSServiceSFTP_SSHThread,
+            mDNSServiceSMBThread,
             mDNSServiceHTTPThread,
             mDNSServiceHTTPSThread,
             mDNSServiceMiddlewareThread,
@@ -255,7 +440,11 @@ class mDNSAdvertiseService(Service):
         ]
 
         for service in mdns_advertise_services:
-            thread = service(middleware=self.middleware, hostname=hostname)
+            if self.threads.get(SrvToThread(service.__name__).name.lower()):
+                self.logger.debug('mDNS advertise thread is already started for service: %s', service.__name__)
+                continue
+
+            thread = service(middleware=self.middleware, hostname=hostname, services=services)
             thread.setup()
             thread_name = thread.service
             self.threads[thread_name] = thread
@@ -279,6 +468,38 @@ class mDNSAdvertiseService(Service):
     def restart(self):
         self.stop()
         self.start()
+
+    @private
+    def reload(self, service_list):
+        mdns_advertise_services = [
+            mDNSServiceAdiskThread,
+            mDNSServiceAFPThread,
+            mDNSServiceFTPThread,
+            mDNSServiceISCSIThread,
+            mDNSServiceSSHThread,
+            mDNSServiceSFTP_SSHThread,
+            mDNSServiceSMBThread,
+            mDNSServiceHTTPThread,
+            mDNSServiceHTTPSThread,
+        ]
+        services = self.middleware.call_sync('service.query')
+        hostname = self.middleware.call_sync('mdnsadvertise.get_hostname')
+        if hostname is None:
+            return
+
+        normalized_service_names = [SrvToThread[x].value for x in service_list]
+        for srvthread in mdns_advertise_services:
+            if srvthread.__name__ in normalized_service_names:
+                service_name = SrvToThread(srvthread.__name__).name.lower()
+                old_thread = self.threads.get(service_name)
+                if old_thread is not None:
+                    old_thread.cancel()
+                    del self.threads[service_name]
+                thread = srvthread(middleware=self.middleware, hostname=hostname, services=services)
+                thread.setup()
+                thread_name = thread.service
+                self.threads[thread_name] = thread
+                thread.start()
 
 
 async def dns_post_sync(middleware):

--- a/src/middlewared/middlewared/plugins/mdns.py
+++ b/src/middlewared/middlewared/plugins/mdns.py
@@ -307,10 +307,10 @@ class mDNSAdvertiseService(Service):
         This is to ensure that the correct hostname is used for mdns advertisements.
         """
         ngc = await self.middleware.call('network.configuration.config')
-        if not await self.middleware.call('system.is_freenas') and await self.middleware.call('notfier.failover_licensed'):
-            failover_status = await self.middleware.call('notifier.failover_status')
+        if 'hostname_virtual' in ngc:
+            failover_status = await self.middleware.call('failover.status')
             if failover_status == 'MASTER':
-                return ngc['virtual_hostname']
+                return ngc['hostname_virtual']
             elif failover_status == 'BACKUP':
                 return None
         else:

--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -842,7 +842,6 @@ class ServiceService(CRUDService):
     async def _restart_afp(self, **kwargs):
         await self._stop_afp()
         await self._start_afp()
-        await self.middleware.call('mdnsadvertise.restart')
 
     async def _reload_afp(self, **kwargs):
         await self.middleware.call("etc.generate", "afpd")

--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -620,25 +620,25 @@ class ServiceService(CRUDService):
 
     async def _reload_ssh(self, **kwargs):
         await self.middleware.call('etc.generate', 'ssh')
-        await self.middleware.call('mdnsadvertise.restart')
+        await self.middleware.call('mdnsadvertise.reload', ['SSH', 'SFTP_SSH'])
         await self._service("openssh", "reload", **kwargs)
         await self._service("ix_sshd_save_keys", "start", quiet=True, **kwargs)
 
     async def _start_ssh(self, **kwargs):
         await self.middleware.call('etc.generate', 'ssh')
-        await self.middleware.call('mdnsadvertise.restart')
+        await self.middleware.call('mdnsadvertise.reload', ['SSH', 'SFTP_SSH'])
         await self._service("openssh", "start", **kwargs)
         await self._service("ix_sshd_save_keys", "start", quiet=True, **kwargs)
 
     async def _stop_ssh(self, **kwargs):
         await self._service("openssh", "stop", force=True, **kwargs)
-        await self.middleware.call('mdnsadvertise.restart')
+        await self.middleware.call('mdnsadvertise.reload', ['SSH', 'SFTP_SSH'])
 
     async def _restart_ssh(self, **kwargs):
         await self.middleware.call('etc.generate', 'ssh')
         await self._service("openssh", "stop", force=True, **kwargs)
-        await self.middleware.call('mdnsadvertise.restart')
         await self._service("openssh", "restart", **kwargs)
+        await self.middleware.call('mdnsadvertise.reload', ['SSH', 'SFTP_SSH'])
         await self._service("ix_sshd_save_keys", "start", quiet=True, **kwargs)
 
     async def _start_ssl(self, **kwargs):
@@ -828,6 +828,7 @@ class ServiceService(CRUDService):
     async def _start_afp(self, **kwargs):
         await self.middleware.call("etc.generate", "afpd")
         await self._service("netatalk", "start", **kwargs)
+        await self.middleware.call('mdnsadvertise.reload', ['ADISK', 'AFP'])
 
     async def _stop_afp(self, **kwargs):
         await self._service("netatalk", "stop", force=True, **kwargs)
@@ -836,14 +837,17 @@ class ServiceService(CRUDService):
         # restarting netatalk.
         await self._system("pkill -9 afpd")
         await self._system("pkill -9 cnid_metad")
+        await self.middleware.call('mdnsadvertise.reload', ['ADISK', 'AFP'])
 
     async def _restart_afp(self, **kwargs):
         await self._stop_afp()
         await self._start_afp()
+        await self.middleware.call('mdnsadvertise.reload', ['ADISK', 'AFP'])
 
     async def _reload_afp(self, **kwargs):
         await self.middleware.call("etc.generate", "afpd")
         await self._system("killall -1 netatalk")
+        await self.middleware.call('mdnsadvertise.reload', ['ADISK', 'AFP'])
 
     async def _reload_nfs(self, **kwargs):
         await self.middleware.call("etc.generate", "nfsd")
@@ -895,17 +899,20 @@ class ServiceService(CRUDService):
     async def _reload_cifs(self, **kwargs):
         await self.middleware.call("etc.generate", "smb_share")
         await self._service("samba_server", "reload", force=True, **kwargs)
+        await self.middleware.call('mdnsadvertise.reload', ['ADISK', 'SMB'])
 
     async def _restart_cifs(self, **kwargs):
         await self.middleware.call("etc.generate", "smb")
         await self.middleware.call("etc.generate", "smb_share")
         await self._service("samba_server", "stop", force=True, **kwargs)
         await self._service("samba_server", "restart", quiet=True, **kwargs)
+        await self.middleware.call('mdnsadvertise.reload', ['ADISK', 'SMB'])
 
     async def _start_cifs(self, **kwargs):
         await self.middleware.call("etc.generate", "smb")
         await self.middleware.call("etc.generate", "smb_share")
         await self._service("samba_server", "start", quiet=True, **kwargs)
+        await self.middleware.call('mdnsadvertise.reload', ['ADISK', 'SMB'])
         try:
             await self.middleware.call("smb.add_admin_group", "", True)
         except Exception as e:
@@ -913,6 +920,7 @@ class ServiceService(CRUDService):
 
     async def _stop_cifs(self, **kwargs):
         await self._service("samba_server", "stop", force=True, **kwargs)
+        await self.middleware.call('mdnsadvertise.reload', ['ADISK', 'SMB'])
 
     async def _started_cifs(self, **kwargs):
         if await self._service("samba_server", "status", quiet=True, onetime=True, **kwargs):
@@ -945,12 +953,12 @@ class ServiceService(CRUDService):
 
     async def _restart_http(self, **kwargs):
         await self.middleware.call("etc.generate", "nginx")
-        await self.middleware.call('mdnsadvertise.restart')
+        await self.middleware.call('mdnsadvertise.reload', ['HTTP', 'HTTPS'])
         await self._service("nginx", "restart", **kwargs)
 
     async def _reload_http(self, **kwargs):
         await self.middleware.call("etc.generate", "nginx")
-        await self.middleware.call('mdnsadvertise.restart')
+        await self.middleware.call('mdnsadvertise.reload', ['HTTP', 'HTTPS'])
         await self._service("nginx", "reload", **kwargs)
 
     async def _reload_loader(self, **kwargs):

--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -620,25 +620,25 @@ class ServiceService(CRUDService):
 
     async def _reload_ssh(self, **kwargs):
         await self.middleware.call('etc.generate', 'ssh')
-        await self.middleware.call('mdnsadvertise.reload', ['SSH', 'SFTP_SSH'])
+        await self.middleware.call('mdnsadvertise.restart')
         await self._service("openssh", "reload", **kwargs)
         await self._service("ix_sshd_save_keys", "start", quiet=True, **kwargs)
 
     async def _start_ssh(self, **kwargs):
         await self.middleware.call('etc.generate', 'ssh')
-        await self.middleware.call('mdnsadvertise.reload', ['SSH', 'SFTP_SSH'])
+        await self.middleware.call('mdnsadvertise.restart')
         await self._service("openssh", "start", **kwargs)
         await self._service("ix_sshd_save_keys", "start", quiet=True, **kwargs)
 
     async def _stop_ssh(self, **kwargs):
         await self._service("openssh", "stop", force=True, **kwargs)
-        await self.middleware.call('mdnsadvertise.reload', ['SSH', 'SFTP_SSH'])
+        await self.middleware.call('mdnsadvertise.restart')
 
     async def _restart_ssh(self, **kwargs):
         await self.middleware.call('etc.generate', 'ssh')
         await self._service("openssh", "stop", force=True, **kwargs)
         await self._service("openssh", "restart", **kwargs)
-        await self.middleware.call('mdnsadvertise.reload', ['SSH', 'SFTP_SSH'])
+        await self.middleware.call('mdnsadvertise.restart')
         await self._service("ix_sshd_save_keys", "start", quiet=True, **kwargs)
 
     async def _start_ssl(self, **kwargs):
@@ -828,7 +828,7 @@ class ServiceService(CRUDService):
     async def _start_afp(self, **kwargs):
         await self.middleware.call("etc.generate", "afpd")
         await self._service("netatalk", "start", **kwargs)
-        await self.middleware.call('mdnsadvertise.reload', ['ADISK', 'AFP'])
+        await self.middleware.call('mdnsadvertise.restart')
 
     async def _stop_afp(self, **kwargs):
         await self._service("netatalk", "stop", force=True, **kwargs)
@@ -837,17 +837,17 @@ class ServiceService(CRUDService):
         # restarting netatalk.
         await self._system("pkill -9 afpd")
         await self._system("pkill -9 cnid_metad")
-        await self.middleware.call('mdnsadvertise.reload', ['ADISK', 'AFP'])
+        await self.middleware.call('mdnsadvertise.restart')
 
     async def _restart_afp(self, **kwargs):
         await self._stop_afp()
         await self._start_afp()
-        await self.middleware.call('mdnsadvertise.reload', ['ADISK', 'AFP'])
+        await self.middleware.call('mdnsadvertise.restart')
 
     async def _reload_afp(self, **kwargs):
         await self.middleware.call("etc.generate", "afpd")
         await self._system("killall -1 netatalk")
-        await self.middleware.call('mdnsadvertise.reload', ['ADISK', 'AFP'])
+        await self.middleware.call('mdnsadvertise.restart')
 
     async def _reload_nfs(self, **kwargs):
         await self.middleware.call("etc.generate", "nfsd")
@@ -899,20 +899,20 @@ class ServiceService(CRUDService):
     async def _reload_cifs(self, **kwargs):
         await self.middleware.call("etc.generate", "smb_share")
         await self._service("samba_server", "reload", force=True, **kwargs)
-        await self.middleware.call('mdnsadvertise.reload', ['ADISK', 'SMB'])
+        await self.middleware.call('mdnsadvertise.restart')
 
     async def _restart_cifs(self, **kwargs):
         await self.middleware.call("etc.generate", "smb")
         await self.middleware.call("etc.generate", "smb_share")
         await self._service("samba_server", "stop", force=True, **kwargs)
         await self._service("samba_server", "restart", quiet=True, **kwargs)
-        await self.middleware.call('mdnsadvertise.reload', ['ADISK', 'SMB'])
+        await self.middleware.call('mdnsadvertise.restart')
 
     async def _start_cifs(self, **kwargs):
         await self.middleware.call("etc.generate", "smb")
         await self.middleware.call("etc.generate", "smb_share")
         await self._service("samba_server", "start", quiet=True, **kwargs)
-        await self.middleware.call('mdnsadvertise.reload', ['ADISK', 'SMB'])
+        await self.middleware.call('mdnsadvertise.restart')
         try:
             await self.middleware.call("smb.add_admin_group", "", True)
         except Exception as e:
@@ -920,7 +920,7 @@ class ServiceService(CRUDService):
 
     async def _stop_cifs(self, **kwargs):
         await self._service("samba_server", "stop", force=True, **kwargs)
-        await self.middleware.call('mdnsadvertise.reload', ['ADISK', 'SMB'])
+        await self.middleware.call('mdnsadvertise.restart')
 
     async def _started_cifs(self, **kwargs):
         if await self._service("samba_server", "status", quiet=True, onetime=True, **kwargs):
@@ -953,12 +953,12 @@ class ServiceService(CRUDService):
 
     async def _restart_http(self, **kwargs):
         await self.middleware.call("etc.generate", "nginx")
-        await self.middleware.call('mdnsadvertise.reload', ['HTTP', 'HTTPS'])
+        await self.middleware.call('mdnsadvertise.restart')
         await self._service("nginx", "restart", **kwargs)
 
     async def _reload_http(self, **kwargs):
         await self.middleware.call("etc.generate", "nginx")
-        await self.middleware.call('mdnsadvertise.reload', ['HTTP', 'HTTPS'])
+        await self.middleware.call('mdnsadvertise.restart')
         await self._service("nginx", "reload", **kwargs)
 
     async def _reload_loader(self, **kwargs):


### PR DESCRIPTION
- Move service mDNS advertisement to middleware
- Properly configure mixed AFP and SMB Time Machine shares. This will allow protocol failover from SMB to AFP.
- Bring in afp, ftp, iscsi, smb advertisement to middleware
- Persistently store VUID for Time Machine over AFP.
- Add ability to selectively restart mDNS advertisement for services (less disruptive than restarting everything).
- Add ability to which services we're currently advertising.
- Only advertise on Active Controller, and use virtual hostname on HA servers