### PR TITLE
Update OS in installer

### DIFF
--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -987,7 +987,7 @@ menu_install()
 	chown -R www:www /tmp/data/data
     fi
 
-    local OS=FreeNAS
+    local OS=TrueNAS
 
     # Tell it to look in /.mount for the packages.
     /usr/local/bin/freenas-install -P /.mount/${OS}/Packages -M /.mount/${OS}-MANIFEST /tmp/data


### PR DESCRIPTION
This commit updates OS in installer so that we use TrueNAS as the default name instead of FreeNAS name to reflect the 12 builds.