### PR TITLE
NAS-103177 / 11.3 / Bug fix for readonly webdav share

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/apache24/Includes/webdav.conf
+++ b/src/middlewared/middlewared/etc_files/local/apache24/Includes/webdav.conf
@@ -87,7 +87,7 @@ Listen ${webdav_config['tcpport']}
 		<Directory "${share['path']}" >
 		</Directory>
 	% if share['ro']:
-		<Location /"${share['name']}" >
+		<Location "/${share['name']}" >
 			AllowMethods GET OPTIONS PROPFIND
 		</Location>
 	% endif


### PR DESCRIPTION
This commit fixes a bug where permissions for readonly shares would not be applied.