### PR TITLE
NAS-102606 / 11.3 / Make domain-specific recycle bin if AD enabled

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf
@@ -203,7 +203,7 @@
                     'client ldap sasl wrapping': db['ad']['ldap_sasl_wrapping'].lower(),
                     'template shell': '/bin/sh',
                     'template homedir': f'{get_cifs_homedir()}/%D/%U',
-                    'ad allow dns update': 'Yes' if db['ad']['allow_dns_updates'] else 'No',
+                    'ads dns update': 'Yes' if db['ad']['allow_dns_updates'] else 'No',
                     'allow trusted domains': 'Yes' if db['ad']['allow_trusted_doms'] else 'No'
                 })
                 if not db['ad']['disable_freenas_cache']:

--- a/src/middlewared/middlewared/etc_files/local/smb4_share.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4_share.conf
@@ -19,6 +19,7 @@
             db['afp_shares'] = middleware.call_sync('sharing.afp.query', [['enabled', '=', True]])
             db['nfs_exports'] = middleware.call_sync('sharing.nfs.query', [['enabled', '=', True]])
             db['fruit_enabled'] = False
+            db['ad_enabled'] = middleware.call_sync('activedirectory.config')['enable']
             for share in db['shares']:
                 if "fruit" in share['vfsobjects'] or share['timemachine']:
                     db['fruit_enabled'] = True
@@ -78,12 +79,11 @@
                     trusted domains.
                 """
                 is_home_share = False
-                is_ad_environment = False
+                is_ad_environment = db['ad_enabled']
                 ixnas_auto_homedir = False
                 if share["home"]:
                     is_home_share = True
                     share["name"] = "homes" 
-                    is_ad_environment =  middleware.call_sync('activedirectory.config')['enable']
 
                 pc[share["name"]] = {}
 
@@ -160,12 +160,14 @@
                     pc[share["name"]].update({"fruit:volume_uuid": share['vuid']})
 
                 if share['recyclebin']:
-                    pc[share["name"]].update({"recycle:repository": ".recycle/%U"})
-                    pc[share["name"]].update({"recycle:keeptree": "yes"})
-                    pc[share["name"]].update({"recycle:keepversions": "yes"})
-                    pc[share["name"]].update({"recycle:touch": "yes"})
-                    pc[share["name"]].update({"recycle:directory_mode": "0777"})
-                    pc[share["name"]].update({"recycle:subdir_mode": "0700"})
+                    pc[share["name"]].update({
+                        "recycle:repository": ".recycle/%D/%U" if is_ad_environment else ".recycle/%U",
+                        "recycle:keeptree": "yes",
+                        "recycle:keepversions": "yes",
+                        "recycle:touch": "yes",
+                        "recycle:directory_mode": "0777",
+                        "recycle:subdir_mode": "0700"
+                    })
 
                 pc[share["name"]].update({
                     "nfs4:chown": "true",

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -371,11 +371,15 @@ class SMBService(SystemServiceService):
                 raise CallError(f'Failed to list passdb output: {pdb.stderr.decode()}')
             for p in (pdb.stdout.decode()).splitlines():
                 entry = p.split(':')
-                pdbentries.append({
-                    'username': entry[0],
-                    'full_name': entry[2],
-                    'uid': entry[1],
-                })
+                try:
+                    pdbentries.append({
+                        'username': entry[0],
+                        'full_name': entry[2],
+                        'uid': entry[1],
+                    })
+                except Exception as e:
+                    self.logger.debug('Failed to parse passdb entry [%s]: %s', p, e)
+
             return pdbentries
 
         pdb = await run([SMBCmd.PDBEDIT.value, '-Lv', '-d', '0'], check=False)

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -762,7 +762,7 @@ class SharingSMBService(CRUDService):
         """
         share = await self._get_instance(id)
         result = await self.middleware.call('datastore.delete', self._config.datastore, id)
-        await self.middleware.call('smb.sharesec._delete', share['name'])
+        await self.middleware.call('smb.sharesec._delete', share['name'] if not share['home'] else 'homes')
         await self._service_change('cifs', 'reload')
         return result
 


### PR DESCRIPTION
This prevents path collisions between AD users and local users recycle bins. Fix a few minor bugs discovered while testing homes and recycle bin in an AD environment.