### PR TITLE
NAS-103583 / 11.3 / Ensure that triggered alerts also update DS state

### DIFF
--- a/src/middlewared/middlewared/alert/source/active_directory.py
+++ b/src/middlewared/middlewared/alert/source/active_directory.py
@@ -38,6 +38,7 @@ class ActiveDirectoryDomainHealthAlertSource(AlertSource):
         try:
             await self.middleware.call("activedirectory.validate_domain")
         except Exception as e:
+            await self.middleware.call("activedirectory.set_state", "FAULTED")
             return Alert(
                 ActiveDirectoryDomainHealthAlertClass,
                 {'verrs': str(e)},
@@ -56,6 +57,7 @@ class ActiveDirectoryDomainBindAlertSource(AlertSource):
         try:
             await self.middleware.call("activedirectory.started")
         except Exception as e:
+            await self.middleware.call("activedirectory.set_state", "FAULTED")
             return Alert(
                 ActiveDirectoryDomainBindAlertClass,
                 {'wberr': str(e)},

--- a/src/middlewared/middlewared/alert/source/ldap.py
+++ b/src/middlewared/middlewared/alert/source/ldap.py
@@ -22,6 +22,7 @@ class LDAPBindAlertSource(AlertSource):
         try:
             await self.middleware.call("ldap.started")
         except Exception as e:
+            await self.middleware.call('ldap.set_state', 'FAULTED')
             return Alert(
                 LDAPBindAlertClass,
                 {'ldaperr': str(e)},

--- a/src/middlewared/middlewared/alert/source/nis.py
+++ b/src/middlewared/middlewared/alert/source/nis.py
@@ -22,6 +22,7 @@ class NISBindAlertSource(AlertSource):
         try:
             await self.middleware.call("nis.started")
         except Exception as e:
+            await self.middleware.call('nis.set_state', 'FAULTED')
             return Alert(
                 NISBindAlertClass,
                 {'niserr': str(e)},

--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -654,7 +654,7 @@ class LDAPService(ConfigService):
         return ret
 
     @private
-    async def __set_state(self, state):
+    async def set_state(self, state):
         return await self.middleware.call('directoryservices.set_state', {'ldap': state.name})
 
     @accepts()
@@ -721,14 +721,14 @@ class LDAPService(ConfigService):
             await self.middleware.call('smb.store_ldap_admin_password')
             await self.middleware.call('service.restart', 'cifs')
 
-        await self.__set_state(DSStatus['HEALTHY'])
+        await self.set_state(DSStatus['HEALTHY'])
         await self.middleware.call('ldap.fill_cache')
 
     @private
     async def stop(self):
         ldap = await self.config()
         await self.middleware.call('datastore.update', self._config.datastore, ldap['id'], {'ldap_enable': False})
-        await self.__set_state(DSStatus['LEAVING'])
+        await self.set_state(DSStatus['LEAVING'])
         await self.middleware.call('etc.generate', 'rc')
         await self.middleware.call('etc.generate', 'nss')
         await self.middleware.call('etc.generate', 'ldap')
@@ -738,7 +738,7 @@ class LDAPService(ConfigService):
             await self.middleware.call('service.restart', 'cifs')
         await self.middleware.call('cache.pop', 'LDAP_cache')
         await self.nslcd_cmd('onestop')
-        await self.__set_state(DSStatus['DISABLED'])
+        await self.set_state(DSStatus['DISABLED'])
 
     @private
     @job(lock='fill_ldap_cache')

--- a/src/middlewared/middlewared/plugins/nis.py
+++ b/src/middlewared/middlewared/plugins/nis.py
@@ -75,7 +75,7 @@ class NISService(ConfigService):
         return await self.config()
 
     @private
-    async def __set_state(self, state):
+    async def set_state(self, state):
         return await self.middleware.call('directoryservices.set_state', {'nis': state.name})
 
     @accepts()
@@ -101,7 +101,7 @@ class NISService(ConfigService):
         if state in ['EXITING', 'JOINING']:
             raise CallError(f'Current state of NIS service is: [{state}]. Wait until operation completes.', errno.EBUSY)
 
-        await self.__set_state(DSStatus['JOINING'])
+        await self.set_state(DSStatus['JOINING'])
         await self.middleware.call('datastore.update', 'directoryservice.nis', nis['id'], {'nis_enable': True})
         await self.middleware.call('etc.generate', 'rc')
         await self.middleware.call('etc.generate', 'pam')
@@ -109,15 +109,15 @@ class NISService(ConfigService):
         await self.middleware.call('etc.generate', 'nss')
         setnisdomain = await run(['/bin/domainname', nis['domain']], check=False)
         if setnisdomain.returncode != 0:
-            await self.__set_state(DSStatus['FAULTED'])
+            await self.set_state(DSStatus['FAULTED'])
             raise CallError(f'Failed to set NIS Domain to [{nis["domain"]}]: {setnisdomain.stderr.decode()}')
 
         ypbind = await run(['/usr/sbin/service', 'ypbind', 'onestart'], check=False)
         if ypbind.returncode != 0:
-            await self.__set_state(DSStatus['FAULTED'])
+            await self.set_state(DSStatus['FAULTED'])
             raise CallError(f'ypbind failed: {ypbind.stderr.decode()}')
 
-        await self.__set_state(DSStatus['HEALTHY'])
+        await self.set_state(DSStatus['HEALTHY'])
         self.logger.debug(f'NIS service successfully started. Setting state to HEALTHY.')
         await self.middleware.call('nis.fill_cache')
         return True
@@ -128,15 +128,9 @@ class NISService(ConfigService):
         The return code from ypwhich is not a reliable health indicator. For example, RPC failure will return 0.
         There are edge cases where ypwhich can hang when NIS is misconfigured.
         """
-        nis = await self.config()
         ypwhich = await run(['/usr/bin/ypwhich'], check=False)
-        if ypwhich.returncode != 0:
-            if nis['enable']:
-                await self.__set_state(DSStatus['FAULTED'])
-                self.logger.debug(f'NIS status check returned [{ypwhich.stderr.decode().strip()}]. Setting state to FAULTED.')
-            return False
+
         if ypwhich.stderr:
-            await self.__set_state(DSStatus['FAULTED'])
             raise CallError(f'NIS status check returned [{ypwhich.stderr.decode().strip()}]. Setting state to FAULTED.')
         return True
 


### PR DESCRIPTION
Also make the various "set_state" functions naming consistent.
I also noticed that I needed to update the return values for
'nis.started'. The various <ds>.started functions should
return True if it's healthy, False if it's disabled, and raise
an exception if it's enabled and not healthy.

ypwhich has some strange and not very helpful failure modes. It
may return 1 indicating failure, or it may fail and return 0. Checking
for stderr is probably less problematic. If it returns 1, there is
also output on stderr so we can reduce the checks here.