### PR TITLE
NAS-102323 / 11.2 / Do not disable AD or LDAP on passive controller in unified config

### DIFF
--- a/src/freenas/etc/directoryservice/ActiveDirectory/ctl
+++ b/src/freenas/etc/directoryservice/ActiveDirectory/ctl
@@ -77,14 +77,8 @@ adctl_start()
 {
 	local cifs_started=0	
 	local ad_started=0
-	local syspool=$(eval echo $(${notifier} call systemdataset.config | /usr/local/bin/jq .pool))
-	local is_freenas=$(${notifier} call system.is_freenas)
-	local failover_status='SINGLE'
-	if [ ${is_freenas} == 'False' ]; then
-		failover_status=$(${notifier} call notifier.failover_status)
-	fi
 
-	if [ ${syspool} != "freenas-boot" ] && [ ${failover_status} == "BACKUP" ]; then
+	if is_unified_standby; then
 		return 0
 	fi
 
@@ -173,6 +167,10 @@ adctl_stop()
 	local cifs_started=1
 	local prev_cifs_started=0
 
+	if is_unified_standby; then
+		return 0
+	fi
+
 	AD_generate_config
 
 	if [ -s "${cifs_file}" ]
@@ -242,6 +240,9 @@ adctl_stop()
 
 adctl_status()
 {
+	if is_unified_standby; then
+		return 0
+	fi
 	adctl_cmd ${service} ix-activedirectory status
 }
 

--- a/src/freenas/etc/directoryservice/ActiveDirectory/ctl
+++ b/src/freenas/etc/directoryservice/ActiveDirectory/ctl
@@ -216,7 +216,7 @@ adctl_stop()
 		srv_set cifs 1
 		cifs_start
 
-	elif [ "${prev_cifs_started}" = "1" -a "${cifs_started}" = "1" ]		
+	elif [ "${prev_cifs_started}" = "1" -a "${cifs_started}" = "1" ]
 	then
 		adctl_cmd ${service} samba_server forcestop
 		activedirectory_set 0

--- a/src/freenas/etc/directoryservice/LDAP/ctl
+++ b/src/freenas/etc/directoryservice/LDAP/ctl
@@ -100,14 +100,7 @@ ldapctl_start()
 	local ldap_started=0
 	local realm
 	local keytab_principal
-	local syspool=$(eval echo $(${notifier} call systemdataset.config | /usr/local/bin/jq .pool))
-	local is_freenas=$(${notifier} call system.is_freenas)
-	local failover_status='SINGLE'
-	if [ ${is_freenas} == 'False' ]; then
-		failover_status=$(${notifier} call notifier.failover_status)
-	fi
-
-	if [ ${syspool} != "freenas-boot" ] && [ ${failover_status} == "BACKUP" ]; then
+	if is_unified_standby; then
 		return 0
 	fi
 
@@ -203,6 +196,9 @@ ldapctl_start()
 
 ldapctl_stop()
 {
+	if is_unified_standby; then
+		return 0
+	fi
 	LDAP_init
 
 	if ! ldap_enabled
@@ -241,6 +237,9 @@ ldapctl_stop()
 
 ldapctl_status()
 {
+	if is_unified_standby; then
+		return 0
+	fi
 	ldapctl_cmd ${service} ix-ldap status
 }
 

--- a/src/freenas/etc/directoryservice/rc.DS_Common
+++ b/src/freenas/etc/directoryservice/rc.DS_Common
@@ -1,0 +1,45 @@
+#!/bin/sh
+#-
+# Copyright (c) 2019 iXsystems, Inc., All rights reserved.
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL Jordan Hubbard OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+
+. /etc/rc.subr
+
+: ${MIDCLT="/usr/local/bin/midclt"}
+: ${JQ="/usr/local/bin/jq"}
+: ${DEFAULT_SYS_DATASET="freenas-boot"}
+
+is_unified_standby()
+{
+	local config_sysdataset=$(eval echo $(${MIDCLT} call systemdataset.config | ${JQ} .pool))
+        local sysdataset=${config_sysdataset:-${DEFAULT_SYS_DATASET}}
+	local failover_status=${HA_STATUS_SINGLE}
+	if ! is_freenas; then
+		failover_status=$(${MIDCLT} call notifier.failover_status)
+	fi
+
+	if [ ${sysdataset} != ${DEFAULT_SYS_DATASET} ] && [ ${failover_status} == ${HA_STATUS_STANDBY} ]; then
+		return 0
+	fi
+	return 1
+}

--- a/src/freenas/etc/ix.rc.d/ix-activedirectory
+++ b/src/freenas/etc/ix.rc.d/ix-activedirectory
@@ -178,6 +178,11 @@ setup_homedirs()
 
 activedirectory_start()
 {
+	if is_unified_standby; then
+                echo got here
+		return 0
+	fi
+        return
 	if dirsrv_enabled activedirectory
 	then
 		RO_FREENAS_CONFIG=$(ro_sqlite ${name} 2> /tmp/${name}.fail && rm /tmp/${name}.fail)
@@ -218,6 +223,9 @@ activedirectory_start()
 
 activedirectory_status()
 {
+	if is_unified_standby; then
+		return 0
+	fi
 	local res=1
 
 	if dirsrv_enabled activedirectory
@@ -234,6 +242,9 @@ activedirectory_status()
 
 activedirectory_stop()
 {
+	if is_unified_standby; then
+		return 0
+	fi
 	AD_init
 
         /usr/local/www/freenasUI/tools/cachetool.py expire

--- a/src/freenas/etc/ix.rc.d/ix-activedirectory
+++ b/src/freenas/etc/ix.rc.d/ix-activedirectory
@@ -179,10 +179,8 @@ setup_homedirs()
 activedirectory_start()
 {
 	if is_unified_standby; then
-                echo got here
 		return 0
 	fi
-        return
 	if dirsrv_enabled activedirectory
 	then
 		RO_FREENAS_CONFIG=$(ro_sqlite ${name} 2> /tmp/${name}.fail && rm /tmp/${name}.fail)

--- a/src/freenas/etc/ix.rc.d/ix-ldap
+++ b/src/freenas/etc/ix.rc.d/ix-ldap
@@ -91,6 +91,9 @@ setup_homedirs()
 
 ldap_status()
 {
+	if is_unified_standby; then
+		return 0
+	fi
 	local IFS=\|
 	local ret=0
 	local fail="/tmp/.ldap_fail"
@@ -196,6 +199,9 @@ ldap_status()
 
 ldap_start()
 {
+	if is_unified_standby; then
+		return 0
+	fi
 	if dirsrv_enabled ldap
 	then
 		RO_FREENAS_CONFIG=$(ro_sqlite ${name} 2> /tmp/${name}.fail && rm /tmp/${name}.fail)
@@ -230,6 +236,9 @@ ldap_start()
 
 ldap_stop()
 {
+	if is_unified_standby; then
+		return 0
+	fi
         /usr/local/www/freenasUI/tools/cachetool.py expire
 }
 

--- a/src/freenas/etc/rc.freenas
+++ b/src/freenas/etc/rc.freenas
@@ -112,6 +112,9 @@
 #	TrueNAS
 #
 : ${HA_MODE_FILE="/tmp/.ha_mode"}
+: ${HA_STATUS_SINGLE="SINGLE"}
+: ${HA_STATUS_ACTIVE="ACTIVE"}
+: ${HA_STATUS_STANDBY="BACKUP"}
 
 
 __escape()


### PR DESCRIPTION
If AD is enabled, but there is a stub smb4.conf on the passive controller, then
if ix-activedirectory start will fail and disable the AD service. This will may
cause the passive controller to cease to renew kerberos tickets and adversely affect
SMB services on failover.

In all AD and LDAP related RC scripts, check if the controller is standby. If it is,
then immediately return. This is to avoid inadvertently disabling the
AD/LDAP service on the passive during boot or normal operations.