### PR TITLE
NAS-103497 / 11.3 / Create generic directoryservice.[get|set]_state functions

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -846,6 +846,10 @@ class ActiveDirectoryService(ConfigService):
 
     @accepts()
     async def get_state(self):
+        """
+        Wrapper function for 'directoryservices.get_state'. Returns only the state of the
+        Active Directory service.
+        """
         return (await self.middleware.call('directoryservices.get_state'))['activedirectory']
 
     @private

--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -21,15 +21,8 @@ from middlewared.schema import accepts, Bool, Dict, Int, List, Str
 from middlewared.service import job, private, ConfigService, Service, ValidationError, ValidationErrors
 from middlewared.service_exception import CallError
 from middlewared.utils import run, Popen
-from samba.dcerpc.messaging import MSG_WINBIND_OFFLINE, MSG_WINBIND_ONLINE
-
-
-class DSStatus(enum.Enum):
-    DISABLED = enum.auto()
-    FAULTED = MSG_WINBIND_OFFLINE
-    LEAVING = enum.auto()
-    JOINING = enum.auto()
-    HEALTHY = MSG_WINBIND_ONLINE
+from middlewared.plugins.directoryservices import DSStatus
+from samba.dcerpc.messaging import MSG_WINBIND_ONLINE
 
 
 class neterr(enum.Enum):
@@ -849,31 +842,11 @@ class ActiveDirectoryService(ConfigService):
 
     @private
     async def _set_state(self, state):
-        await self.middleware.call('cache.put', 'AD_State', state.name)
+        return await self.middleware.call('directoryservices.set_state', {'activedirectory': state.name})
 
     @accepts()
     async def get_state(self):
-        """
-        `DISABLED` Directory Service is disabled.
-
-        `FAULTED` Directory Service is enabled, but not HEALTHY. Review logs and generated alert
-        messages to debug the issue causing the service to be in a FAULTED state.
-
-        `LEAVING` Directory Service is in process of stopping.
-
-        `JOINING` Directory Service is in process of starting.
-
-        `HEALTHY` Directory Service is enabled, and last status check has passed.
-        """
-        try:
-            return (await self.middleware.call('cache.get', 'AD_State'))
-        except KeyError:
-            try:
-                await self.started()
-            except Exception:
-                pass
-
-        return (await self.middleware.call('cache.get', 'AD_State'))
+        return (await self.middleware.call('directoryservices.get_state'))['activedirectory']
 
     @private
     async def start(self):
@@ -993,7 +966,7 @@ class ActiveDirectoryService(ConfigService):
         await self.middleware.call('service.restart', 'cifs')
         await self.middleware.call('etc.generate', 'pam')
         await self.middleware.call('etc.generate', 'nss')
-        await self.middleware.call('cache.pop', 'AD_State')
+        await self._set_state(DSStatus['DISABLED'])
 
     @private
     def validate_credentials(self, ad=None):
@@ -1124,14 +1097,12 @@ class ActiveDirectoryService(ConfigService):
         'winbind request timeout ='
         """
         if not (await self.config())['enable']:
-            await self._set_state(DSStatus['DISABLED'])
             return False
 
         netlogon_ping = await run([SMBCmd.WBINFO.value, '-P'], check=False)
         if netlogon_ping.returncode != 0:
-            await self._set_state(DSStatus['FAULTED'])
             raise CallError(netlogon_ping.stderr.decode().strip('\n'))
-        await self._set_state(DSStatus['HEALTHY'])
+
         return True
 
     @private

--- a/src/middlewared/middlewared/plugins/cache.py
+++ b/src/middlewared/middlewared/plugins/cache.py
@@ -175,20 +175,15 @@ class DSCache(Service):
         users and groups will simply not appear in query results (UI features).
 
         """
-        ds_enabled = {}
         res = []
+        ds_state = await self.middleware.call('directoryservices.get_state')
 
         is_name_check = bool(filters and len(filters) == 1 and filters[0][0] in ['username', 'groupname'])
 
-        for ds in ['activedirectory', 'ldap', 'nis']:
-            ds_enabled.update({
-                str(ds): True if await self.middleware.call(f'{ds}.get_state') != 'DISABLED' else False
-            })
-
         res.extend((await self.middleware.call(f'{objtype.lower()[:-1]}.query', filters, options)))
 
-        for dstype, enabled in ds_enabled.items():
-            if enabled:
+        for dstype, state in ds_state.items():
+            if state != 'DISABLED':
                 """
                 Avoid iteration here if possible.  Use keys if single filter "=" and x in x=y is a
                 username or groupname.

--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -1,0 +1,67 @@
+import enum
+from middlewared.schema import accepts
+from middlewared.service import Service, private
+from samba.dcerpc.messaging import MSG_WINBIND_OFFLINE, MSG_WINBIND_ONLINE
+
+
+class DSStatus(enum.Enum):
+    DISABLED = enum.auto()
+    FAULTED = MSG_WINBIND_OFFLINE
+    LEAVING = enum.auto()
+    JOINING = enum.auto()
+    HEALTHY = MSG_WINBIND_ONLINE
+
+
+class DSType(enum.Enum):
+    AD = 'activedirectory'
+    LDAP = 'ldap'
+    NIS = 'nis'
+
+
+class DirectoryServices(Service):
+    class Config:
+        service = "directoryservices"
+
+    @accepts()
+    async def get_state(self):
+        """
+        `DISABLED` Directory Service is disabled.
+
+        `FAULTED` Directory Service is enabled, but not HEALTHY. Review logs and generated alert
+        messages to debug the issue causing the service to be in a FAULTED state.
+
+        `LEAVING` Directory Service is in process of stopping.
+
+        `JOINING` Directory Service is in process of starting.
+
+        `HEALTHY` Directory Service is enabled, and last status check has passed.
+        """
+        try:
+            return (await self.middleware.call('cache.get', 'DS_State'))
+        except KeyError:
+            ds_state = {}
+            for srv in DSType:
+                try:
+                    res = await self.middleware.call(f'{srv.value}.started')
+                    ds_state[srv.value] = DSStatus.HEALTHY.name if res else DSStatus.DISABLED.name
+                except Exception:
+                    ds_state[srv.value] = DSStatus.FAULTED.name
+
+            await self.middleware.call('cache.put', 'DS_STATE', ds_state)
+            return ds_state
+
+    @private
+    async def set_state(self, new):
+        ds_state = {
+            'activedirectory': DSStatus.DISABLED.name,
+            'ldap': DSStatus.DISABLED.name,
+            'nis': DSStatus.DISABLED.name
+        }
+        ds_state.update(await self.get_state())
+        ds_state.update(new)
+        self.middleware.send_event('directoryservices.status', 'CHANGED', fields=ds_state)
+        return await self.middleware.call('cache.put', 'DS_STATE', ds_state)
+
+
+def setup(middleware):
+    middleware.event_register('directoryservices.status', 'Sent on directory service state changes.')

--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -659,6 +659,10 @@ class LDAPService(ConfigService):
 
     @accepts()
     async def get_state(self):
+        """
+        Wrapper function for 'directoryservices.get_state'. Returns only the state of the
+        LDAP service.
+        """
         return (await self.middleware.call('directoryservices.get_state'))['ldap']
 
     @private

--- a/src/middlewared/middlewared/plugins/nis.py
+++ b/src/middlewared/middlewared/plugins/nis.py
@@ -1,5 +1,4 @@
 import asyncio
-import enum
 import errno
 import pwd
 import grp
@@ -8,14 +7,7 @@ from middlewared.schema import accepts, Bool, Dict, List, Str
 from middlewared.service import job, private, ConfigService
 from middlewared.service_exception import CallError
 from middlewared.utils import run
-
-
-class DSStatus(enum.Enum):
-    DISABLED = 0
-    FAULTED = 1
-    LEAVING = 2
-    JOINING = 3
-    HEALTHY = 4
+from middlewared.plugins.directoryservices import DSStatus
 
 
 class NISService(ConfigService):
@@ -84,31 +76,11 @@ class NISService(ConfigService):
 
     @private
     async def __set_state(self, state):
-        await self.middleware.call('cache.put', 'NIS_State', state.name)
+        return await self.middleware.call('directoryservices.set_state', {'nis': state.name})
 
-    @private
+    @accepts()
     async def get_state(self):
-        """
-        `DISABLED` Directory Service is disabled.
-
-        `FAULTED` Directory Service is enabled, but not HEALTHY. Review logs and generated alert
-        messages to debug the issue causing the service to be in a FAULTED state.
-
-        `LEAVING` Directory Service is in process of stopping.
-
-        `JOINING` Directory Service is in process of starting.
-
-        `HEALTHY` Directory Service is enabled, and last status check has passed.
-        """
-        try:
-            return (await self.middleware.call('cache.get', 'NIS_State'))
-        except KeyError:
-            try:
-                await self.started()
-            except Exception:
-                pass
-
-        return (await self.middleware.call('cache.get', 'NIS_State'))
+        return (await self.middleware.call('directoryservices.get_state'))['nis']
 
     @private
     async def start(self):
@@ -168,15 +140,12 @@ class NISService(ConfigService):
     async def started(self):
         ret = False
         if not (await self.config())['enable']:
-            await self.__set_state(DSStatus['DISABLED'])
             return ret
         try:
             ret = await asyncio.wait_for(self.__ypwhich(), timeout=5.0)
         except asyncio.TimeoutError:
             raise CallError('nis.started check timed out after 5 seconds.')
 
-        if ret:
-            await self.__set_state(DSStatus['HEALTHY'])
         return ret
 
     @private
@@ -206,7 +175,7 @@ class NISService(ConfigService):
         await self.middleware.call('etc.generate', 'pam')
         await self.middleware.call('etc.generate', 'hostname')
         await self.middleware.call('etc.generate', 'nss')
-        await self.middleware.call('cache.pop', 'NIS_cache')
+        await self.__set_state(DSStatus['DISABLED'])
         self.logger.debug(f'NIS service successfully stopped. Setting state to DISABLED.')
         return True
 

--- a/src/middlewared/middlewared/plugins/nis.py
+++ b/src/middlewared/middlewared/plugins/nis.py
@@ -80,6 +80,10 @@ class NISService(ConfigService):
 
     @accepts()
     async def get_state(self):
+        """
+        Wrapper function for 'directoryservices.get_state'. Returns only the state of the
+        NIS service.
+        """
         return (await self.middleware.call('directoryservices.get_state'))['nis']
 
     @private


### PR DESCRIPTION
Return status of all directory services in one API call. Register event for status changes.