### PR TITLE
NAS-102571 / 12 / Fix position of installer boot logo

### DIFF
--- a/src/freenas-installer/boot/loader.conf.local
+++ b/src/freenas-installer/boot/loader.conf.local
@@ -1,5 +1,4 @@
 loader_logo="FreeNAS"
 loader_menu_title="Welcome to FreeNAS"
 loader_brand="FreeNAS"
-loader_logo_y="10"
 openzfs_load="YES"


### PR DESCRIPTION
With the old menu now ported to Lua, this manual override is no longer
correct.