### PR TITLE
NAS-101734 / 11.3 / Improve VM Device CRUD operations (by sonicaj)

### DIFF
--- a/gui/vm/migrations/0010_normalize_size.py
+++ b/gui/vm/migrations/0010_normalize_size.py
@@ -1,0 +1,40 @@
+import math
+
+from django.db import migrations
+
+
+def convert_size(apps, schema_editor):
+    device_model = apps.get_model('vm', 'Device')
+    for device in device_model.objects.filter(dtype='RAW'):
+        if isinstance(device.attributes.get('size') or 0, str):
+            size = original_value = device.attributes['size']
+            suffix = original_value[-1]
+            if not suffix.isdigit():
+                size = original_value[:-1]
+
+            try:
+                size = int(size)
+            except ValueError:
+                # If the value is malformed, we shift it to 1GB
+                size = 1
+
+            if suffix == 'T':
+                size *= 1024
+            elif suffix == 'M':
+                size = math.ceil(size / 1024)
+
+            # If we have a suffix other then T/G/B, we disregard it completely following how vm plugin does it
+            # and consider size to be in GB now
+            device.attributes['size'] = size
+            device.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('vm', '0009_auto_20190315_1058'),
+    ]
+
+    operations = [
+        migrations.RunPython(convert_size),
+    ]

--- a/gui/vm/migrations/0010_normalize_size.py
+++ b/gui/vm/migrations/0010_normalize_size.py
@@ -1,13 +1,12 @@
-import math
-
 from django.db import migrations
 
 
 def convert_size(apps, schema_editor):
     device_model = apps.get_model('vm', 'Device')
     for device in device_model.objects.filter(dtype='RAW'):
-        if isinstance(device.attributes.get('size') or 0, str):
-            size = original_value = device.attributes['size']
+        size = device.attributes.get('size')
+        if not isinstance(size, int):
+            size = original_value = str(device.attributes.get('size') or 1)
             suffix = original_value[-1]
             if not suffix.isdigit():
                 size = original_value[:-1]
@@ -19,14 +18,23 @@ def convert_size(apps, schema_editor):
                 size = 1
 
             if suffix == 'T':
-                size *= 1024
+                size *= (1024 * 1024 * 1024 * 1024)
+            elif suffix == 'G' or suffix.isdigit():
+                # suffix would be a digit in cases where we only have say "14" saved in db
+                size *= (1024 * 1024 * 1024)
             elif suffix == 'M':
-                size = math.ceil(size / 1024)
+                size *= (1024 * 1024)
 
             # If we have a suffix other then T/G/B, we disregard it completely following how vm plugin does it
             # and consider size to be in GB now
-            device.attributes['size'] = size
-            device.save()
+        else:
+            # If it's an integer already, it's in GB
+            size = size or 1
+            size *= (1024 * 1024 * 1024)
+
+        # At this stage size has been converted to bytes
+        device.attributes['size'] = size
+        device.save()
 
 
 class Migration(migrations.Migration):

--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -887,11 +887,24 @@ class VMService(CRUDService):
         for create_device in filter(lambda v: 'id' not in v, devices):
             await self.middleware.call('vm.device.create', create_device)
 
-    @accepts(Int('id'), Patch(
-        'vm_create',
-        'vm_update',
-        ('attr', {'update': True}),
-    ))
+    @accepts(
+        Int('id'),
+        Patch(
+            'vm_create',
+            'vm_update',
+            ('attr', {'update': True}),
+            (
+                'edit', {
+                    'name': 'devices', 'method': lambda v: setattr(
+                        v, 'items', [Patch(
+                            'vmdevice_create', 'vmdevice_update', ('attr', {'update': True}),
+                            ('add', {'name': 'id', 'type': 'int', 'required': False})
+                        )]
+                    )
+                }
+            )
+        )
+    )
     async def do_update(self, id, data):
         """Update all information of a specific VM."""
 

--- a/src/middlewared/middlewared/schema.py
+++ b/src/middlewared/middlewared/schema.py
@@ -827,6 +827,7 @@ class Patch(object):
                 attr = schema.attrs[patch['name']]
                 if 'method' in patch:
                     patch['method'](attr)
+                    schema.attrs[patch['name']] = attr.resolve(schemas)
             elif operation == 'attr':
                 for key, val in list(patch.items()):
                     setattr(schema, key, val)


### PR DESCRIPTION
This PR introduces following changes:
1) Ensures that we are able to create/update devices when creating/updating vm's.
2) Ensures that in case of a vm update/create failure we do a complete rollback and do not leave any newly created resources lying around.
3) Ability to create/update raw files on vm device creation/updation.
4) Normalize raw file size to be in bytes.
5) Bug fix where we didn't correctly update an edited patch's schema.
6) Improved validation for vm device and vm service.