### PR TITLE
NAS-103663 / 11.3 / Make middleware aware of ID_TYPE_BOTH from winbindd

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -96,6 +96,8 @@ class UserService(CRUDService):
     async def user_compress(self, user):
         if 'local' in user:
             user.pop('local')
+        if 'id_type_both' in user:
+            user.pop('id_type_both')
         return user
 
     @filterable
@@ -130,7 +132,7 @@ class UserService(CRUDService):
             'datastore.query', self._config.datastore, [], datastore_options
         )
         for entry in result:
-            entry.update({'local': True})
+            entry.update({'local': True, 'id_type_both': False})
         return await self.middleware.run_in_thread(
             filter_list, result, filters, options
         )
@@ -766,6 +768,8 @@ class GroupService(CRUDService):
     async def group_compress(self, group):
         if 'local' in group:
             group.pop('local')
+        if 'id_type_both' in group:
+            group.pop('id_type_both')
         return group
 
     @filterable
@@ -800,7 +804,7 @@ class GroupService(CRUDService):
             'datastore.query', self._config.datastore, [], datastore_options
         )
         for entry in result:
-            entry.update({'local': True})
+            entry.update({'local': True, 'id_type_both': False})
         return await self.middleware.run_in_thread(
             filter_list, result, filters, options
         )


### PR DESCRIPTION
IDs allocated by winbindd idmap backends supporting ID_TYPE_BOTH
will appear as both users and groups. In this situation add
entries to both user and group cache. Also add additional key
to results of user.query and group.query to indicate whether
the ID was allocated by such a backend.