### PR TITLE
NAS-102450 / 11.3 / Set HSTS header if explicitly specified

### DIFF
--- a/gui/system/models.py
+++ b/gui/system/models.py
@@ -84,7 +84,8 @@ class Settings(Model):
         verbose_name=_('WebGUI HTTP -> HTTPS Redirect'),
         default=False,
         help_text=_(
-            'Redirect all incoming HTTP requests to HTTPS'
+            'Redirect all incoming HTTP requests to HTTPS and '
+            'enable the HTTP Strict Transport Security (HSTS) header.'
         ),
     )
     stg_language = models.CharField(

--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf
@@ -104,7 +104,7 @@ http {
         ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
         ssl_prefer_server_ciphers on;
         ssl_ciphers EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA256:EDH+aRSA:EECDH:!RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS;
-        add_header Strict-Transport-Security max-age=31536000;
+        add_header Strict-Transport-Security max-age=${31536000 if general_settings['ui_httpsredirect'] else 0};
 
         ## TODO: OCSP Stapling
         #ssl_stapling on;


### PR DESCRIPTION
This PR introduces changes to only set hsts header explicitly if user wants traffic to be only https based. Also when this is not wanted, we do add the header but set the value to 0 which invalidates the last setting browser saves for the ip/domain.