### PR TITLE
NAS-102482 / 11.3 / Use new py-libzfs api for datasets retrieval

### DIFF
--- a/src/middlewared/middlewared/plugins/cloud_sync.py
+++ b/src/middlewared/middlewared/plugins/cloud_sync.py
@@ -320,8 +320,6 @@ def rclone_encrypt_password(password):
 
 
 def get_dataset_recursive(datasets, directory):
-    datasets = flatten_datasets(datasets)
-
     datasets = [
         dict(dataset, prefixlen=len(
             os.path.dirname(os.path.commonprefix([dataset["mountpoint"] + "/", directory + "/"]))))
@@ -344,10 +342,6 @@ def get_dataset_recursive(datasets, directory):
         for ds in datasets
         if ds != dataset
     )
-
-
-def flatten_datasets(datasets):
-    return sum([[ds] + flatten_datasets(ds["children"]) for ds in datasets], [])
 
 
 class _FsLockCore(aiorwlock._RWLockCore):

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -2448,7 +2448,9 @@ class PoolDatasetService(CRUDService):
             if len(f) == 3:
                 if f[0] in ('id', 'name', 'pool', 'type'):
                     zfsfilters.append(f)
-        datasets = self.middleware.call_sync('zfs.dataset.query', zfsfilters, None)
+        datasets = self.middleware.call_sync(
+            'zfs.dataset.query', zfsfilters, {'extra': (options or {}).get('extra', {})}
+        )
         return filter_list(self.__transform(datasets), filters, options)
 
     def __transform(self, datasets):

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -341,7 +341,7 @@ class PoolService(CRUDService):
                     ('pool', 'in', vol_names),
                     ('type', 'in', types),
                 ],
-                {'select': ['name', 'pool', 'type']},
+                {'extra': {'retrieve_properties': False}},
             )
         ]
 

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -453,17 +453,17 @@ class ZFSDatasetService(CRUDService):
         return filter_list(datasets, filters, options)
 
     def query_for_quota_alert(self):
-        with libzfs.ZFS() as zfs:
-            return [
-                {
-                    k: v.__getstate__()
-                    for k, v in i.properties.items()
-                    if k in ["name", "quota", "used", "refquota", "usedbydataset", "mounted", "mountpoint",
-                             "org.freenas:quota_warning", "org.freenas:quota_critical",
-                             "org.freenas:refquota_warning", "org.freenas:refquota_critical"]
-                }
-                for i in zfs.datasets
-            ]
+        return [
+            {
+                k: v for k, v in dataset['properties'].items()
+                if k in [
+                    "name", "quota", "used", "refquota", "usedbydataset", "mounted", "mountpoint",
+                    "org.freenas:quota_warning", "org.freenas:quota_critical",
+                    "org.freenas:refquota_warning", "org.freenas:refquota_critical"
+                ]
+            }
+            for dataset in self.query()
+        ]
 
     @accepts(Dict(
         'dataset_create',

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -445,7 +445,7 @@ class ZFSDatasetService(CRUDService):
             options = options or {}
             extra = options.get('extra', {}).copy()
             mountpoint = extra.get('mountpoint', True)
-            props = extra.get('properties', []).copy()
+            props = extra.get('properties', None)
             flat = extra.get('flat', True)
 
             with libzfs.ZFS() as zfs:

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -423,6 +423,34 @@ class ZFSDatasetService(CRUDService):
 
     @filterable
     def query(self, filters=None, options=None):
+        """
+        In `query-options` we can provide `extra` arguments which control which data should be retrieved
+        for a dataset.
+
+        `query-options.extra.top_level_properties` is a list of properties which we will like to include in the
+        top level dict of dataset. It defaults to adding only mountpoint key keeping legacy behavior. If none are
+        desired in top level dataset, an empty list should be passed else if null is specified it will add mountpoint
+        key to the top level dict if it's present in `query-options.extra.properties` or it's null as well.
+
+        `query-options.extra.properties` is a list of properties which should be retrieved. If null ( by default ),
+        it would retrieve all properties, if empty, it will retrieve no property ( `mountpoint` is special in this
+        case and is controlled by `query-options.extra.mountpoint` attribute ).
+
+        We provide 2 ways how zfs.dataset.query returns dataset's data. First is a flat structure ( default ), which
+        means that all the datasets in the system are returned as separate objects which also contain all the data
+        their is for their children. This retrieval type is slightly slower because of duplicates which exist in
+        each object.
+        Second type is hierarchical where only top level datasets are returned in the list and they contain all the
+        children there are for them in `children` key. This retrieval type is slightly faster.
+        These options are controlled by `query-options.extra.flat` attribute which defaults to true.
+
+        `query-options.extra.user_properties` controls if user defined properties of datasets should be retrieved
+        or not.
+
+        While we provide a way to exclude all properties from data retrieval, we introduce a single attribute
+        `query-options.extra.retrieve_properties` which if set to false will make sure that no property is retrieved
+        whatsoever and overrides any other property retrieval attribute.
+        """
         options = options or {}
         extra = options.get('extra', {}).copy()
         top_level_props = None if extra.get('top_level_properties') is None else extra['top_level_properties'].copy()

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -446,7 +446,8 @@ class ZFSDatasetService(CRUDService):
                     except libzfs.ZFSException:
                         datasets = []
                 else:
-                    datasets = [i.__getstate__() for i in zfs.datasets]
+                    props = (options or {}).get('extra', {}).get('properties', []).copy()
+                    datasets = list(zfs.datasets_serialized(props=props))
         return filter_list(datasets, filters, options)
 
     def query_for_quota_alert(self):

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -429,6 +429,12 @@ class ZFSDatasetService(CRUDService):
         props = extra.get('properties', None)
         flat = extra.get('flat', True)
         custom_props = extra.get('custom_properties', True)
+        retrieve_properties = extra.get('retrieve_properties', True)
+        if not retrieve_properties:
+            # This is a short hand version where consumer can specify that they don't want any property to
+            # be retrieved
+            custom_props = mountpoint = False
+            props = []
 
         with libzfs.ZFS() as zfs:
             # Handle `id` filter specially to avoiding getting all datasets

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -425,15 +425,15 @@ class ZFSDatasetService(CRUDService):
     def query(self, filters=None, options=None):
         options = options or {}
         extra = options.get('extra', {}).copy()
-        mountpoint = extra.get('mountpoint', True)
+        top_level_props = None if extra.get('top_level_properties') is None else extra['top_level_properties'].copy()
         props = extra.get('properties', None)
         flat = extra.get('flat', True)
-        custom_props = extra.get('custom_properties', True)
+        user_properties = extra.get('user_properties', True)
         retrieve_properties = extra.get('retrieve_properties', True)
         if not retrieve_properties:
             # This is a short hand version where consumer can specify that they don't want any property to
             # be retrieved
-            custom_props = mountpoint = False
+            user_properties = False
             props = []
 
         with libzfs.ZFS() as zfs:
@@ -444,7 +444,9 @@ class ZFSDatasetService(CRUDService):
                 except libzfs.ZFSException:
                     datasets = []
             else:
-                datasets = zfs.datasets_serialized(props=props, mountpoint=mountpoint, custom_props=custom_props)
+                datasets = zfs.datasets_serialized(
+                    props=props, top_level_props=top_level_props, user_props=user_properties
+                )
                 if flat:
                     datasets = self.flatten_datasets(datasets)
                 else:

--- a/src/middlewared/middlewared/pytest/unit/plugins/test_cloud_sync.py
+++ b/src/middlewared/middlewared/pytest/unit/plugins/test_cloud_sync.py
@@ -14,6 +14,10 @@ def test__get_dataset_recursive_1():
                         "children": []
                     }
                 ]
+            },
+            {
+                "mountpoint": "/mnt/data/test",
+                "children": []
             }
         ],
         "/mnt/data",
@@ -34,6 +38,10 @@ def test__get_dataset_recursive_2():
                         "children": []
                     }
                 ]
+            },
+            {
+                "mountpoint": "/mnt/data/test",
+                "children": []
             }
         ],
         "/mnt/data/test",
@@ -54,6 +62,10 @@ def test__get_dataset_recursive_3():
                         "children": []
                     }
                 ]
+            },
+            {
+                "mountpoint": "/mnt/data/test",
+                "children": []
             }
         ],
         "/mnt/data/test2",
@@ -79,6 +91,19 @@ def test__get_dataset_recursive_4():
                         ]
                     }
                 ]
+            },
+            {
+                "mountpoint": "/mnt/data/backup",
+                "children": [
+                    {
+                        "mountpoint": "/mnt/data/backup/test0/test1/test2",
+                        "children": [],
+                    }
+                ]
+            },
+            {
+                "mountpoint": "/mnt/data/backup/test0/test1/test2",
+                "children": [],
             }
         ],
         "/mnt/data/backup/test0",
@@ -104,6 +129,19 @@ def test__get_dataset_recursive_5():
                         ]
                     }
                 ]
+            },
+            {
+                "mountpoint": "/mnt/data/backup",
+                "children": [
+                    {
+                        "mountpoint": "/mnt/data/backup/test0/test1/test2",
+                        "children": [],
+                    }
+                ]
+            },
+            {
+                "mountpoint": "/mnt/data/backup/test0/test1/test2",
+                "children": [],
             }
         ],
         "/mnt/data/backup/test0/test3",


### PR DESCRIPTION
This PR updates zfs.dataset namespace to use new dataset serialization api exposed by py-libzfs which is way faster then `zfs.datasets`. Also we expose two structure options for retrieving datasets, first is hierarchical and the second is a flattened approach.