### PR TITLE
NAS-103534 / 11.2 / Clear AD config file before validating credentials

### DIFF
--- a/gui/directoryservice/forms.py
+++ b/gui/directoryservice/forms.py
@@ -502,6 +502,15 @@ class ActiveDirectoryForm(ModelForm):
             bindpw = self.instance.ad_bindpw
             cdata['ad_bindpw'] = bindpw
 
+        """
+        The AD configuration file takes precedence over newly-added
+        parameters. It must be removed before validating passwords.
+        """
+        try:
+            os.unlink('/etc/directoryservice/ActiveDirectory/config')
+        except FileNotFoundError:
+            pass
+
         if cdata.get("ad_enable") is False:
             return cdata
 


### PR DESCRIPTION
This will potentially make configuration changes slightly slower, but it will also reduce potential for errors due to a stale config file.