### PR TITLE
NAS-100109 / 12 / Cleanly shutdown VM's on system shutdown

### DIFF
--- a/gui/vm/migrations/0011_normalize_devices_attributes.py
+++ b/gui/vm/migrations/0011_normalize_devices_attributes.py
@@ -78,4 +78,9 @@ class Migration(migrations.Migration):
         migrations.RunPython(ensure_vnc_port),
         migrations.RunPython(add_physical_sector_size_support),
         migrations.RunPython(normalize_mac_address),
+        migrations.AddField(
+            model_name='vm',
+            name='shutdown_timeout',
+            field=models.IntegerField(default=90),
+        ),
     ]

--- a/gui/vm/models.py
+++ b/gui/vm/models.py
@@ -94,6 +94,10 @@ class VM(Model):
         choices=choices.VM_TIMECHOICES,
         default='LOCAL',
     )
+    shutdown_timeout = models.IntegerField(
+        default=90,
+        verbose_name=_('Shutdown timeout')
+    )
 
     class Meta:
         verbose_name = _(u"VM")

--- a/nas_ports/freenas/py-middlewared/files/middlewared.in
+++ b/nas_ports/freenas/py-middlewared/files/middlewared.in
@@ -28,7 +28,7 @@ middlewared_start() {
 		/usr/local/bin/tmux new-session -s middlewared -d
 		/usr/local/bin/tmux send -t middlewared "env PATH=$PATH:/usr/local/sbin:/usr/local/bin LC_ALL=en_US.UTF-8 /usr/local/bin/middlewared ${overlay_dirs_arg} -P" ENTER
 	else
-		env PATH=$PATH:/usr/local/sbin:/usr/local/bin LC_ALL=en_US.UTF-8 ${command} -f -P ${pidfile} -r /usr/local/bin/middlewared ${overlay_dirs_arg} --log-handler=file
+		env PATH=$PATH:/usr/local/sbin:/usr/local/bin LC_ALL=en_US.UTF-8 ${command} -f -p ${pidfile} -r /usr/local/bin/middlewared ${overlay_dirs_arg} --log-handler=file
 	fi
 	if ! LD_LIBRARY_PATH=/usr/local/lib /usr/local/bin/midclt -t 240 waitready; then
 		echo "##############################################################"

--- a/nas_ports/freenas/py-middlewared/files/middlewared.in
+++ b/nas_ports/freenas/py-middlewared/files/middlewared.in
@@ -12,6 +12,7 @@
 : ${middlewared_debug="NO"}
 : ${middlewared_overlay_dirs=""}
 pidfile=/var/run/middlewared.pid
+daemon_pidfile=/var/run/middlewared_daemon.pid
 command="/usr/sbin/daemon"
 
 middlewared_start() {
@@ -28,7 +29,7 @@ middlewared_start() {
 		/usr/local/bin/tmux new-session -s middlewared -d
 		/usr/local/bin/tmux send -t middlewared "env PATH=$PATH:/usr/local/sbin:/usr/local/bin LC_ALL=en_US.UTF-8 /usr/local/bin/middlewared ${overlay_dirs_arg} -P" ENTER
 	else
-		env PATH=$PATH:/usr/local/sbin:/usr/local/bin LC_ALL=en_US.UTF-8 ${command} -f -p ${pidfile} -r /usr/local/bin/middlewared ${overlay_dirs_arg} --log-handler=file
+		env PATH=$PATH:/usr/local/sbin:/usr/local/bin LC_ALL=en_US.UTF-8 ${command} -f -P ${daemon_pidfile} -p ${pidfile} -r /usr/local/bin/middlewared ${overlay_dirs_arg} --log-handler=file
 	fi
 	if ! LD_LIBRARY_PATH=/usr/local/lib /usr/local/bin/midclt -t 240 waitready; then
 		echo "##############################################################"
@@ -39,10 +40,15 @@ middlewared_start() {
 
 middlewared_stop() {
 	if [ -f "${pidfile}" ] ; then
-		rc_pid=$(cat $pidfile)
+		mw_pid=$(cat $pidfile)
+		if [ -f "${daemon_pidfile}" ] ; then
+			rc_pid=$(cat $daemon_pidfile)
+		else
+			rc_pid=$mw_pid
+		fi
 		echo 'Stopping middlewared.'
 		kill -s TERM ${rc_pid}
-		wait_for_pids ${rc_pid}
+		wait_for_pids ${mw_pid}
 	else
 		echo 'middlewared is not running'
 		exit 1

--- a/nas_ports/freenas/py-middlewared/files/middlewared.in
+++ b/nas_ports/freenas/py-middlewared/files/middlewared.in
@@ -63,8 +63,22 @@ middlewared_stop() {
 	fi
 }
 
+middlewared_status() {
+	if [ -f "${pidfile}" ] ; then
+		mw_pid=$(cat $pidfile)
+		kill -0 "${mw_pid}" >> /dev/null 2>&1
+		if [ $? -eq 0 ]; then
+			echo "$name is running as pid $mw_pid"
+			return 0
+		fi
+	fi
+	echo "$name is not running"
+	return 1
+}
+
 name="middlewared"
 start_cmd='middlewared_start'
+status_cmd='middlewared_status'
 stop_cmd='middlewared_stop'
 
 load_rc_config $name

--- a/src/freenas/etc/ix.rc.d/ix-shutdown
+++ b/src/freenas/etc/ix.rc.d/ix-shutdown
@@ -11,7 +11,7 @@
 
 do_shutdown()
 {
-	/usr/local/bin/midclt call core.event_send system ADDED '{"id": "shutting-down"}' > /dev/null
+	/usr/local/bin/midclt call core.event_send system ADDED '{"id": "shutdown"}' > /dev/null
 
 	/usr/local/bin/midclt call -job initshutdownscript.execute_init_tasks SHUTDOWN > /dev/null 2>&1
 }

--- a/src/freenas/etc/rc.conf
+++ b/src/freenas/etc/rc.conf
@@ -94,6 +94,3 @@ zfsd_enable="YES"
 # This will allow python scripts (mostly) to get correct encoding
 # while generating config files. See #24973
 export LANG=en_US.UTF-8
-
-# Enable libvirtd
-libvirtd_enable="YES"

--- a/src/freenas/etc/rc.shutdown.local
+++ b/src/freenas/etc/rc.shutdown.local
@@ -1,4 +1,3 @@
-/usr/local/bin/midclt call core.event_send system ADDED '{"id": "shutdown"}' > /dev/null
 if [ -f /etc/killpower ]; then
 	/usr/local/sbin/upsdrvctl shutdown
 fi

--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -383,10 +383,18 @@ class ServiceService(CRUDService):
         return False, []
 
     async def _started_libvirtd(self, **kwargs):
-        if await self._service('libvirtd', 'status', quiet=True, **kwargs):
+        if await self._service('libvirtd', 'status', onetime=True, **kwargs):
             return False, []
         else:
             return True, []
+
+    async def _start_libvirtd(self, **kwargs):
+        kwargs.setdefault('onetime', True)
+        await self._service('libvirtd', 'start', **kwargs)
+
+    async def _stop_libvirtd(self, **kwargs):
+        kwargs.setdefault('onetime', True)
+        await self._service('libvirtd', 'stop', **kwargs)
 
     async def _start_openvpn_server(self, **kwargs):
         kwargs.setdefault('onetime', True)

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -1328,7 +1328,8 @@ async def update_timeout_value(middleware, *args):
     ):
         # Default 120 seconds is being added to scripts timeout to ensure other
         # system related scripts can execute safely within the default timeout
-        timeout_value = 120 + sum(
+        initial_timeout_value = 120
+        timeout_value = sum(
             list(
                 map(
                     lambda i: i['timeout'],
@@ -1341,6 +1342,14 @@ async def update_timeout_value(middleware, *args):
                 )
             )
         )
+
+        vm_timeout = (await middleware.call('vm.terminate_timeout'))
+        if vm_timeout > timeout_value:
+            # VM's and init tasks are executed asynchronously - so if VM timeout is greater then init tasks one,
+            # we use that, else init tasks timeout is good enough to ensure VM's cleanly exit
+            timeout_value = vm_timeout
+
+        timeout_value += initial_timeout_value
 
         await middleware.run_in_thread(
             lambda: setattr(
@@ -1386,7 +1395,7 @@ async def setup(middleware):
 
     await update_timeout_value(middleware)
 
-    for srv in ['initshutdownscript', 'tunable']:
+    for srv in ['initshutdownscript', 'tunable', 'vm']:
         for event in ('create', 'update', 'delete'):
             middleware.register_hook(
                 f'{srv}.post_{event}',

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -522,14 +522,10 @@ class SystemService(Service):
         """
         Shuts down the operating system.
 
-        Emits an "added" event of name "system" and id "shutdown".
+        An "added" event of name "system" and id "shutdown" is emitted when shutdown is initiated.
         """
         if options is None:
             options = {}
-
-        self.middleware.send_event('system', 'ADDED', id='shutdown', fields={
-            'description': 'System is going to shutdown',
-        })
 
         delay = options.get('delay')
         if delay:
@@ -1235,7 +1231,7 @@ async def _event_system(middleware, event_type, args):
     global SYSTEM_SHUTTING_DOWN
     if args['id'] == 'ready':
         SYSTEM_READY = True
-    if args['id'] == 'shutting-down':
+    if args['id'] == 'shutdown':
         SYSTEM_SHUTTING_DOWN = True
 
 

--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -1525,6 +1525,10 @@ class VMService(CRUDService):
             await self.middleware.call('vm.close_libvirt_connection')
 
     @private
+    async def terminate_timeout(self):
+        return max(map(lambda v: v['shutdown_timeout'], await self.middleware.call('vm.query')), default=10)
+
+    @private
     async def wait_for_libvirtd(self, timeout):
         async def libvirtd_started(middleware):
             await middleware.call('service.start', 'libvirtd')

--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -1282,7 +1282,13 @@ class VMService(CRUDService):
     )
     @job(lock=lambda args: f'stop_vm_{args[0]}_{args[1].get("force") if len(args) == 2 else False}')
     def stop(self, job, id, options):
-        """Stop a VM."""
+        """
+        Stops a VM.
+
+        For unresponsive guests who have exceeded the `shutdown_timeout` defined by the user and have become
+        unresponsive, they required to be powered down using `vm.poweroff`. `vm.stop` is only going to send a
+        shutdown signal to the guest and wait the desired `shutdown_timeout` value before tearing down guest vmemory.
+        """
         self.ensure_libvirt_connection()
         vm_data = self.middleware.call_sync('vm._get_instance', id)
         vm = self.vms[vm_data['name']]


### PR DESCRIPTION
This PR introduces following changes:
1) Introduce a `shutdown_timeout` field for each VM.
2) On system shutdown, each VM is sent a hardware shutdown signal and then system waits for `shutdown_timeout` seconds for the VM to cleanly exit. If the VM does not cleanly exit by then, system forcefully initiates a poweroff for the VM.
3) Ensures middlewared is the last service which is stopped at shutdown.
4) Removes `shutting-down` event as that causes confusion with `shutdown` event.
5) Fixes an issue where we issues multiple `shutdown` events.
6) Ensures start/stop/status for middlewared rc are respected.
7) Fixes a bug where middlewared failed to stop because we didn't stop the process pool executor. In this case we send a `SIGKILL` to middlewared after it has cleanly cleared it's tasks as we don't want to wait for the process pool to shutdown because for any reason it can take a long time if not forever halting shutdown and prompting init to come in.