### PR TITLE
NAS-103591 / 11.3 / Validate directory service config during health checks

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -1124,15 +1124,17 @@ class ActiveDirectoryService(ConfigService):
             return False
 
         await self.common_validate(config, config, verrors)
-        if verrors:
+
+        try:
+            verrors.check()
+        except Exception as e:
             await self.middleware.call(
                 'datastore.update',
                 'directoryservice.activedirectory',
                 config['id'],
                 {'ad_enable': False}
             )
-            cerrors = ' '.join(v.errmsg for v in verrors.errors)
-            raise CallError(cerrors, errno.EINVAL)
+            raise CallError(e) 
 
         netlogon_ping = await run([SMBCmd.WBINFO.value, '-P'], check=False)
         if netlogon_ping.returncode != 0:

--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -1127,14 +1127,15 @@ class ActiveDirectoryService(ConfigService):
 
         try:
             verrors.check()
-        except Exception as e:
+        except Exception:
             await self.middleware.call(
                 'datastore.update',
                 'directoryservice.activedirectory',
                 config['id'],
                 {'ad_enable': False}
             )
-            raise CallError(e) 
+            raise CallError('Automatically disabling ActiveDirectory service due to invalid configuration.',
+                            errno.EINVAL)
 
         netlogon_ping = await run([SMBCmd.WBINFO.value, '-P'], check=False)
         if netlogon_ping.returncode != 0:

--- a/src/middlewared/middlewared/plugins/nis.py
+++ b/src/middlewared/middlewared/plugins/nis.py
@@ -49,7 +49,8 @@ class NISService(ConfigService):
 
         `manycast` when enabled sets ypbind(8) to bind to the server that responds the fastest.
 
-        `enable` when true disables the configuration of the NIS service.
+        `enable` enables and starts the NIS service. The NIS service is disabled when this
+        value is changed to False.
         """
         must_reload = False
         old = await self.config()


### PR DESCRIPTION
When LDAP or AD is enabled, certain assumptions are made about the
service having valid data in the service config. Since the presence
of bad data in the config can adversely affect system behavior
outside of the service in question (and there are some online guides
suggesting using the sqlite command to manually edit the database),
perform an additional configuration validation step the respective
<ds>.started methods. These methods are called in periodic health
checks as part of the directory service alerts, and will convert
the ValidationError into a proper alert. When this check fails,
disable the directory service in question to help recover from
undefined behavior.