### PR TITLE
NAS-102893 / 11.3 / Avoid unnecessarily starting SMB service when restarting system_dataset

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -686,7 +686,8 @@ class PoolService(CRUDService):
         # in background.
         async def restart_services():
             await self.middleware.call('service.reload', 'disk')
-            await self.middleware.call('service.restart', 'system_datasets')
+            if (await self.middleware.call('systemdataset.config'))['pool'] == 'freenas-boot':
+                await self.middleware.call('service.restart', 'system_datasets')
             # regenerate crontab because of scrub
             await self.middleware.call('service.restart', 'cron')
 

--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -977,7 +977,7 @@ class ServiceService(CRUDService):
             return None
         if systemdataset['syslog']:
             await self.restart("syslogd", kwargs)
-        await self.restart("cifs", kwargs)
+        await self.restart("cifs", {'onetime': False})
 
         # Restarting rrdcached can take a long time. There is no
         # benefit in waiting for it, since even if it fails it will not


### PR DESCRIPTION
SMB service should not be started if it's disabled. Likewise we
should avoid restarting system_datasets if possible.