### PR TITLE
NAS-102566 / 11.3 / Disable legacy UI by default

### DIFF
--- a/gui/system/forms.py
+++ b/gui/system/forms.py
@@ -1128,7 +1128,7 @@ class AdvancedForm(MiddlewareModelForm, ModelForm):
     def __init__(self, *args, **kwargs):
         super(AdvancedForm, self).__init__(*args, **kwargs)
         self.fields['adv_motd'].strip = False
-        self.original_instance = self.instance.__dict__
+        self.original_instance = self.instance.__dict__.copy()
 
         self.fields['adv_serialport'].choices = list(choices.SERIAL_CHOICES())
 
@@ -1160,6 +1160,9 @@ class AdvancedForm(MiddlewareModelForm, ModelForm):
             events.append("_msg_start()")
         else:
             events.append("_msg_stop()")
+
+        if self.original_instance['adv_legacy_ui'] != self.instance.adv_legacy_ui:
+            events.append(f'evilrestartHttpd(\'http://{request.META["HTTP_HOST"]}\')')
 
         if self.original_instance['adv_advancedmode'] != self.instance.adv_advancedmode:
             # Invalidate cache

--- a/gui/system/migrations/0046_legacy_ui.py
+++ b/gui/system/migrations/0046_legacy_ui.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('system', '0045_fromname'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='Advanced',
+            name='adv_legacy_ui',
+            field=models.BooleanField(
+                default=False,
+                help_text='Enable or disable the legacy UI.',
+                verbose_name='Enable legacy UI'
+            ),
+        )
+    ]

--- a/gui/system/models.py
+++ b/gui/system/models.py
@@ -218,6 +218,11 @@ class NTPServer(Model):
 
 
 class Advanced(Model):
+    adv_legacy_ui = models.BooleanField(
+        verbose_name=_('Enable legacy UI'),
+        default=False,
+        help_text=_('Enable or disable the legacy UI.')
+    )
     adv_consolemenu = models.BooleanField(
         verbose_name=_("Show Text Console without Password Prompt"),
         default=False,

--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf
@@ -27,7 +27,7 @@
         middleware.call_sync('alert.oneshot_delete', 'WebUiCertificateSetupFailed', None)
 
     system_version = middleware.call_sync('system.info')['version']
-
+    enable_legacy_ui = middleware.call_sync('system.advanced.config')['legacy_ui']
 %>
 #
 #    FreeNAS nginx configuration file
@@ -123,7 +123,7 @@ http {
             rewrite ^.* /ui/;
         }
 
-        location ~ ^/(legacy|plugins|api/v1.0)/ {
+        location ~ ^/(${'legacy|plugins|' if enable_legacy_ui else ''}api/v1.0)/ {
             include fastcgi_params;
             fastcgi_pass 127.0.0.1:9042;
             fastcgi_pass_header Authorization;
@@ -142,6 +142,7 @@ http {
             report_uploads proxied;
         }
 
+% if enable_legacy_ui:
         location ^~ /legacy/static {
             alias /usr/local/www/freenasUI/static;
             add_header Cache-Control "must-revalidate";
@@ -151,6 +152,7 @@ http {
         location ^~ /legacy/dojango/dojo-media/release/${dojo_version} {
             alias /usr/local/www/dojo;
         }
+% endif
 
         location /api/docs {
             proxy_pass http://127.0.0.1:6000/api/docs;

--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf
@@ -120,7 +120,7 @@ http {
 % endif
 
         location / {
-            rewrite ^.* /ui/;
+            rewrite ^.* /ui/ redirect;
         }
 
         location ~ ^/(${'legacy|plugins|' if enable_legacy_ui else ''}api/v1.0)/ {

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -105,6 +105,7 @@ class SystemAdvancedService(ConfigService):
             'system_advanced_update',
             Bool('advancedmode'),
             Bool('autotune'),
+            Bool('legacy_ui'),
             Int('boot_scrub', validators=[Range(min=1)]),
             Bool('consolemenu'),
             Bool('consolemsg'),

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -240,6 +240,11 @@ class SystemService(Service):
         """
         return "FreeNAS" if await self.middleware.call("system.is_freenas") else "TrueNAS"
 
+    @no_auth_required
+    @accepts()
+    async def legacy_ui_enabled(self):
+        return (await self.middleware.call('system.advanced.config'))['legacy_ui']
+
     @accepts()
     def version(self):
         """

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -134,6 +134,8 @@ class SystemAdvancedService(ConfigService):
 
         `autotune` when enabled executes autotune script which attempts to optimize the system based on the installed
         hardware.
+
+        `legacy_ui` is disabled by default. Enabling it allows end users to use the legacy UI.
         """
         config_data = await self.config()
         original_data = config_data.copy()
@@ -243,6 +245,9 @@ class SystemService(Service):
     @no_auth_required
     @accepts()
     async def legacy_ui_enabled(self):
+        """
+        Returns a boolean value indicating if the legacy UI can be used by end users.
+        """
         return (await self.middleware.call('system.advanced.config'))['legacy_ui']
 
     @accepts()

--- a/src/middlewared/middlewared/plugins/usage.py
+++ b/src/middlewared/middlewared/plugins/usage.py
@@ -188,6 +188,7 @@ class UsageService(Service):
                 {'platform': platform},
                 {'usage_version': usage_version},
                 {'version': version},
+                {'legacy_ui_enabled': (await self.middleware.call('system.advanced.config'))['legacy_ui']},
                 {'system': [
                     {
                         'users': users, 'snapshots': snapshots, 'zvols': zvols,


### PR DESCRIPTION
This PR introduces following changes:
1) Disables legacy UI by default.
2) Exposes an unauthenticated api to query legacy UI status.
3) Collects legacy UI status anonymously via our usage plugin.