### PR TITLE
NAS-103046 / 11.2 / Fix kerberos keytab related string handling

### DIFF
--- a/gui/common/freenasldap.py
+++ b/gui/common/freenasldap.py
@@ -631,7 +631,7 @@ class FreeNAS_LDAP_Base(FreeNAS_LDAP_Directory):
                     if kp:
                         kwargs['kerberos_principal'] = kp
                         kwargs['keytab_principal'] = kp.principal_name
-                        kwargs['keytab_file'] = '/etc/kerberos/%s' % kp.principal_keytab.keytab_name
+                        kwargs['keytab_file'] = '/etc/kerberos/%s' % kp.principal_keytab.id
 
                 else:
                     if newkey not in kwargs:
@@ -1604,7 +1604,7 @@ class FreeNAS_ActiveDirectory_Base(object):
                     if kp:
                         kwargs['kerberos_principal'] = kp
                         kwargs['keytab_principal'] = kp.principal_name
-                        kwargs['keytab_file'] = '/etc/kerberos/%s' % kp.principal_keytab.keytab_name
+                        kwargs['keytab_file'] = '/etc/kerberos/%s' % kp.principal_keytab.id
                         # self.flags |= FLAGS_SASL_GSSAPI
 
                 else:

--- a/gui/common/system.py
+++ b/gui/common/system.py
@@ -88,8 +88,32 @@ def get_sw_year():
     return str(datetime.now().year)
 
 
+def get_freenas_var_ds_config(f, var):
+    """
+    False gets picked up in get_freenas_var()
+    and results in default value (if it exists)
+    being set.
+    """
+    ds_config = []
+    with open(f, 'r') as conf:
+        ds_config.extend(list(conf))
+
+    for entry in ds_config:
+        if entry.startswith(var):
+            return entry.lstrip(f'{var}=')[:-1]
+
+    return False
+
+
 def get_freenas_var_by_file(f, var):
     assert f and var
+    ds_config = [
+        '/etc/directoryservice/ActiveDirectory/config',
+        '/etc/directoryservice/LDAP/config'
+    ]
+
+    if f in ds_config:
+        return get_freenas_var_ds_config(f, var)
 
     pipe = os.popen('. "%s"; echo "${%s}"' % (f, var, ))
     try:

--- a/gui/common/system.py
+++ b/gui/common/system.py
@@ -92,8 +92,8 @@ def get_freenas_var_ds_config(f, var):
     ds_config = []
     if not os.path.exists(f):
         log.debug(
-           "Config file [%s]. Unable to get value for [%s].",
-           f, var
+            "Config file [%s]. Unable to get value for [%s].",
+            f, var
         )
         return False
 

--- a/gui/common/system.py
+++ b/gui/common/system.py
@@ -89,12 +89,14 @@ def get_sw_year():
 
 
 def get_freenas_var_ds_config(f, var):
-    """
-    False gets picked up in get_freenas_var()
-    and results in default value (if it exists)
-    being set.
-    """
     ds_config = []
+    if not os.path.exists(f):
+        log.debug(
+           "Config file [%s]. Unable to get value for [%s].",
+           f, var
+        )
+        return False
+
     with open(f, 'r') as conf:
         ds_config.extend(list(conf))
 

--- a/src/middlewared/middlewared/etc_files/krb5.keytab.py
+++ b/src/middlewared/middlewared/etc_files/krb5.keytab.py
@@ -34,5 +34,5 @@ async def render(service, middleware):
 
     for keytab in keytabs:
         db_keytabfile = base64.b64decode(keytab['keytab_file'])
-        db_keytabname = keytab['keytab_name']
+        db_keytabname = keytab['id']
         await write_keytab(db_keytabname, db_keytabfile)


### PR DESCRIPTION
Use 'id' value rather than UI keytab name to generate temporary keytab.
Change freenasldap to use new-style temporary keytab.
Add dedicated parser for ldap and ad config files.