### PR TITLE
NAS-102849 / 11.3 / Use filesystem.chown and filesystem.setperm in account and webdav

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/apache24/Includes/webdav.conf
+++ b/src/middlewared/middlewared/etc_files/local/apache24/Includes/webdav.conf
@@ -14,17 +14,6 @@
 	if not os.path.isdir(oscmd):
 		os.mkdir(oscmd, 0o774)
 
-	# Changing ownership for all directories and files in oscmd
-	webdav_user = middleware.call_sync('user.query', [['username', '=', 'webdav']])
-	if not webdav_user:
-		uid, gid = 0, 0
-	else:
-		uid, gid = webdav_user[0]['uid'], webdav_user[0]['group']['bsdgrp_gid']
-
-	for root, dirs, files in os.walk(oscmd):
-		for o in list(itertools.chain(dirs, files)):
-			os.chown(os.path.join(root, o), uid, gid)
-
 	webdav_config = middleware.call_sync('webdav.config')
 	auth_type = webdav_config['htauth'].lower()
 	web_shares = middleware.call_sync('sharing.webdav.query')

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -220,7 +220,13 @@ class UserService(CRUDService):
                 try:
                     os.makedirs(data['home'], mode=int(home_mode, 8))
                     new_homedir = True
-                    os.chown(data['home'], data['uid'], group['gid'])
+                    await self.middleware.call('filesystem.setperm', {
+                        'path': data['home'],
+                        'mode': home_mode,
+                        'uid': data['uid'],
+                        'gid': group['gid'],
+                        'options': {'stripacl': True}
+                    })
                 except FileExistsError:
                     if not os.path.isdir(data['home']):
                         raise CallError(
@@ -229,8 +235,13 @@ class UserService(CRUDService):
                             errno.EEXIST
                         )
 
-                    # If it exists, ensure the user is owner
-                    os.chown(data['home'], data['uid'], group['gid'])
+                    # If it exists, ensure the user is owner.
+                    await self.middleware.call('filesystem.chown', {
+                        'path': data['home'],
+                        'uid': data['uid'],
+                        'gid': group['gid'],
+                        'options': {'recursive': True}
+                    })
                 except OSError as oe:
                     raise CallError(
                         'Failed to create the home directory '
@@ -280,7 +291,12 @@ class UserService(CRUDService):
                     dest_file = os.path.join(data['home'], f)
                 if not os.path.exists(dest_file):
                     shutil.copyfile(os.path.join(SKEL_PATH, f), dest_file)
-                    os.chown(dest_file, data['uid'], group['gid'])
+                    await self.middleware.call('filesystem.chown', {
+                        'path': dest_file,
+                        'uid': data['uid'],
+                        'gid': group['gid'],
+                        'options': {'recursive': True}
+                    })
 
             data['sshpubkey'] = sshpubkey
             try:
@@ -354,7 +370,11 @@ class UserService(CRUDService):
         if home_copy and not os.path.isdir(user['home']):
             try:
                 os.makedirs(user['home'])
-                os.chown(user['home'], user['uid'], group['bsdgrp_gid'])
+                await self.middleware.call('filesystem.chown', {
+                    'path': user['home'],
+                    'uid': user['uid'],
+                    'gid': group['bsdgrp_gid'],
+                })
             except OSError:
                 self.logger.warn('Failed to chown homedir', exc_info=True)
             if not os.path.isdir(user['home']):
@@ -367,6 +387,10 @@ class UserService(CRUDService):
         def set_home_mode():
             if home_mode is not None:
                 try:
+                    # Strip ACL before chmod. This is required when aclmode = restricted
+                    setfacl = subprocess.run(['/bin/setfacl', '-b', user['home']], check=False)
+                    if setfacl.returncode != 0:
+                        self.logger.debug('Failed to strip ACL: %s', setfacl.stderr.decode())
                     os.chmod(user['home'], int(home_mode, 8))
                 except OSError:
                     self.logger.warn('Failed to set homedir mode', exc_info=True)
@@ -702,11 +726,22 @@ class UserService(CRUDService):
             os.mkdir(sshpath, mode=0o700)
         if not os.path.isdir(sshpath):
             raise CallError(f'{sshpath} is not a directory')
+
+        # Make extra sure to enforce correct mode on .ssh directory.
+        # stripping the ACL will allow subsequent chmod calls to succeed even if
+        # dataset aclmode is restricted.
+        await self.middleware.call('filesystem.setperm', {
+            'path': sshpath,
+            'mode': str(700),
+            'uid': user['uid'],
+            'gid': group,
+            'options': {'recursive': True, 'stripacl': True}
+        })
+
         with open(keysfile, 'w') as f:
             f.write(pubkey)
             f.write('\n')
-        os.chmod(keysfile, 0o600)
-        await run('/usr/sbin/chown', '-R', f'{user["username"]}:{group}', sshpath, check=False)
+        await self.middleware.call('filesystem.setperm', {'path': keysfile, 'mode': str(600)})
 
 
 class GroupService(CRUDService):

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -240,7 +240,6 @@ class UserService(CRUDService):
                         'path': data['home'],
                         'uid': data['uid'],
                         'gid': group['gid'],
-                        'options': {'recursive': True}
                     })
                 except OSError as oe:
                     raise CallError(

--- a/src/middlewared/middlewared/plugins/webdav.py
+++ b/src/middlewared/middlewared/plugins/webdav.py
@@ -74,6 +74,13 @@ class WebDAVSharingService(CRUDService):
             data,
             {'prefix': self._config.datastore_prefix}
         )
+        if data['perm']:
+            await self.middleware.call('filesystem.chown', {
+                'path': data['path'],
+                'uid': (await self.middleware.call('dscache.get_uncached_user', 'webdav'))['pw_uid'],
+                'gid': (await self.middleware.call('dscache.get_uncached_group', 'webdav'))['gr_gid'],
+                'options': {'recursive': True}
+            })
 
         await self._service_change('webdav', 'reload')
 


### PR DESCRIPTION
Avoid direct chown and chmod in account and webdav plugins. This will improve auditing since they're middleware jobs and ensure proper interaction with ZFS ACLs.