### PR TITLE
NAS-102987 / 11.3 / Retrieve default configuration of jails

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -617,6 +617,16 @@ class JailService(CRUDService):
             d['name'].endswith('/iocage') for root_dataset in datasets for d in root_dataset['children']
         ))
 
+    @accepts()
+    def default_configuration(self):
+        """
+        Retrieve default configuration for iocage jails.
+        """
+        if not self.iocage_set_up():
+            return IOCJson.retrieve_default_props()
+        else:
+            return self.query(filters=[['host_hostuuid', '=', 'default']], options={'get': True})
+
     @accepts(
         Bool('remote', default=False),
     )


### PR DESCRIPTION
This commit introduces a new method which helps us retrieve the default configuration of jails. It ensures that if iocage hasn't been initialized, we don't initialize it just to return it's default configuration.