### PR TITLE
NAS-103135 / 11.3 / Fix error in ACL canonicalization of incomplete flagsets

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -557,7 +557,7 @@ class FilesystemService(Service):
         """
         inheritance_flags = ['FILE_INHERIT', 'DIRECTORY_INHERIT', 'NO_PROPAGATE_INHERIT', 'INHERIT_ONLY']
         for i in inheritance_flags:
-            if flags[i]:
+            if flags.get(i):
                 return True
 
         return False


### PR DESCRIPTION
Full flagset should not be required for canonicalization to succeed.