### PR TITLE
NAS-102893 / 11.2 / Avoid unnecessary Samba starts / stops during sysdataset manipulation

### DIFF
--- a/gui/middleware/notifier.py
+++ b/gui/middleware/notifier.py
@@ -2137,7 +2137,12 @@ class notifier(metaclass=HookMetaclass):
         self.start("ix-syslogd")
         self.start("ix-warden")
         # FIXME: do not restart collectd again
-        self.restart("system_datasets")
+        sys_dataset_confgured = False
+        with client as c:
+            sys_dataset_configured = c.call('systemdataset.config')['pool']
+
+        if not sys_dataset_configured:
+            self.restart("system_datasets")
 
         return volume
 

--- a/gui/middleware/notifier.py
+++ b/gui/middleware/notifier.py
@@ -2137,12 +2137,7 @@ class notifier(metaclass=HookMetaclass):
         self.start("ix-syslogd")
         self.start("ix-warden")
         # FIXME: do not restart collectd again
-        sys_dataset_confgured = False
-        with client as c:
-            sys_dataset_configured = c.call('systemdataset.config')['pool']
-
-        if not sys_dataset_configured:
-            self.restart("system_datasets")
+        self.restart("system_datasets")
 
         return volume
 

--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -1069,7 +1069,7 @@ class ServiceService(CRUDService):
         if systemdataset['syslog']:
             await self.restart("syslogd", kwargs)
         # hard-code onetime to avoid starting Samba if it's disabled
-        await self.restart("cifs",  {'onetime': False})
+        await self.restart("cifs", {'onetime': False})
         if systemdataset['rrd']:
             # Restarting collectd may take a long time and there is no
             # benefit in waiting for it since even if it fails it wont

--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -1068,7 +1068,8 @@ class ServiceService(CRUDService):
             return None
         if systemdataset['syslog']:
             await self.restart("syslogd", kwargs)
-        await self.restart("cifs", kwargs)
+        # hard-code onetime to avoid starting Samba if it's disabled
+        await self.restart("cifs",  {'onetime': False})
         if systemdataset['rrd']:
             # Restarting collectd may take a long time and there is no
             # benefit in waiting for it since even if it fails it wont


### PR DESCRIPTION
- Only restart system_datasets if the system dataset isn't located on a zpool
- During system_datasets restart, do not pass onerestart to Samba.
  This is to prevent samba from restarting when it's not enabled.