### PR TITLE
NAS-103460 / 11.3 / Make sure jails start at boot regardless of some failing

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -1340,7 +1340,7 @@ class JailService(CRUDService):
     @private
     def start_on_boot(self):
         self.logger.debug('Starting jails on boot: PENDING')
-        ioc.IOCage(rc=True, reset_cache=True).start()
+        ioc.IOCage(rc=True, reset_cache=True).start(ignore_exception=True)
         self.logger.debug('Starting jails on boot: SUCCESS')
 
         return True


### PR DESCRIPTION
This commit ensures that jails start at boot as desired. If any fails, right now next jails in line didn't start at all. This ensures if one or more fail, the ones which wouldn't fail start as desired