### PR TITLE
Reload nginx after enabling/disabling legacy ui

### DIFF
--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -203,6 +203,9 @@ class SystemAdvancedService(ConfigService):
             if original_data['fqdn_syslog'] != config_data['fqdn_syslog']:
                 await self.middleware.call('service.restart', 'syslogd', {'onetime': False})
 
+            if original_data['legacy_ui'] != config_data['legacy_ui']:
+                await self.middleware.call('service.reload', 'http')
+
         return await self.config()
 
     @private


### PR DESCRIPTION
This commit introduces changes which reload nginx after we enable/disable legacy ui. It does not pose an issue as existing connections aren't dropped.