### PR TITLE
NAS-100293 / 11.3 / Improve iscsi portal choices and validation (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi.py
+++ b/src/middlewared/middlewared/plugins/iscsi.py
@@ -180,7 +180,7 @@ class ISCSIPortalService(CRUDService):
         """
         Returns possible choices for `listen.ip` attribute of portal create and update.
         """
-        choices = {'0.0.0.0': '0.0.0.0'}
+        choices = {'0.0.0.0': '0.0.0.0', '[::]': '[::]'}
         alua = (await self.middleware.call('iscsi.global.config'))['alua']
         if alua:
             # If ALUA is enabled we actually want to show the user the IPs of each node

--- a/src/middlewared/middlewared/plugins/iscsi.py
+++ b/src/middlewared/middlewared/plugins/iscsi.py
@@ -208,10 +208,7 @@ class ISCSIPortalService(CRUDService):
         if not data['listen']:
             verrors.add(f'{schema}.listen', 'At least one listen entry is required.')
         else:
-            system_ips = [
-                ip['address'] for ip in await self.middleware.call('interface.ip_in_use')
-            ]
-            system_ips.extend(['0.0.0.0', '::'])
+            system_ips = await self.listen_ip_choices()
             new_ips = set(i['ip'] for i in data['listen']) - set(i['ip'] for i in old['listen']) if old else set()
             for i in data['listen']:
                 filters = [


### PR DESCRIPTION
This PR adds changes to introduce ipv6 wildcard address in the iscsi portal choices. Also we update the validation for iscsi portals to ensure that no dynamic address is configured with iscsi portals as it's possible that we might not have it when system boots resulting in ctld failure.