### PR TITLE
NAS-101794 / 12 / Bind nptd to localhost

### DIFF
--- a/src/middlewared/middlewared/etc_files/ntp.conf
+++ b/src/middlewared/middlewared/etc_files/ntp.conf
@@ -21,8 +21,8 @@ server ${ntp['address']}\
 
 % endfor
 % if ntp_query:
-restrict default limited kod nomodify notrap nopeer noquery
-restrict -6 default limited kod nomodify notrap nopeer noquery
+restrict default ignore
+restrict -6 default ignore
 restrict 127.0.0.1
 restrict -6 ::1
 restrict 127.127.1.0


### PR DESCRIPTION
This commit introduces changes which bind ntpd to the localhost only as we had requests from some TN customers who wanted to disable ntpd entirely due to concerns of it probing their network.