### PR TITLE
NAS-103413 / 11.3 / Use keytab index for naming temporary keytab

### DIFF
--- a/src/middlewared/middlewared/etc_files/krb5.keytab.py
+++ b/src/middlewared/middlewared/etc_files/krb5.keytab.py
@@ -36,5 +36,5 @@ async def render(service, middleware):
 
     for keytab in keytabs:
         db_keytabfile = base64.b64decode(keytab['file'].encode())
-        db_keytabname = keytab['name']
+        db_keytabname = keytab['id']
         await write_keytab(db_keytabname, db_keytabfile)


### PR DESCRIPTION
Do not use user-provided name for temporary keytabs.