### PR TITLE
NAS-103568 / 11.3 / Ensure iocage checks are performed on boot

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -1339,6 +1339,10 @@ class JailService(CRUDService):
 
     @private
     def start_on_boot(self):
+        if not self.iocage_set_up():
+            return
+
+        self.check_dataset_existence()
         self.logger.debug('Starting jails on boot: PENDING')
         ioc.IOCage(rc=True, reset_cache=True).start()
         self.logger.debug('Starting jails on boot: SUCCESS')


### PR DESCRIPTION
This commit ensures iocage checks are performed before attempting to start any jail which is supposed to start at boot.