### PR TITLE
NAS-102780 / 11.3 / Bug fix for cloning a VM

### DIFF
--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -1119,6 +1119,7 @@ class VMService(CRUDService):
         try:
             for item in vm['devices']:
                 item.pop('id', None)
+                item.pop('vm', None)
                 if item['dtype'] == 'NIC':
                     if 'mac' in item['attributes']:
                         del item['attributes']['mac']


### PR DESCRIPTION
This commit fixes a bug where we were unable to clone a vm because of a schema issue which required that vm attribute inside devices must not be present when creating a vm ensuring that they don't belong to any VM.