### PR TITLE
NAS-103612 / 11.2 / log when vmware vm isn't powered on

### DIFF
--- a/gui/tools/autosnap.py
+++ b/gui/tools/autosnap.py
@@ -438,6 +438,7 @@ if len(mp_to_task_map) > 0:
             vm_view = content.viewManager.CreateContainerView(content.rootFolder, [vim.VirtualMachine], True)
             for vm in vm_view.view:
                 if vm.summary.runtime.powerState != 'poweredOn':
+                    log.debug("VM: %s is not powered on. Skip creating a vmware aware snapshot.", vm.name)
                     continue
                 if doesVMDependOnDataStore(vm, vmsnapobj.datastore):
                     try:


### PR DESCRIPTION
This is in our documentation but we should log it in a log file so TrueNAS support has a way of identifying the perplexing issue for when vmware aware snapshots don't seem to be working when it's by design.