### PR TITLE
NAS-102945 / 11.3 / Remove winacl reset action

### DIFF
--- a/src/winacl/Makefile
+++ b/src/winacl/Makefile
@@ -4,6 +4,5 @@ MK_MAN=	no
 
 PROG=	winacl
 BINDIR=	/usr/bin
-LINKS= ${BINDIR}/winacl ${BINDIR}/cloneacl
 
 .include <bsd.prog.mk>


### PR DESCRIPTION
Original "WA_RESET" action recursively applied a default ACL to the given path. This is almost always the wrong thing to do, and so we're removing the foot-gun.