### PR TITLE
NAS-103368 / 11.2 / Properly clear and rebuild user/group cache

### DIFF
--- a/gui/common/freenascache.py
+++ b/gui/common/freenascache.py
@@ -99,7 +99,7 @@ class FreeNAS_BaseCache(object):
             os.makedirs(self.cachedir)
 
         flags = db.DB_CREATE | db.DB_THREAD | db.DB_INIT_LOCK | \
-            db.DB_INIT_MPOOL | db.DB_INIT_TXN
+            db.DB_INIT_MPOOL | db.DB_INIT_TXN | db.DB_INIT_LOG
 
         self.__dbenv = db.DBEnv()
         self.__dbenv.set_lk_detect(db.DB_LOCK_DEFAULT)

--- a/src/middlewared/middlewared/plugins/notifier.py
+++ b/src/middlewared/middlewared/plugins/notifier.py
@@ -243,7 +243,7 @@ class NotifierService(Service):
     async def ds_clearcache(self):
         """Temporary call to rebuild DS cache"""
         cachetool_job = await self.middleware.call('notifier.cachetool', 'expire')
-        cachetool_job.wait()
+        await cachetool_job.wait()
         if cachetool_job.error:
             raise CallError(f'cachetool expire failed with error {cachetool_job.error}')
 


### PR DESCRIPTION
There's a missing await in ds_clearcache, which is called when users manually click the "rebuild directory services cache" button. Un-break this.