### PR TITLE
NAS-103165 / 11.3 / Retrieve implicit defaults set by iocage for plugins

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -467,7 +467,10 @@ class PluginService(CRUDService):
         index = self.retrieve_plugin_index(options)
         if options['plugin'] not in index:
             raise CallError(f'{options["plugin"]} not found')
-        return {'plugin': options['plugin'], 'properties': index[options['plugin']].get('properties', [])}
+        return {
+            'plugin': options['plugin'],
+            'properties': {**IOCPlugin.DEFAULT_PROPS, **index[options['plugin']].get('properties', {})}
+        }
 
     @accepts(
         Str('repository', default='https://github.com/freenas/iocage-ix-plugins.git')


### PR DESCRIPTION
This commit retrieves the implicit defaults iocage sets for plugins and if they are overridden by the plugin manifest, it ensures that the result is consistent and shows the plugin manifest values in this case.