### PR TITLE
NAS-102545 / 11.3 / Correctly join multiple certificates

### DIFF
--- a/src/middlewared/middlewared/etc_files/generate_ssl_certs.py
+++ b/src/middlewared/middlewared/etc_files/generate_ssl_certs.py
@@ -8,8 +8,7 @@ def write_certificates(certs):
 
         if cert['chain_list']:
             with open(cert['certificate_path'], 'w') as f:
-                for i in cert['chain_list']:
-                    f.write(i)
+                f.write('\n'.join(cert['chain_list']))
 
         if cert['privatekey']:
             with open(cert['privatekey_path'], 'w') as f:


### PR DESCRIPTION
This commit fixes a bug where we did not introduce a line break between two certs in a cert chain list. This behavior was okay when almost all certs include a line break at the end but if a cert does not have a line break at end, this fails and nginx is unable to parse the certs correctly.