### PR TITLE
NAS-102505 / 11.2 / Tighten security of default ACL in winacl reset

### DIFF
--- a/src/winacl/winacl.c
+++ b/src/winacl/winacl.c
@@ -57,7 +57,7 @@ struct windows_acl_info {
 /* default ACL entries if none are specified */
 #define	WA_ENTRY_OWNER		"owner@:rwxpDdaARWcCos:fd:allow"
 #define	WA_ENTRY_GROUP		"group@:rwxpDdaARWcCos:fd:allow"
-#define	WA_ENTRY_EVERYONE	"everyone@:rxaRc:fd:allow"
+#define	WA_ENTRY_EVERYONE	"everyone@::fd:allow"
 
 #define	WA_OP_SET	(WA_APPEND|WA_CLONE|WA_REMOVE|WA_UPDATE|WA_RESET)
 #define	WA_OP_CHECK(flags, bit) ((flags & ~bit) & WA_OP_SET)


### PR DESCRIPTION
current default is to grant everyone read access. Modify default everyone@ entry
so it is everyone@::fd:allow. This sets an inheriting empty everyone entry,
which is a requirement for proper behavior of vfs_ixnas.