### PR TITLE
NAS-102977 / 11.3 / Bug fix for creating VM in legacy UI

### DIFF
--- a/gui/vm/forms.py
+++ b/gui/vm/forms.py
@@ -44,7 +44,7 @@ class VMForm(ModelForm):
                     cdata['devices'] = [
                         {'dtype': 'NIC', 'attributes': {'type': 'E1000'}},
                     ]
-                self.instance = models.VM.objects.get(pk=c.call('vm.create', cdata))
+                self.instance = models.VM.objects.get(pk=(c.call('vm.create', cdata))['id'])
         return self.instance
 
     def delete(self, **kwargs):


### PR DESCRIPTION
This commit fixes a bug which occurred while we created a VM via legacy UI. VM is created successfully but as the create api has been updated to return the VM data as a dictionary instead of just an id, the legacy usage expected an integer and errored out when given a dict.