### PR TITLE
NAS-103041 / 11.3 / Correctly show address acquired by dhcp

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -562,7 +562,7 @@ class JailService(CRUDService):
                 for jail in jail_dicts:
                     jail = list(jail.values())[0]
                     jail['id'] = jail['host_hostuuid']
-                    if jail['dhcp'] == 'on':
+                    if jail['dhcp']:
                         uuid = jail['host_hostuuid']
 
                         if jail['state'] == 'up':


### PR DESCRIPTION
This commit fixes a bug where we did not correctly show the ip address acquired by dhcp jail.