### PR TITLE
NAS-102432 / 11.3 / Add some ACL templates to help choose sane permissions

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -521,7 +521,7 @@ class FilesystemService(Service):
         return [x.name for x in ACLDefault]
 
     @accepts(
-        Str('acl_type', default='GENERIC_OPEN', enum=[x.name for x in ACLDefault])
+        Str('acl_type', default='OPEN', enum=[x.name for x in ACLDefault])
     )
     async def get_default_acl(self, acl_type):
         """

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -17,7 +17,7 @@ from middlewared.utils import filter_list
 
 
 class ACLDefault(enum.Enum):
-    GENERIC_OPEN = [
+    OPEN = [
         {
             'tag': 'owner@',
             'id': None,
@@ -40,7 +40,7 @@ class ACLDefault(enum.Enum):
             'type': 'ALLOW'
         }
     ]
-    GENERIC_RESTRICTED = [
+    RESTRICTED = [
         {
             'tag': 'owner@',
             'id': None,
@@ -56,7 +56,7 @@ class ACLDefault(enum.Enum):
             'type': 'ALLOW'
         },
     ]
-    GENERIC_HOME = [
+    HOME = [
         {
             'tag': 'owner@',
             'id': None,

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -871,7 +871,7 @@ class SharingSMBService(CRUDService):
 
         acl = []
         if not is_home:
-            acl = await self.middleware.call('filesystem.get_default_acl', 'GENERIC_RESTRICTED')
+            acl = await self.middleware.call('filesystem.get_default_acl', 'RESTRICTED')
         elif await self.middleware.call('activedirectory.get_state') != 'DISABLED':
             acl = await self.middleware.call('filesystem.get_default_acl', 'DOMAIN_HOME')
         else:

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -875,7 +875,7 @@ class SharingSMBService(CRUDService):
         elif await self.middleware.call('activedirectory.get_state') != 'DISABLED':
             acl = await self.middleware.call('filesystem.get_default_acl', 'DOMAIN_HOME')
         else:
-            acl = await self.middleware.call('filesystem.get_default_acl', 'GENERIC_HOME')
+            acl = await self.middleware.call('filesystem.get_default_acl', 'HOME')
 
         await self.middleware.call('filesystem.setacl', {
             'path': path,

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -11,7 +11,6 @@ import asyncio
 import codecs
 import enum
 import errno
-import grp
 import os
 import re
 import subprocess
@@ -871,70 +870,12 @@ class SharingSMBService(CRUDService):
             return
 
         acl = []
-        admin = None
-        smb = await self.middleware.call('smb.config')
-        if smb['admin_group']:
-            admin = await self.middleware.run_in_thread(grp.getgrnam, smb['admin_group'])
-            acl.append({
-                "tag": "GROUP",
-                "id": admin[2],
-                "type": "ALLOW",
-                "perms": {"BASIC": "FULL_CONTROL"},
-                "flags": {"BASIC": "INHERIT"}
-            })
-
-        acl.append({
-            "tag": "owner@",
-            "id": None,
-            "type": "ALLOW",
-            "perms": {"BASIC": "FULL_CONTROL"},
-            "flags": {"BASIC": "INHERIT"},
-        })
-
         if not is_home:
-            acl.append({
-                "tag": "group@",
-                "id": None,
-                "type": "ALLOW",
-                "perms": {"BASIC": "FULL_CONTROL"},
-                "flags": {"BASIC": "INHERIT"},
-            })
-
+            acl = await self.middleware.call('filesystem.get_default_acl', 'GENERIC_RESTRICTED')
         elif await self.middleware.call('activedirectory.get_state') != 'DISABLED':
-            acl.extend([
-                {
-                    "tag": "group@",
-                    "id": None,
-                    "type": "ALLOW",
-                    "perms": {"BASIC": "MODIFY"},
-                    "flags": {'DIRECTORY_INHERIT': True, 'INHERIT_ONLY': True, 'NO_PROPAGATE_INHERIT': True}
-                },
-                {
-                    "tag": "everyone@",
-                    "id": None,
-                    "type": "ALLOW",
-                    "perms": {"BASIC": "TRAVERSE"},
-                    "flags": {"BASIC": "NOINHERIT"}
-                },
-            ])
-
+            acl = await self.middleware.call('filesystem.get_default_acl', 'DOMAIN_HOME')
         else:
-            acl.extend([
-                {
-                    "tag": "group@",
-                    "id": None,
-                    "type": "ALLOW",
-                    "perms": {"BASIC": "MODIFY"},
-                    "flags": {"BASIC": "NOINHERIT"}
-                },
-                {
-                    "tag": "everyone@",
-                    "id": None,
-                    "type": "ALLOW",
-                    "perms": {"BASIC": "TRAVERSE"},
-                    "flags": {"BASIC": "NOINHERIT"}
-                },
-            ])
+            acl = await self.middleware.call('filesystem.get_default_acl', 'GENERIC_HOME')
 
         await self.middleware.call('filesystem.setacl', {
             'path': path,


### PR DESCRIPTION
filesystem.get_default_acl, returns an ACL that can then be used in filesystem.setacl calls.
filesystem.get_default_acl_choices, returns a list of available default ACLs.