### PR TITLE
NAS-102845 / 11.3 / Enclose dynamic DNS username in quotes

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/inadyn.conf
+++ b/src/middlewared/middlewared/etc_files/local/inadyn.conf
@@ -31,7 +31,7 @@ provider ${config['provider']} {
     checkip-path = "${config['checkip_path']}"
 % endif
 % if config['username']:
-    username = ${config['username']}
+    username = "${config['username']}"
 % endif
 % if config['password']:
     password = '${re.sub(r"(\\|')", r"\\\1", config['password'])}'


### PR DESCRIPTION
This commit makes sure we use quotes to enclose dynamic DNS username as for certain usernames involving email addresses with a '+' symbol, dynamic dns service fails to start if isn't enclosed properly.