### PR TITLE
NAS-102533 / 11.3 / Fix API for smb.sharesec

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1077,7 +1077,7 @@ class ShareSec(CRUDService):
             parsed_sd = await self.middleware.call('smb.sharesec._parse_share_sd', share, options)
             if parsed_sd:
                 parsed_sd.update({'id': idx})
-                idx = idx+1
+                idx = idx + 1
                 share_sd_list.append(parsed_sd)
 
         return share_sd_list
@@ -1262,18 +1262,18 @@ class ShareSec(CRUDService):
     @accepts(Dict(
         'smbsharesec_create',
         Str('share_name', required=True),
-        List('share_acl', items=[
-            Dict('aclentry',
-                 Str('ae_who_sid', default=None),
-                 Dict('ae_who_name',
-                      Str('domain', default=''),
-                      Str('name', default=''),
-                      default=None),
-                 Str('ae_perm', enum=['FULL', 'CHANGE', 'READ']),
-                 Str('ae_type', enum=['ALLOWED', 'DENIED']))
-            ],
-            default=[{'ae_who_sid': 'S-1-1-0', 'ae_perm': 'FULL', 'ae_type': 'ALLOWED'}]
-        )
+        List('share_acl',
+             items=[
+                Dict('aclentry',
+                     Str('ae_who_sid', default=None),
+                     Dict('ae_who_name',
+                          Str('domain', default=''),
+                          Str('name', default=''),
+                          default=None),
+                     Str('ae_perm', enum=['FULL', 'CHANGE', 'READ']),
+                     Str('ae_type', enum=['ALLOWED', 'DENIED']))
+             ],
+             default=[{'ae_who_sid': 'S-1-1-0', 'ae_perm': 'FULL', 'ae_type': 'ALLOWED'}])
     ))
     async def do_create(self, data):
         """
@@ -1305,18 +1305,18 @@ class ShareSec(CRUDService):
     @accepts(
         Int('id', required=True),
         Dict('smbsharesec_update',
-             List('share_acl', items=[
-                 Dict('aclentry',
-                      Str('ae_who_sid', default=None),
-                      Dict('ae_who_name',
-                           Str('domain', default=''),
-                           Str('name', default=''),
-                           default=None),
-                      Str('ae_perm', enum=['FULL', 'CHANGE', 'READ']),
-                      Str('ae_type', enum=['ALLOWED', 'DENIED']))
-                 ],
-                 default=[{'ae_who_sid': 'S-1-1-0', 'ae_perm': 'FULL', 'ae_type': 'ALLOWED'}]
-             ))
+             List('share_acl',
+                  items=[
+                    Dict('aclentry',
+                         Str('ae_who_sid', default=None),
+                         Dict('ae_who_name',
+                              Str('domain', default=''),
+                              Str('name', default=''),
+                              default=None),
+                         Str('ae_perm', enum=['FULL', 'CHANGE', 'READ']),
+                         Str('ae_type', enum=['ALLOWED', 'DENIED']))
+                  ],
+                  default=[{'ae_who_sid': 'S-1-1-0', 'ae_perm': 'FULL', 'ae_type': 'ALLOWED'}]))
     )
     async def do_update(self, id, data):
         """


### PR DESCRIPTION
Convert sharesec into a CRUD service. When _view_all is called (for instance through smb.sharesec.query), add a numerical index key to the parsed security descritor for each share. Since the ordering is fairly consistent, this can serve as a unique ID for the update and delete methods. Delete can take the numeric id or
share name as an argument. Deletion in this case means replacing the existing Share ACL with S-1-1-0/FULL. The distinction between create and update is that the former takes a share name and the latter a numeric ID since it is only possible to apply an ACL to an existing share.