### PR TITLE
NAS-102770 / 11.3 / Add Extended Key Usage extension by default for CA's

### DIFF
--- a/src/middlewared/middlewared/plugins/crypto.py
+++ b/src/middlewared/middlewared/plugins/crypto.py
@@ -507,6 +507,8 @@ class CryptoKeyService(Service):
             ), True
         ).add_extension(
             x509.SubjectKeyIdentifier.from_public_key(key.public_key()), False
+        ).add_extension(
+            x509.ExtendedKeyUsage([x509.oid.ExtendedKeyUsageOID.SERVER_AUTH]), False
         ).public_key(
             key.public_key()
         )


### PR DESCRIPTION
This commit makes sure we add extendedkeyusage extension automatically for server certs as coming macos version enforces them (https://support.apple.com/en-us/HT210176).