### PR TITLE
NAS-102523 / 11.3 / Update official repositories choices for plugins

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -146,7 +146,10 @@ class PluginService(CRUDService):
         process_pool = True
 
     OFFICIAL_REPOSITORIES = {
-        'https://github.com/freenas/iocage-ix-plugins.git'
+        'IXSYSTEMS': {
+            'name': 'iXsystems',
+            'git_repository': 'https://github.com/freenas/iocage-ix-plugins.git',
+        }
     }
 
     @accepts()
@@ -154,7 +157,7 @@ class PluginService(CRUDService):
         """
         List officially supported plugin repositories.
         """
-        return {k: k for k in self.OFFICIAL_REPOSITORIES}
+        return self.OFFICIAL_REPOSITORIES
 
     @filterable
     def query(self, filters=None, options=None):


### PR DESCRIPTION
This commit updates the api we expose for retrieving officially supported plugin repos including an icon uri and a user friendly name for the official repo.