### PR TITLE
Update trueview_stats.sh

### DIFF
--- a/src/freenas/usr/local/bin/trueview_stats.sh
+++ b/src/freenas/usr/local/bin/trueview_stats.sh
@@ -64,7 +64,7 @@ gstat_to_json(){
 
 ifstat_to_json(){
   _tmp=""
-  local _out=$( ifstat -a -T 0.1 1 |
+  local _out=$( ifstat -a -T 0.2 1 |
   while read line
   do
     # First line is interface labels


### PR DESCRIPTION
Quick patch to increase the length of the polling interval for network traffic stats.
Should be backported to 11.2 ASAP as well.