### PR TITLE
NAS-102308 / 11.3 / Only start nut if ups is configured in master mode

### DIFF
--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -777,7 +777,8 @@ class ServiceService(CRUDService):
     async def _start_ups(self, **kwargs):
         await self.middleware.call('ups.dismiss_alerts')
         await self.middleware.call('etc.generate', 'ups')
-        await self._service("nut", "start", **kwargs)
+        if (await self.middleware.call('ups.config'))['mode'] == 'MASTER':
+            await self._service("nut", "start", **kwargs)
         await self._service("nut_upsmon", "start", **kwargs)
         await self._service("nut_upslog", "start", **kwargs)
         if await self.started('collectd'):
@@ -816,7 +817,8 @@ class ServiceService(CRUDService):
 
         await self._service("nut_upslog", "stop", force=True, onetime=True)
 
-        await self._service("nut", "restart", onetime=True)
+        if (await self.middleware.call('ups.config'))['mode'] == 'MASTER':
+            await self._service("nut", "restart", onetime=True)
         await self._service("nut_upsmon", "restart", onetime=True)
         await self._service("nut_upslog", "restart", onetime=True)
         if await self.started('collectd'):


### PR DESCRIPTION
When UPS is configured in slave mode, we should not start nut service at all as it is not used and results in erroneous messages saying relevant conf files don't exist.