### PR TITLE
NAS-102597 / 11.3 / Do not create DOMAIN directory in "homes" share when ixnas:zfs_auto_h…

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4_share.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4_share.conf
@@ -79,23 +79,13 @@
                 """
                 is_home_share = False
                 is_ad_environment = False
+                ixnas_auto_homedir = False
                 if share["home"]:
                     is_home_share = True
                     share["name"] = "homes" 
-                    ad =  middleware.call_sync('datastore.config', 'directoryservice.activedirectory') 
-                    if ad['ad_enable']:
-                        is_ad_environment = True
+                    is_ad_environment =  middleware.call_sync('activedirectory.config')['enable']
 
                 pc[share["name"]] = {}
-                if is_home_share and is_ad_environment:
-                    pc[share["name"]].update({"path": f'{share["path"]}/%D/%U'})
-                    base_homedir = f"{share['path']}/{db['cifs']['workgroup']}"
-                    make_homedir(base_homedir) 
-
-                elif is_home_share:
-                    pc[share["name"]].update({"path": f'{share["path"]}/%U'})
-                else:
-                    pc[share["name"]].update({"path": share["path"]})
 
                 if share['comment']:
                     pc[share["name"]].update({"comment": share['comment']})
@@ -189,16 +179,26 @@
                     try:
                         param_kv = [kv.strip() for kv in param.split("=")]
                         pc[share["name"]].update({param_kv[0]: param_kv[1]})
+                        if param_kv[0] == 'ixnas:zfs_auto_homedir':
+                            ixnas_auto_homedir = True
                     except Exception:
                         logger.debug(f"[{share['name']}] contains invalid auxiliary parameter: ({param})")
+
+                if is_home_share and is_ad_environment:
+                    pc[share["name"]].update({"path": f'{share["path"]}/%D/%U'})
+                    base_homedir = f"{share['path']}/{db['cifs']['workgroup']}"
+                    if not ixnas_auto_homedir:
+                        make_homedir(base_homedir)
+                elif is_home_share:
+                    pc[share["name"]].update({"path": f'{share["path"]}/%U'})
+                else:
+                    pc[share["name"]].update({"path": share["path"]})
 
             return pc
 
         db = get_db_config()
         parsed_conf = {}
         parsed_conf = parse_db_config(db)
-
-
 %>
 
 % if db['truenas_conf']['failover_status'] is not "BACKUP":


### PR DESCRIPTION
…omedir is enabled

In this situation we can rely on samba to auto-create the necessary path components.