### PR TITLE
NAS-103079 / 11.3 / Bug fix for apache uploads

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/apache24/Includes/webdav.conf
+++ b/src/middlewared/middlewared/etc_files/local/apache24/Includes/webdav.conf
@@ -105,4 +105,5 @@ Listen ${webdav_config['tcpport']}
 		BrowserMatch "^XML Spy" redirect-carefully
 		BrowserMatch "^Dreamweaver-WebDAV-SCM1" redirect-carefully
 		BrowserMatch " Konqueror/4" redirect-carefully
+		RequestReadTimeout handshake=0 header=20-40,MinRate=500 body=20,MinRate=500
 	</VirtualHost>


### PR DESCRIPTION
This commit workarounds an issue in apache 2.4.39 which does not set defaults for request read timeouts and request timeouts at 20 seconds. This workaround explicitly defines the defaults which make sure that the upload isn't timed out by apache.
It is documented in 'https://bz.apache.org/bugzilla/show_bug.cgi?id=63325'.