### PR TITLE
NAS-102932 / 11.3 / Prevent deadlock for jail plugin services

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -142,9 +142,6 @@ def common_validation(middleware, options, update=False, jail=None, schema='opti
 
 class PluginService(CRUDService):
 
-    class Config:
-        process_pool = True
-
     @accepts()
     async def official_repositories(self):
         """
@@ -580,9 +577,6 @@ class PluginService(CRUDService):
 
 
 class JailService(CRUDService):
-
-    class Config:
-        process_pool = True
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -337,7 +337,7 @@ class PluginService(CRUDService):
     )
     @job(
         lock=lambda args: 'available_plugins_{}_{}'.format(
-            args[0].get('branch') if args else None, args[0].get('plugin_repository') if args else None
+            (args or [{}])[0].get('branch'), (args or [{}])[0].get('plugin_repository')
         )
     )
     def available(self, job, options):
@@ -345,8 +345,28 @@ class PluginService(CRUDService):
         List available plugins which can be fetched for `plugin_repository`.
         """
         self.middleware.call_sync('jail.check_dataset_existence')
-        branch = options.get('branch') or self.get_version()
-        options['plugin_repository'] = options.get('plugin_repository') or self.default_repo()
+        default_branch = self.get_version()
+        default_repo = self.default_repo()
+        branch = options.get('branch') or default_branch
+        options['plugin_repository'] = options.get('plugin_repository') or default_repo
+        # If user passes no parameters we assume defaults for branch and repo which are evaluated dynamically,
+        # however if the same defaults are passed to the function, job locking can't have the latter call wait
+        # because it is unable to retrieve defaults from schema layer or access our dynamic defaults
+        # In this case we decide to wait for a job which might already be running with the specified branch/repo
+        if options['cache'] and branch == default_branch and options['plugin_repository'] == default_repo:
+            plugin_avail_job = self.middleware.call_sync(
+                'core.get_jobs', [
+                    ['method', '=', 'plugin.available'],
+                    ['state', 'in', ['RUNNING', 'WAITING']],
+                    ['arguments', '=', []],
+                    ['id', '!=', job.id]
+                ]
+            )
+            if plugin_avail_job:
+                self.middleware.call_sync(
+                    'core.job_wait', plugin_avail_job[0]['id'], job=True
+                )
+
         iocage = ioc.IOCage(skip_jails=True)
         if options['cache']:
             with contextlib.suppress(KeyError):

--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -326,6 +326,7 @@ class PluginService(CRUDService):
         await self._get_instance(id)
         return await self.middleware.call('jail.delete', id)
 
+    @periodic(interval=86400)
     @accepts(
         Dict(
             'available_plugin_options',
@@ -406,7 +407,6 @@ class PluginService(CRUDService):
 
         return resource_list
 
-    @periodic(interval=86400)
     @private
     @accepts(
         Str('branch', null=True, default=None),


### PR DESCRIPTION
This PR introduces the following changes:
1) We run `plugin.available` as a periodic task now.
2) We ensure that if a `plugin.available` job is executing without parameters ( i.e job locking on none ), and we call the same job, this time with default parameters ( i.e 11.3-RELEASE ), we wait for the first job to finish as they are basically the same thing.
3) Changes `jail` and `plugin` service to not execute in a process pool as py-libzfs has been removed for iocage.
4) Updates jail plugin to reflect changes outlined in `3`.