### PR TITLE
NAS-102594 / 11.3 / Bug fix for credential providers

### DIFF
--- a/gui/freeadmin/static/lib/js/freeadmin.js
+++ b/gui/freeadmin/static/lib/js/freeadmin.js
@@ -1287,7 +1287,12 @@ require([
 
         var provider = registry.byId(provider_id).get('value');
         var credentialsSchemas = JSON.parse(registry.byId("id_credentials_schemas").get('value'));
-        var credentialsOauths = JSON.parse(registry.byId("id_credentials_oauths").get('value'));
+        var credentialsOauths = registry.byId("id_credentials_oauths");
+        if (credentialsOauths == null) {
+            credentialsOauths = {};
+        } else {
+            credentialsOauths = JSON.parse(credentialsOauths.get("value"));
+        }
 
         var attributesInput = dom.byId("id_attributes");
         var attributes = JSON.parse(attributesInput.value) || {};


### PR DESCRIPTION
This commit fixes a bug where we tried to access a field which was not present and resulted in termination of the js function. ( A use case is ACME DNS Authenticator form which does not have this field )