### PR TITLE
NAS-102878 / 11.3 / Fix regression in webdav start

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/apache24/Includes/webdav.conf
+++ b/src/middlewared/middlewared/etc_files/local/apache24/Includes/webdav.conf
@@ -45,12 +45,9 @@
 		raise ValueError("Invalid auth_type (must be one of 'none', 'basic', 'digest')")
 
 	if path:
+		uid = middleware.call_sync('user.get_user_obj', {'username': 'webdav'})['pw_uid']
+		gid = middleware.call_sync('group.get_group_obj', {'groupname': 'webdav'})['gr_gid']
 		os.chown(path, uid, gid)
-
-	# A function to change permissions on a webdav share
-	def change_perms(path):
-		subprocess.Popen(f'chown -R webdav:webdav {path}', stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, close_fds=True).communicate()
-
 %>\
 Listen ${webdav_config['tcpport']}
 	<VirtualHost *:${webdav_config['tcpport']}>
@@ -86,9 +83,6 @@ Listen ${webdav_config['tcpport']}
 			AllowMethods GET OPTIONS PROPFIND
 		</Location>
 	% endif
-<% if share['perm']:
-	change_perms(share['path'])	
-%>
 
 % endfor
 		# The following directives disable redirects on non-GET requests for

--- a/src/middlewared/middlewared/etc_files/local/apache24/Includes/webdav.conf
+++ b/src/middlewared/middlewared/etc_files/local/apache24/Includes/webdav.conf
@@ -14,6 +14,15 @@
 	if not os.path.isdir(oscmd):
 		os.mkdir(oscmd, 0o774)
 
+	try:
+		uid = middleware.call_sync('user.get_user_obj', {'username': 'webdav'})['pw_uid']
+		gid = middleware.call_sync('group.get_group_obj', {'groupname': 'webdav'})['gr_gid']
+	except Exception:
+		uid = 0
+		gid = 0
+
+	subprocess.run(['/usr/sbin/chown', '-Rx', f'{uid}:{gid}', oscmd], check=False)
+
 	webdav_config = middleware.call_sync('webdav.config')
 	auth_type = webdav_config['htauth'].lower()
 	web_shares = middleware.call_sync('sharing.webdav.query')
@@ -45,9 +54,8 @@
 		raise ValueError("Invalid auth_type (must be one of 'none', 'basic', 'digest')")
 
 	if path:
-		uid = middleware.call_sync('user.get_user_obj', {'username': 'webdav'})['pw_uid']
-		gid = middleware.call_sync('group.get_group_obj', {'groupname': 'webdav'})['gr_gid']
 		os.chown(path, uid, gid)
+
 %>\
 Listen ${webdav_config['tcpport']}
 	<VirtualHost *:${webdav_config['tcpport']}>

--- a/src/middlewared/middlewared/plugins/webdav.py
+++ b/src/middlewared/middlewared/plugins/webdav.py
@@ -114,6 +114,14 @@ class WebDAVSharingService(CRUDService):
 
             await self._service_change('webdav', 'reload')
 
+        if data['perm']:
+            await self.middleware.call('filesystem.chown', {
+                'path': data['path'],
+                'uid': (await self.middleware.call('dscache.get_uncached_user', 'webdav'))['pw_uid'],
+                'gid': (await self.middleware.call('dscache.get_uncached_group', 'webdav'))['gr_gid'],
+                'options': {'recursive': True}
+            })
+
         return await self.query(filters=[('id', '=', id)], options={'get': True})
 
     @accepts(


### PR DESCRIPTION
Finish cleaning up permissions-related code in webdav config generation. Share permissions are changed when the share is created.