### PR TITLE
NAS-102283 / 11.3 / Run periodic tasks when system is ready  (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -854,7 +854,7 @@ class Middleware(LoadPluginsMixin):
 
         self.logger.debug('All plugins loaded')
 
-    def __setup_periodic_tasks(self):
+    def _setup_periodic_tasks(self):
         for service_name, service_obj in self.get_services().items():
             for task_name in dir(service_obj):
                 method = getattr(service_obj, task_name)
@@ -1351,7 +1351,8 @@ class Middleware(LoadPluginsMixin):
         await restful_api.register_resources()
         asyncio.ensure_future(self.jobs.run())
 
-        self.__setup_periodic_tasks()
+        if await self.call('system.state') == 'READY':
+            self._setup_periodic_tasks()
 
         # Start up middleware worker process pool
         self.__procpool._start_queue_management_thread()

--- a/src/middlewared/middlewared/plugins/crypto.py
+++ b/src/middlewared/middlewared/plugins/crypto.py
@@ -1023,7 +1023,7 @@ class CertificateService(CRUDService):
                     f'DNS challenge {"completed" if status else "failed"} for {domain}'
                 )
 
-    @periodic(86400, run_on_start=False)
+    @periodic(86400)
     @private
     @job(lock='acme_cert_renewal')
     def renew_certs(self, job):

--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -404,7 +404,7 @@ class PluginService(CRUDService):
 
         return resource_list
 
-    @periodic(interval=86400, run_on_start=False)
+    @periodic(interval=86400)
     @private
     @accepts(
         Str('branch', null=True, default=None),

--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -446,6 +446,9 @@ class CoreService(Service):
             {'id': 'ready'}
         )
 
+        # Let's setup periodic tasks now
+        self.middleware._setup_periodic_tasks()
+
     @accepts(Int('id'))
     def job_abort(self, id):
         job = self.middleware.jobs.all()[id]


### PR DESCRIPTION
This commit adds the ability to execute periodic tasks when the system is ready. Motivation for this is tasks which require network interaction, as middlewared boots early in the process, networking isn't setup. We still support  attribute but if  is enabled, that takes precedence over.