### PR TITLE
NAS-102570 / 11.3 / Multiple fixes in smb4.conf

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf
@@ -23,7 +23,7 @@
 
             conf['cifs'] = middleware.call_sync('smb.config')
             conf['ad'] = middleware.call_sync('activedirectory.config')
-            conf['ldap'] = middleware.call_sync('datastore.config', 'directoryservice.ldap')
+            conf['ldap'] = middleware.call_sync('ldap.config')
             conf['nis'] = middleware.call_sync('datastore.config', 'directoryservice.nis')
             conf['gc'] = middleware.call_sync('network.configuration.config')
             conf['shares'] = middleware.call_sync('sharing.smb.query', [['enabled', '=', True]])
@@ -40,7 +40,7 @@
 
             if conf['ad']['enable']:
                 conf['role'] = 'ad_member'
-            elif conf['ldap']['ldap_enable'] and conf['ldap']['ldap_has_samba_schema']:
+            elif conf['ldap']['enable'] and conf['ldap']['has_samba_schema']:
                 conf['role'] = 'ldap_member'
 
             if any(filter(lambda x: x['guestok'], conf['shares'])):
@@ -165,6 +165,17 @@
 
             return pc
 
+
+        def generate_ldap_backend(ldap):
+            """
+            LDAP connections should be secured where possible. This may
+            be done with Start-TLS or by specifying ldaps:// in the URL
+            argument. Multiple servers may be specified in double-quotes.
+            """
+            prefix = "ldaps://" if ldap["ssl"] == "ON" else "ldap://"
+            uri_string = f' {prefix}'.join(ldap['hostname'])
+            return f'ldapsam:"{prefix}{uri_string}"'
+
         def add_rolebased_params(pc, db):
             """
             `AD MEMBER` Ability to become Master Browser is disabled. `enum users`
@@ -207,23 +218,19 @@
                 pc.update({
                     'server role': 'member server',
                     'security': 'user',
-                    'ldap admin dn': db['ldap']['ldap_binddn'],
-                    'ldap suffix': db['ldap']['ldap_basedn'],
-                    'ldap user suffix': db['ldap']['ldap_usersuffix'],
-                    'ldap group suffix': db['ldap']['ldap_groupsuffix'],
-                    'ldap machine suffix': db['ldap']['ldap_machinesuffix'],
+                    'ldap admin dn': db['ldap']['binddn'],
+                    'ldap suffix': db['ldap']['basedn'],
+                    'ldap user suffix': db['ldap']['usersuffix'],
+                    'ldap group suffix': db['ldap']['groupsuffix'],
+                    'ldap machine suffix': db['ldap']['machinesuffix'],
                     'ldap replication sleep': '1000',
                     'ldap passwd sync': 'Yes',
-                    'ldap ssl': 'off' if db['ldap']['ldap_ssl'] != 'START_TLS' else 'start tls',
+                    'ldap ssl': 'off' if db['ldap']['ssl'] != 'START_TLS' else 'start tls',
                     'ldapsam:trusted': 'Yes',
                     'domain logons': 'Yes',
+                    'passdb backend': generate_ldap_backend(db['ldap']),
                     'workgroup': db['cifs']['workgroup'].upper(),
                 })
-                ldap_pdb_backend = "ldapsam:\"%s\"" & " ".join([
-                    "%s://%s" % ("ldaps" if db['ldap']['ldap_ssl'] == 'ON' else "ldap", hostname)
-                    for hostname in db['ldap']['ldap_hostname'].split()
-                ])
-                pc.update({'passdb backend': ldap_pdb_backend})
 
             elif db['role'] == "standalone":
                 pc.update({'server role': 'standalone'})
@@ -247,7 +254,7 @@
                 if autorid_enabled and idmap['domain']['idmap_domain_name'] == 'DS_TYPE_DEFAULT_DOMAIN':
                     return
 
-            if db['ldap']['ldap_enable'] and idmap['domain']['idmap_domain_name'] == 'DS_TYPE_ACTIVEDIRECTORY':
+            if db['ldap']['enable'] and idmap['domain']['idmap_domain_name'] == 'DS_TYPE_ACTIVEDIRECTORY':
                 return
 
             if db['role'] == 'standalone':

--- a/src/middlewared/middlewared/etc_files/local/smb4.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf
@@ -29,16 +29,15 @@
             conf['shares'] = middleware.call_sync('sharing.smb.query', [['enabled', '=', True]])
             conf['role'] = 'standalone'
             conf['guest_enabled'] = False
-            conf['system_dataset'] = middleware.call_sync('systemdataset.config')
             conf['loglevel'] = LOGLEVEL_UNMAP.get(conf['cifs']['loglevel'])
             conf['fruit_enabled'] = False
 
             conf['truenas_conf'] = {'is_truenas_ha': False, 'failover_status': 'DEFAULT', 'smb_ha_mode': 'LEGACY'}
-            if not middleware.call_sync('system.is_freenas') and middleware.call_sync('failover.licensed'):
+            conf['truenas_conf']['smb_ha_mode'] = middleware.call_sync('smb.get_smb_ha_mode')
+            if conf['truenas_conf']['smb_ha_mode'] != 'STANDALONE':
                 conf['truenas_conf']['is_truenas_ha'] = True
                 conf['truenas_conf']['failover_status'] = middleware.call_sync('failover.status')
-                if conf['system_dataset']['pool'] != 'freenas-boot':
-                    conf['truenas_conf']['smb_ha_mode'] = 'UNIFIED'
+
             if conf['ad']['enable']:
                 conf['role'] = 'ad_member'
             elif conf['ldap']['ldap_enable'] and conf['ldap']['ldap_has_samba_schema']:
@@ -75,6 +74,10 @@
             return False
 
         def add_bind_interfaces(pc, db):
+            """
+            smbpasswd by default connects to 127.0.0.1 as an SMB client. For this reason, localhost is added
+            to the list of bind ip addresses here.
+            """
             if db['cifs']['bindip']:
                 bindips = (db['cifs']['bindip'])
                 bindips.insert(0, "127.0.0.1")
@@ -83,23 +86,44 @@
             pc.update({'bind interfaces only': 'Yes'})
 
         def add_general_params(pc, db):
-            if os.path.exists("/usr/local/etc/smbusername.map"):
-                pc.update({'username map': '/usr/local/etc/smbusername.map'})
-            pc.update({'dns proxy': 'No'})
-            pc.update({'deadtime': '15'})
-            pc.update({'max log size': '51200'})
-            pc.update({'allocation roundup size': '0'})
-            pc.update({'load printers': 'No'})
-            pc.update({'printing': 'bsd'})
+            """
+            The deadtime counter only takes effect if the number of open files is zero.
+            Allocation roundup size is a legacy performance optimization. It generates user confusion at
+            default value. The setting we have here is the new default in 4.11.
+
+            `dos filemode` was originally set for windows behavior regarding changing owner. This should be
+            reviewed for accuracy. `kernel change notify` is disabled because it will result in an open fd for
+            every file that is monitored, leading to resource exhaustion on moderately busy servers.
+            `directory name cache size` is a parameter to work around a bug in directory caching in SMB1 for
+            FreeBSD. Recent testing could not reproduce the bug, but the issue is moot since SMB1 is being
+            deprecated. `username map` is used to map Microsoft accounts to local accounts
+            (bob@microsoft.com to bob). `unix extensions` are legacy SMB1 Unix Extensions. We disable
+            by default if SMB1 is disabled.
+            """
+            pc.update({
+                'dns proxy': 'No',
+                'deadtime': '15',
+                'max log size': '51200',
+                'allocation roundup size': '0',
+                'load printers': 'No',
+                'printing': 'bsd',
+                'disable spoolss': 'Yes',
+                'dos filemode': 'Yes',
+                'kernel change notify': 'No',
+                'directory name cache size': '0',
+                'nsupdate command': '/usr/local/bin/samba-nsupdate -g',
+                'unix charset': db['cifs']['unixcharset'],
+                'log level': db['loglevel'],
+                'username map': '/usr/local/etc/smbusername.map',
+                'username map cache time': '60',
+            })
             if not db['cifs']['syslog']:
                 pc.update({'logging': 'file'})
-            pc.update({'log level': db['loglevel']})
             if db['cifs']['enable_smb1']:
                 pc.update({'server min protocol': 'NT1'})
             else:
                 pc.update({'server min protocol': 'SMB2_02'})
                 pc.update({'unix extensions': 'No'})
-            pc.update({'disable spoolss': 'Yes'})
             if db['cifs']['guest'] != "nobody":
                 pc.update({'guest account': db['cifs']['guest']})
             if db['guest_enabled']:
@@ -107,21 +131,14 @@
             if db['cifs']['ntlmv1_auth']:
                 pc.update({'ntlm auth': 'Yes'})
                 pc.update({'client ntlmv2 auth': 'No'})
-            pc.update({'directory name cache size': '0'})
-            pc.update({'kernel change notify': 'No'})
             if pam_is_required(db):
                 pc.update({'obey pam restrictions': 'True'})
-            pc.update({'nsupdate command': "/usr/local/bin/samba-nsupdate -g"})
             if db['cifs']['description']:
                 pc.update({'server string': db['cifs']['description']})
-            pc.update({'dos filemode': 'Yes'})
-            if not db['cifs']['zeroconf']:
-                pc.update({'multicast dns register': 'No'})
             if db['cifs']['filemask']:
                 pc.update({'create mask': db['cifs']['filemask']})
             if db['cifs']['dirmask']:
                 pc.update({'directory mask': db['cifs']['dirmask']})
-            pc.update({'unix charset': db['cifs']['unixcharset']})
             if db['fruit_enabled']:
                 pc.update({'fruit:nfs_aces': 'No'})
 
@@ -149,58 +166,64 @@
             return pc
 
         def add_rolebased_params(pc, db):
+            """
+            `AD MEMBER` Ability to become Master Browser is disabled. `enum users`
+            and `enum groups` are disabled if the active caching is disabled.
+            `allow dns updates` controls whether the server will dynamically
+            update its DNS record in AD. This should be disabled in clustered
+            or HA configurations. Maximum number of domain connections is increased
+            from default of 1 to improve scalability in large AD environments.
+
+            `LDAP MEMBER` configures ldapsam passdb backend for samba. This requires
+            that the openldap server have the Samba LDAP schema extensions.
+            """
             if db['role'] == "ad_member":
-                pc.update({'server role': 'member server'})
-                pc.update({'kerberos method': 'secrets and keytab'})
-                pc.update({'workgroup': db['cifs']['workgroup'].upper()})
-                pc.update({'realm': db['ad']['domainname'].upper()})
-                pc.update({'security': 'ADS'})
-                pc.update({'client use spnego': 'Yes'})
-                pc.update({'local master': 'No'})
-                pc.update({'domain master': 'No'})
-                pc.update({'preferred master': 'No'})
-                if not db['ad']['allow_dns_updates']:
-                    pc.update({'ad allow dns update': 'No'})
-                pc.update({'winbind cache time': '7200'})
-                pc.update({'winbind offline logon': 'Yes'})
-                pc.update({'winbind enum users': 'Yes'})
-                pc.update({'winbind enum groups': 'Yes'})
+                pc.update({
+                    'server role': 'member server',
+                    'kerberos method': 'secrets and keytab',
+                    'workgroup': db['cifs']['workgroup'].upper(),
+                    'realm': db['ad']['domainname'].upper(),
+                    'security': 'ADS',
+                    'local master': 'No',
+                    'domain master': 'No',
+                    'preferred master': 'No',
+                    'winbind cache time': '7200',
+                    'winbind max domain connections': '10',
+                    'client ldap sasl wrapping': db['ad']['ldap_sasl_wrapping'].lower(),
+                    'template shell': '/bin/sh',
+                    'template homedir': f'{get_cifs_homedir()}/%D/%U',
+                    'ad allow dns update': 'Yes' if db['ad']['allow_dns_updates'] else 'No',
+                    'allow trusted domains': 'Yes' if db['ad']['allow_trusted_doms'] else 'No'
+                })
+                if not db['ad']['disable_freenas_cache']:
+                    pc.update({'winbind enum users': 'Yes'})
+                    pc.update({'winbind enum groups': 'Yes'})
                 if db['ad']['use_default_domain']:
                     pc.update({'winbind use default domain': 'Yes'})
-                pc.update({'winbind refresh tickets': 'Yes'})
                 if db['ad']['nss_info']:
                     pc.update({'winbind nss info': db['ad']['nss_info'].lower()})
-                if not db['ad']['allow_trusted_doms']:
-                    pc.update({'allow trusted domains': 'No'})
-                pc.update({'client ldap sasl wrapping': db['ad']['ldap_sasl_wrapping'].lower()})
-                pc.update({'template shell': '/bin/sh'})
-                pc.update({'template homedir': f'{get_cifs_homedir()}/%D/%U'})
 
             elif db['role'] == 'ldap_member':
-                pc.update({'server role': 'member server'})
-                pc.update({'security': 'user'})
-                if type(db['ldap']['ldap_hostname']) == list:
-                    ldap_pdb_backend = "ldapsam:\"%s\"" & " ".join([
-                        "%s://%s" % ("ldaps" if db['ldap']['ldap_ssl'] == 'ON' else "ldap", hostname)
-                        for hostname in db['ldap']['ldap_hostname'].split()
-                    ])
-                else:
-                    ldap_pdb_backend = f"ldapsam:{'ldaps' if db['ldap']['ldap_ssl'] == 'ON' else 'ldap'}://{db['ldap']['ldap_hostname']}"
-
+                pc.update({
+                    'server role': 'member server',
+                    'security': 'user',
+                    'ldap admin dn': db['ldap']['ldap_binddn'],
+                    'ldap suffix': db['ldap']['ldap_basedn'],
+                    'ldap user suffix': db['ldap']['ldap_usersuffix'],
+                    'ldap group suffix': db['ldap']['ldap_groupsuffix'],
+                    'ldap machine suffix': db['ldap']['ldap_machinesuffix'],
+                    'ldap replication sleep': '1000',
+                    'ldap passwd sync': 'Yes',
+                    'ldap ssl': 'off' if db['ldap']['ldap_ssl'] != 'START_TLS' else 'start tls',
+                    'ldapsam:trusted': 'Yes',
+                    'domain logons': 'Yes',
+                    'workgroup': db['cifs']['workgroup'].upper(),
+                })
+                ldap_pdb_backend = "ldapsam:\"%s\"" & " ".join([
+                    "%s://%s" % ("ldaps" if db['ldap']['ldap_ssl'] == 'ON' else "ldap", hostname)
+                    for hostname in db['ldap']['ldap_hostname'].split()
+                ])
                 pc.update({'passdb backend': ldap_pdb_backend})
-                pc.update({'ldap admin dn': db['ldap']['ldap_binddn']})
-                pc.update({'ldap suffix': db['ldap']['ldap_basedn']})
-                pc.update({'ldap user suffix': db['ldap']['ldap_usersuffix']})
-                pc.update({'ldap group suffix': db['ldap']['ldap_groupsuffix']})
-                pc.update({'ldap machine suffix': db['ldap']['ldap_machinesuffix']})
-                pc.update({'workgroup': db['cifs']['workgroup'].upper()})
-                if db['ldap']['ldap_ssl'] != "START_TLS":
-                    pc.update({'ldap ssl': 'off'})
-                pc.update({'ldap replication sleep': '1000'})
-                pc.update({'ldap passwd sync': 'Yes'})
-                pc.update({'ldapsam:trusted': 'Yes'})
-
-                pc.update({'domain logons': 'Yes'})
 
             elif db['role'] == "standalone":
                 pc.update({'server role': 'standalone'})
@@ -321,6 +344,13 @@
 
         def parse_config(db):
             pc = {}
+            if db['truenas_conf']['smb_ha_mode'] == 'UNIFIED' and db['truenas_conf']['failover_status'] != 'MASTER':
+                stub_config = {
+                    'netbios name': f"{db['gc']['hostname_virtual']}_PASSIVE",
+                    'logging': 'file'
+                }
+                return stub_config
+
             add_general_params(pc, db)
             add_bind_interfaces(pc, db)
             add_licensebased_params(pc, db)
@@ -336,12 +366,6 @@
 %>
 
 [global]
-%if db['truenas_conf']['smb_ha_mode'] == 'UNIFIED' and db['truenas_conf']['failover_status'] != 'MASTER':
-        [global]
-        netbios name = {db['gc']['hostname_virtual']}_PASSIVE
-        multicast dns register = False
-        logging = file
-%else:
     % for param, value in parsed_conf.items():
       % if type(value) == list:
         ${param} = ${' '.join(value)}
@@ -349,6 +373,5 @@
         ${param} = ${value}
       % endif
     % endfor
-%endif
 
         include = /usr/local/etc/smb4_share.conf

--- a/src/middlewared/middlewared/etc_files/local/smb4_share.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4_share.conf
@@ -9,9 +9,9 @@
 
         def get_db_config():
             db = {}
-            db['truenas_conf'] = {"is_truenas_ha": False, "failover_status": "DEFAULT"}
-            if not middleware.call_sync('system.is_freenas') and middleware.call_sync('failover.licensed'):
-                db['truenas_conf']['is_truenas_ha'] = True
+            db['truenas_conf'] = {'smb_ha_mode': 'STANDALONE', "failover_status": "DEFAULT"}
+            db['truenas_conf']['smb_ha_mode'] = middleware.call_sync('smb.get_smb_ha_mode')
+            if db['truenas_conf']['smb_ha_mode'] != 'STANDALONE':
                 db['truenas_conf']['failover_status'] = middleware.call_sync('failover.status')
 
             db['cifs'] = middleware.call_sync('smb.config')
@@ -27,6 +27,12 @@
             return db
 
         def make_homedir(homedir_path=None):
+            """
+            This creates the path to the ['homes'] share if it does not exist. This is of
+            particular relevance in an AD environment where the DOMAIN directory must be
+            created in order for users to connect to their homes share. The actual user
+            home directory will be automatically created by pam_mkhomedir.
+            """
             ret = True
             if not os.access(homedir_path, os.F_OK):
                 try:
@@ -37,7 +43,7 @@
             return ret
 
         def order_vfs_objects(vfs_objects):
-            vfs_objects_special = ('catia', 'zfs_space', 'noacl', 'zfsacl',
+            vfs_objects_special = ('shadow_copy_zfs', 'catia', 'zfs_space', 'noacl', 'ixnas', 'zfsacl',
                                    'fruit', 'streams_xattr', 'crossrename', 'recycle')
             vfs_objects_ordered = []
 
@@ -46,8 +52,6 @@
                     vfs_objects.append('streams_xattr')
 
             if 'noacl' in vfs_objects:
-                if 'zfsacl' not in vfs_objects:
-                    vfs_objects.append('zfsacl')
                 if 'ixnas' in vfs_objects:
                     vfs_objects.remove('ixnas')
 
@@ -68,10 +72,10 @@
                     Special behavior is needed for [homes]:
                     We append %U (authenticated username) to the share path
                     for non-AD environments, and %D/%U for AD environments.
-                    This prevents users from being able to access the each 
+                    This prevents users from being able to access the each
                     others home directories. %D is required for AD to prevent
                     collisions between AD users and local users or users in
-                    trusted domains. 
+                    trusted domains.
                 """
                 is_home_share = False
                 is_ad_environment = False
@@ -173,8 +177,11 @@
                     pc[share["name"]].update({"recycle:directory_mode": "0777"})
                     pc[share["name"]].update({"recycle:subdir_mode": "0700"})
 
-                pc[share["name"]].update({"nfs4:chown": "true"})
-                pc[share["name"]].update({"nfs4:acedup": "merge"})
+                pc[share["name"]].update({
+                    "nfs4:chown": "true",
+                    "nfs4:acedup": "merge",
+                    "mangled names": "illegal"
+                })
 
                 for param in share['auxsmbconf'].splitlines():
                     if not param.strip():


### PR DESCRIPTION
Increase default number max winbindd connections. Offline logons limits winbind to single connection per domain. This can limit scalability in large environments.
Turn off user and group enumeration in winbind if the FreeNAS cache is disabled.
Fix smb4.conf generation on TrueNAS HA (unified config had second [global] heading).
Fix ordering of vfs objects for shadow_copy_zfs and ixnas.
vfs_noacl now disables NT ACL support behind the scenes so it no longer should be stacked with zfsacl.
LDAP hostnames is now always a list, so remove this check.
'client use spnego = yes' is now the default, so remove the parameter.
mDNS registration now happens through middleware, so remove this parameter.