### PR TITLE
NAS-103674 / 11.3 / Fix kinit bug when using AD_MACHINE_ACCOUNT keytab in TrueNAS HA

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf
@@ -208,6 +208,8 @@
                     'ads dns update': 'Yes' if db['ad']['allow_dns_updates'] else 'No',
                     'allow trusted domains': 'Yes' if db['ad']['allow_trusted_doms'] else 'No'
                 })
+                if db['truenas_conf']['smb_ha_mode'] == 'UNIFIED':
+                    pc.update({'ads dns update': 'No'})
                 if not db['ad']['disable_freenas_cache']:
                     pc.update({'winbind enum users': 'Yes'})
                     pc.update({'winbind enum groups': 'Yes'})

--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -928,6 +928,7 @@ class ActiveDirectoryService(ConfigService):
         if ret == neterr.NOTJOINED:
             self.logger.debug(f"Test join to {ad['domainname']} failed. Performing domain join.")
             await self._net_ads_join()
+            await self._register_virthostname(ad, smb, smb_ha_mode)
             if smb_ha_mode != 'LEGACY':
                 kt_id = await self.middleware.call('kerberos.keytab.store_samba_keytab')
                 if kt_id:
@@ -936,7 +937,7 @@ class ActiveDirectoryService(ConfigService):
                         'datastore.update',
                         'directoryservice.activedirectory',
                         ad['id'],
-                        {'ad_bindpw': '', 'ad_kerberos_principal': f'{smb["netbiosname"].upper()}$@{ad["domainname"]}'}
+                        {'ad_bindpw': '', 'ad_kerberos_principal': f'{ad["netbiosname"].upper()}$@{ad["domainname"]}'}
                     )
                     ad = await self.config()
 
@@ -1108,6 +1109,28 @@ class ActiveDirectoryService(ConfigService):
             raise CallError(netlogon_ping.stderr.decode().strip('\n'))
 
         return True
+
+    @private
+    async def _register_virthostname(self, ad, smb, smb_ha_mode):
+        """
+        This co-routine performs virtual hostname aware
+        dynamic DNS updates after joining AD to register
+        CARP addresses.
+        """
+        if not ad['allow_dns_updates'] or smb_ha_mode == 'STANDALONE':
+            return
+
+        vhost = (await self.middleware.call('network.configuration.config'))['hostname_virtual']
+        carp_ips = set(await self.middleware.call('failover.get_ips'))
+        smb_bind_ips = set(smb['bindip']) if smb['bindip'] else carp_ips
+        to_register = carp_ips & smb_bind_ips
+        hostname = f'{vhost}.{ad["domainname"]}'
+        cmd = [SMBCmd.NET.value, '-k', 'ads', 'dns', 'register', hostname]
+        cmd.extend(to_register)
+        netdns = await run(cmd, check=False)
+        if netdns.returncode != 0:
+            self.logger.debug("hostname: %s, ips: %s, text: %s",
+                              hostname, to_register, netdns.stderr.decode())
 
     @private
     async def _net_ads_join(self):


### PR DESCRIPTION
Two separate issues,
(1) We need to use a keytab based on the virtual hostname in a
    UNIFIED HA config
(2) TrueNAS HA should register the virtual hostname and CARP
    addresses on domain join. In the case of LEGACY HA config
    this will result in potentially three DNS entries being
    generated (one for each controller with the netbios name
    of the controller, and one for the shared virtual hostname).
    In UNIFIED HA, there will be only one DNS entry with the
    virtual hostname and CARP address.