### PR TITLE
NAS-103472 / 11.3 / Add Security Headers to Nginx

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf
@@ -111,6 +111,10 @@ http {
     % endfor
 % endif
 
+        # Security Headers
+        add_header X-Content-Type-Options nosniff;
+        add_header X-XSS-Protection "1";
+
         location / {
             rewrite ^.* /ui/ redirect;
         }


### PR DESCRIPTION
This commit adds following security headers to nginx:
1) X-Content-Type-Options:  prevents attacks based on MIME-type mismatch.
2) X-XSS-Protection: enables the browser built-in Cross-Site Scripting (XSS) filter to prevent cross-site scripting attacks.