### PR TITLE
NAS-103207 / 11.3 / Raise exception in update jail callback

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -1279,6 +1279,9 @@ class JailService(CRUDService):
 
         def progress_callback(content, exception):
             msg = content['message'].strip('\n')
+            if content['level'] == 'EXCEPTION':
+                raise exception(msg)
+
             msg_queue.append(msg)
             final_msg = '\n'.join(msg_queue)
 


### PR DESCRIPTION
This commit adds changes which ensure that we raise an exception when we are updating a jail in it's callback.