### PR TITLE
NAS-103592 / 11.3 / Add auto to ups port choices

### DIFF
--- a/src/middlewared/middlewared/plugins/ups.py
+++ b/src/middlewared/middlewared/plugins/ups.py
@@ -38,6 +38,7 @@ class UPSService(SystemServiceService):
         ports = [x for x in glob.glob('/dev/cua*') if x.find('.') == -1]
         ports.extend(glob.glob('/dev/ugen*'))
         ports.extend(glob.glob('/dev/uhid*'))
+        ports.append('auto')
         return ports
 
     @accepts()


### PR DESCRIPTION
This commit adds auto to ups port choices which enables auto management of port which NUT handles for drivers which support it.