### PR TITLE
NAS-102991 / 11.2 / Correct defaults for cifs share (by sonicaj)

### DIFF
--- a/gui/sharing/models.py
+++ b/gui/sharing/models.py
@@ -123,7 +123,7 @@ class CIFS_Share(Model):
         verbose_name=_('VFS Objects'),
         max_length=255,
         blank=True,
-        default='zfs_space,zfsacl,streams_xattr',
+        default=['zfs_space', 'zfsacl', 'streams_xattr'],
         choices=list(choices.CIFS_VFS_OBJECTS())
     )
     cifs_storage_task = models.ForeignKey(


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 577963c0dc64dcd7e5e0793f87c439e63bb30054

This commit fixes a bug where if cifs_vfsobjects wasn't specified, the default would fail validation as the default value wasn't present in the choices specified by model.