### PR TITLE
NAS-103172 / 11.2 / Only start jail if it's not already active

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -832,6 +832,9 @@ class JailService(CRUDService):
 
         def progress_callback(content, exception):
             msg = content['message'].strip('\n')
+            if content['level'] == 'EXCEPTION':
+                raise exception(msg)
+
             msg_queue.append(msg)
             final_msg = '\n'.join(msg_queue)
 

--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -855,10 +855,19 @@ class JailService(CRUDService):
         jail_type = IOCJson(path).json_load()['type']
         iocage.update()
 
+        _, _, iocage = self.check_jail_existence(jail)
+        # If jail is running, we should ensure at the end that is reflected
+        status = self.query([['host_hostuuid', '=', jail]], {'get': True})['state'] == 'up'
+
         if jail_type == 'pluginv2':
             # Lame 11.2 hack to update the plugin version shown
+            if status:
+                iocage.stop()
             iocage.start()
             iocage.stop()
+
+        if status and jail_type == 'pluginv2':
+            iocage.start()
 
         return True
 


### PR DESCRIPTION
This commit fixes a bug where we started a jail which was already running. Iocage tried to raise an exception but the callback configured didn't handle that exception.