### PR TITLE
NAS-103518 / 11.3 / Ensure validation errors are raised with api v1

### DIFF
--- a/gui/api/utils.py
+++ b/gui/api/utils.py
@@ -491,6 +491,9 @@ class DojoModelResource(ResourceMixin, ModelResource):
         """
         try:
             form.save()
+            if form._errors:
+                # This might happen for a form which does not raise validation errors for django compatibility
+                raise ValidationErrors([])
         except ValidationErrors as e:
             handle_middleware_validation(form, e)
             raise ImmediateHttpResponse(response=self.error_response(


### PR DESCRIPTION
This commit adds changes which ensure that for forms other then middleware forms, we do raise validation errors if any.