### PR TITLE
QE-239 Get gateway before runing interfaces API testing

### DIFF
--- a/tests/api2/interfaces.py
+++ b/tests/api2/interfaces.py
@@ -19,6 +19,15 @@ aliases = {'address': ip}
 vlan1_ip = f"192.168.0.{random.randint(10, 250)}"
 
 
+def test_00_store_default_routes_as_gateway_for_network_testing():
+    results = GET("/network/general/summary/")
+    assert results.status_code == 200
+    gateway = results.json()['default_routes'][0]
+    cfg_file = open("auto_config.py", 'a')
+    cfg_file.writelines(f'gateway = "{gateway}"\n')
+    cfg_file.close()
+
+
 def test_01_get_interface_name():
     results = GET(f'/interface?name={interface}')
     assert results.status_code == 200, results.text

--- a/tests/api2/network.py
+++ b/tests/api2/network.py
@@ -9,7 +9,7 @@ import os
 
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from auto_config import hostname, domain
+from auto_config import hostname, domain, gateway
 from functions import GET, PUT
 from config import *
 
@@ -20,13 +20,11 @@ Reason = "AD_DOMAIN BRIDGEDNS are missing in ixautomation.conf"
 dns_cfg = pytest.mark.skipif("BRIDGEDNS" not in locals(), reason=Reason)
 
 
-def test_01_get_default_routes():
+def test_01_get_default_network_general_summary():
     results = GET("/network/general/summary/")
     assert results.status_code == 200
     assert isinstance(results.json(), dict), results.text
     assert isinstance(results.json()['default_routes'], list), results.text
-    global gateway
-    gateway = results.json()['default_routes'][0]
 
 
 @dns_cfg


### PR DESCRIPTION
grabbing the default_routes before runing interfaces testing and sourcing it for network testing will fix the network API testing.