### PR TITLE
NAS-103139 / 11.3 / Chown in non-recursive filesystem.setacl calls

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -819,6 +819,7 @@ class FilesystemService(Service):
             a.apply(data['path'])
 
         if not options['recursive']:
+            os.chown(data['path'], uid, gid)
             return True
 
         self._winacl(data['path'], 'clone', uid, gid, options)


### PR DESCRIPTION
Ability to chown in filesystem.setacl was a late addition, and
I overlooked adding an os.chown to non-recursive setacl calls.