### PR TITLE
NAS-103208 / 11.2 / Ensure middlewared is the last service to stop (by sonicaj)

### DIFF
--- a/nas_ports/freenas/py-middlewared/files/middlewared.in
+++ b/nas_ports/freenas/py-middlewared/files/middlewared.in
@@ -28,7 +28,7 @@ middlewared_start() {
 		/usr/local/bin/tmux new-session -s middlewared -d
 		/usr/local/bin/tmux send -t middlewared "env PATH=$PATH:/usr/local/sbin:/usr/local/bin LC_ALL=en_US.UTF-8 /usr/local/bin/middlewared ${overlay_dirs_arg} -P" ENTER
 	else
-		env PATH=$PATH:/usr/local/sbin:/usr/local/bin LC_ALL=en_US.UTF-8 ${command} -f -P ${pidfile} -r /usr/local/bin/middlewared ${overlay_dirs_arg} --log-handler=file
+		env PATH=$PATH:/usr/local/sbin:/usr/local/bin LC_ALL=en_US.UTF-8 ${command} -f -p ${pidfile} -r /usr/local/bin/middlewared ${overlay_dirs_arg} --log-handler=file
 	fi
 	if ! LD_LIBRARY_PATH=/usr/local/lib /usr/local/bin/midclt -t 240 waitready; then
 		echo "##############################################################"

--- a/nas_ports/freenas/py-middlewared/files/middlewared.in
+++ b/nas_ports/freenas/py-middlewared/files/middlewared.in
@@ -12,6 +12,7 @@
 : ${middlewared_debug="NO"}
 : ${middlewared_overlay_dirs=""}
 pidfile=/var/run/middlewared.pid
+daemon_pidfile=/var/run/middlewared_daemon.pid
 command="/usr/sbin/daemon"
 
 middlewared_start() {
@@ -28,7 +29,7 @@ middlewared_start() {
 		/usr/local/bin/tmux new-session -s middlewared -d
 		/usr/local/bin/tmux send -t middlewared "env PATH=$PATH:/usr/local/sbin:/usr/local/bin LC_ALL=en_US.UTF-8 /usr/local/bin/middlewared ${overlay_dirs_arg} -P" ENTER
 	else
-		env PATH=$PATH:/usr/local/sbin:/usr/local/bin LC_ALL=en_US.UTF-8 ${command} -f -p ${pidfile} -r /usr/local/bin/middlewared ${overlay_dirs_arg} --log-handler=file
+		env PATH=$PATH:/usr/local/sbin:/usr/local/bin LC_ALL=en_US.UTF-8 ${command} -f -P ${daemon_pidfile} -p ${pidfile} -r /usr/local/bin/middlewared ${overlay_dirs_arg} --log-handler=file
 	fi
 	if ! LD_LIBRARY_PATH=/usr/local/lib /usr/local/bin/midclt -t 240 waitready; then
 		echo "##############################################################"
@@ -39,10 +40,15 @@ middlewared_start() {
 
 middlewared_stop() {
 	if [ -f "${pidfile}" ] ; then
-		rc_pid=$(cat $pidfile)
+		mw_pid=$(cat $pidfile)
+		if [ -f "${daemon_pidfile}" ] ; then
+			rc_pid=$(cat $daemon_pidfile)
+		else
+			rc_pid=$mw_pid
+		fi
 		echo 'Stopping middlewared.'
 		kill -s TERM ${rc_pid}
-		wait_for_pids ${rc_pid}
+		wait_for_pids ${mw_pid}
 	else
 		echo 'middlewared is not running'
 		exit 1

--- a/nas_ports/freenas/py-middlewared/files/middlewared.in
+++ b/nas_ports/freenas/py-middlewared/files/middlewared.in
@@ -63,8 +63,22 @@ middlewared_stop() {
 	fi
 }
 
+middlewared_status() {
+	if [ -f "${pidfile}" ] ; then
+		mw_pid=$(cat $pidfile)
+		kill -0 "${mw_pid}" >> /dev/null 2>&1
+		if [ $? -eq 0 ]; then
+			echo "$name is running as pid $mw_pid"
+			return 0
+		fi
+	fi
+	echo "$name is not running"
+	return 1
+}
+
 name="middlewared"
 start_cmd='middlewared_start'
+status_cmd='middlewared_status'
 stop_cmd='middlewared_stop'
 
 load_rc_config $name

--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -1273,6 +1273,10 @@ class Middleware(LoadPluginsMixin):
             if e.args[0] != "Event loop is closed":
                 raise
 
+        # We use "_exit" specifically as otherwise process pool executor won't let middlewared process die because
+        # it is still active. We don't initiate a shutdown for it because it may hang forever for any reason
+        os._exit(0)
+
     def terminate(self):
         self.logger.info('Terminating')
         self.__loop.create_task(self.__terminate())


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x cd774f89473dd861da4df624f0bab4a97957b7f1
    git cherry-pick -x 976e93615bb65ede53c0fd37b41ffebc47c587ac
    git cherry-pick -x 1a42a12d86a1f0cdfea6e07f063a56ddf52d7918

This PR introduces following changes:
1) Ensures middlewared is the last service to stop.
2) Ensures status of middlewared is correctly reflected.
3) Ensure start/stop of middlewared service behaves as desired.