### PR TITLE
NAS-102457 / 11.3 / Allow request body with GET/DELETE requests

### DIFF
--- a/src/middlewared/middlewared/restful.py
+++ b/src/middlewared/middlewared/restful.py
@@ -480,7 +480,12 @@ class Resource(object):
                     else:
                         data = await req.json()
                         params = self.__method_params.get(methodname)
-                        if not params or len(params) == 1:
+                        if not params and http_method in ('get', 'delete') and not data:
+                            # This will happen when the request body contains empty dict "{}"
+                            # Keeping compatibility with how we used to accept the above case, this
+                            # makes sure that existing client implementations are not affected
+                            method_args = []
+                        elif not params or len(params) == 1:
                             method_args = [data]
                         else:
                             if not isinstance(data, dict):


### PR DESCRIPTION
This PR introduces the following changes:
1) As RFC 7231 specifies that a GET request can have a request body though older implementations might reject it, we now conform to RFC 7231 allowing a GET request to have a request body. It should be noted that it does not enforce server implementations to reject it as earlier RFC's did neither does it enforce them to accept it.
2) We allow payload to be passed to DELETE requests as well, this PR makes sure that we allow the same wrt API.
3) Our old implementation ignored request body altogether for GET/DELETE which meant that any value being passed had no affect what so ever. With the changes introduced in 1,2, this is not the case anymore but it does introduce a new issue. If a request body is defined but empty i.e `{}`, we raise an exception in this case as we pass that empty dictionary to the underlying method ( if it does not accept any params ). This PR keeps the old behaviour in this case which is if request is GET/DELETE and we have a defined but empty request body plus the end target does not accept any params, we ignore the empty request body. 