### PR TITLE
NAS-102636 / 11.2 / Disable user/group caching with extreme prejudice when requested

### DIFF
--- a/gui/common/freenascache.py
+++ b/gui/common/freenascache.py
@@ -102,6 +102,7 @@ class FreeNAS_BaseCache(object):
             db.DB_INIT_MPOOL | db.DB_INIT_TXN
 
         self.__dbenv = db.DBEnv()
+        self.__dbenv.set_lk_detect(db.DB_LOCK_DEFAULT)
         self.__dbenv.open(
             self.cachedir,
             flags,

--- a/gui/common/system.py
+++ b/gui/common/system.py
@@ -379,6 +379,19 @@ def activedirectory_enabled():
     return enabled
 
 
+def ds_cache_enabled():
+    from freenasUI.directoryservice.models import ActiveDirectory
+
+    enabled = False
+    try:
+        ad = ActiveDirectory.objects.all()[0]
+        enabled = not ad.ad_disable_freenas_cache
+    except Exception:
+        log_traceback(log=log)
+
+    return enabled
+
+
 def activedirectory_has_unix_extensions():
     from freenasUI.directoryservice.models import ActiveDirectory
 

--- a/gui/tools/cachetool.py
+++ b/gui/tools/cachetool.py
@@ -40,7 +40,8 @@ django.setup()
 from freenasUI.common.system import (
     activedirectory_enabled,
     ldap_enabled,
-    nis_enabled
+    nis_enabled,
+    ds_cache_enabled
 )
 
 from freenasUI.common.freenascache import (
@@ -210,7 +211,7 @@ def _cache_keys_default(**kwargs):
 
 
 def cache_keys(**kwargs):
-    if activedirectory_enabled():
+    if activedirectory_enabled() and ds_cache_enabled():
         _cache_keys_ActiveDirectory(**kwargs)
 
     elif nis_enabled():
@@ -301,7 +302,7 @@ def _cache_rawdump_default(**kwargs):
 
 
 def cache_rawdump(**kwargs):
-    if activedirectory_enabled():
+    if activedirectory_enabled() and ds_cache_enabled():
         _cache_rawdump_ActiveDirectory(**kwargs)
 
     elif nis_enabled():
@@ -492,7 +493,7 @@ def _cache_check_default(**kwargs):
 
 
 def cache_check(**kwargs):
-    if activedirectory_enabled():
+    if activedirectory_enabled() and ds_cache_enabled():
         _cache_check_ActiveDirectory(**kwargs)
 
     elif nis_enabled():
@@ -540,7 +541,7 @@ def _cache_count_default(**kwargs):
 
 
 def cache_count(**kwargs):
-    if activedirectory_enabled():
+    if activedirectory_enabled() and ds_cache_enabled():
         _cache_count_ActiveDirectory(**kwargs)
 
     elif nis_enabled():

--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -826,13 +826,12 @@ def add_activedirectory_conf(client, smb4_conf):
              "yes" if ad.ad_allow_dns_updates else "no")
 
     confset1(smb4_conf, "winbind cache time = 7200")
-    confset1(smb4_conf, "winbind offline logon = yes")
+    confset1(smb4_conf, "winbind max domain connections = 10")
     confset1(smb4_conf, "winbind enum users = yes")
     confset1(smb4_conf, "winbind enum groups = yes")
     confset1(smb4_conf, "winbind nested groups = yes")
     confset2(smb4_conf, "winbind use default domain = %s",
              "yes" if ad.ad_use_default_domain else "no")
-    confset1(smb4_conf, "winbind refresh tickets = yes")
 
     if ad.ad_nss_info:
         confset2(smb4_conf, "winbind nss info = %s", ad.ad_nss_info)


### PR DESCRIPTION
The user and group cache in 11.2 does not scale well for large LDAP and AD environments. Make sure we've thoroughly disabled everything related to it when the admin has chosen to disable it. Also boost number of winbind domain connections to improve scalability in large environments. 

Replace legacy FreeNAS_User and FreeNAS_Group in notifier plugin with getpwnam and getgrnam.