### PR TITLE
Remove unused installer boot config file

### DIFF
--- a/src/freenas-installer/boot/loader.conf.local
+++ b/src/freenas-installer/boot/loader.conf.local
@@ -1,4 +1,0 @@
-loader_logo="FreeNAS"
-loader_menu_title="Welcome to FreeNAS"
-loader_brand="FreeNAS"
-openzfs_load="YES"


### PR DESCRIPTION
The values in this file are not correct and it isn't copied to the ISO
anyway.  Remove it to avoid confusion.