### PR TITLE
NAS-102386 / 11.3 / Fix key error in smb plugin.

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -561,7 +561,7 @@ class SMBService(SystemServiceService):
         if new['netbiosname'] and new['netbiosname'].lower() == new['workgroup'].lower():
             verrors.add('smb_update.netbiosname', 'NetBIOS and Workgroup must be unique')
 
-        if data['bindip']:
+        if data.get('bindip'):
             bindip_choices = list((await self.bindip_choices()).keys())
             for idx, item in enumerate(data['bindip']):
                 if item not in bindip_choices:


### PR DESCRIPTION
Regression caused by changes related to bindip in smb plugin.