### PR TITLE
NAS-102991 / 11.3 / Correct defaults for cifs share

### DIFF
--- a/gui/sharing/models.py
+++ b/gui/sharing/models.py
@@ -131,7 +131,7 @@ class CIFS_Share(Model):
         verbose_name=_('VFS Objects'),
         max_length=255,
         blank=True,
-        default='ixnas,streams_xattr',
+        default=['ixnas', 'streams_xattr'],
         choices=list(choices.CIFS_VFS_OBJECTS())
     )
     cifs_vuid = models.CharField(


### PR DESCRIPTION
This commit fixes a bug where if cifs_vfsobjects wasn't specified, the default would fail validation as the default value wasn't present in the choices specified by model.