### PR TITLE
NAS-102662 / 11.3 / Make sure system ports aren't used by NAT based jails

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -972,7 +972,7 @@ class JailService(CRUDService):
 
         if not status:
             try:
-                iocage.start()
+                iocage.start(used_ports=[6000] + list(range(1025)))
             except Exception as e:
                 raise CallError(str(e))
 


### PR DESCRIPTION
This commit introduces a change where we make sure that system ports aren't used by NAT based jails for port forwarding.