### PR TITLE
NAS-100271 / 11.3 / Remove CARP IPs from NICChoices even if failover is not licensed (by themylogin)

### DIFF
--- a/gui/choices.py
+++ b/gui/choices.py
@@ -389,8 +389,7 @@ class NICChoices(object):
         try:
             if (
                 os.environ.get('MIDDLEWARED_LOADING') != 'True' and
-                hasattr(notifier, 'failover_status') and
-                notifier().failover_licensed()
+                hasattr(notifier, 'failover_status')
             ):
                 for iface in notifier().failover_internal_interfaces():
                     if iface in self._NIClist:


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x f6da82ae61405dab7f9125ae6ed76f57a81afdf2

