### PR TITLE
NAS-102571 / 12 / Add shift to loader FreeNAS logo definition

### DIFF
--- a/src/freenas/boot/loader.conf
+++ b/src/freenas/boot/loader.conf
@@ -4,7 +4,6 @@
 product="FreeNAS"
 autoboot_delay="5"
 loader_logo="FreeNAS"
-loader_logo_y="10"
 loader_menu_title="Welcome to FreeNAS"
 loader_brand="FreeNAS"
 loader_version=" "

--- a/src/freenas/boot/lua/logo-FreeNAS.lua
+++ b/src/freenas/boot/lua/logo-FreeNAS.lua
@@ -46,6 +46,7 @@ local freenas_color = {
 drawer.addLogo("FreeNAS", {
 	requires_color = false,
 	graphic = freenas_color,
+	shift = {x = 0, y = 6},
 })
 
 return true


### PR DESCRIPTION
Instead of overriding the absolute y position of the loader logo artwork
in loader.conf, bake the required offset into the definition.  This
ensures the logo is correctly positioned in both the installer and the
installed system boot loader menus.