### PR TITLE
NAS-103168 / 11.3 / Force AD Domain Name to uppercase before kinit

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf
@@ -151,8 +151,9 @@
                     'netbios aliases': db['cifs']['netbiosalias']
                 })
             elif db['truenas_conf']['is_truenas_ha']:
+                node = middleware.call_sync('failover.node')
                 pc.update({
-                    'netbios name': db['cifs']['netbiosname'],
+                    'netbios name': db['cifs']['netbiosname'] if node == 'A' else db['cifs']['netbiosname_b'],
                     'netbios aliases': db['cifs']['netbiosalias'],
                     'private dir': '/root/samba/private',
                     'winbind netbios alias spn': 'true'

--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -247,7 +247,7 @@ class KerberosService(ConfigService):
                 if ad_kinit.returncode != 0:
                     raise CallError(f"kinit for domain [{ad['domainname']}] with principal [{ad['kerberos_principal']}] failed: {ad_kinit.stderr.decode()}")
             else:
-                principal = f'{ad["bindname"]}@{ad["domainname"]}'
+                principal = f'{ad["bindname"]}@{ad["domainname"].upper()}'
                 ad_kinit = await Popen(
                     ['/usr/bin/kinit', '--renewable', '--password-file=STDIN', principal],
                     stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE


### PR DESCRIPTION
When username is passed as "username@domain" for kinit in AD
environment <domainname> must be uppercase. We force uppercase
prior to writing to the DB in 11.3, but this doesn't account
for possible upgrades from 11.2->11.3. Add extra step to force
<domainname> to uppercase prior to kinit to account for this
edge case.