### PR TITLE
NAS-103729 / 12 / Expose a new has_private attribute

### DIFF
--- a/src/middlewared/middlewared/pytest/unit/test_schema.py
+++ b/src/middlewared/middlewared/pytest/unit/test_schema.py
@@ -331,6 +331,14 @@ def test__schema_dict_mixed_args(value, expected, msg):
         assert dictargs(self, value) == expected
 
 
+@pytest.mark.parametrize('items,value', [
+    ([List('b', items=[List('c', private=True)])], [[['a']]]),
+    ([Dict('b', Str('c', private=True))], [{'c': 'secret'}])
+])
+def test__schema_list_private_items(items, value):
+    assert List('a', items=items).dump(value) == '********'
+
+
 def test__schema_list_empty():
 
     @accepts(List('data', empty=False))

--- a/src/middlewared/middlewared/schema.py
+++ b/src/middlewared/middlewared/schema.py
@@ -85,7 +85,7 @@ class Attribute(object):
         return self.private
 
     def dump(self, value):
-        if self.has_private():
+        if self.private:
             return "********"
 
         return value
@@ -472,6 +472,11 @@ class List(EnumMixin, Attribute):
 
     def has_private(self):
         return self.private or any(item.has_private() for item in self.items)
+
+    def dump(self, value):
+        if self.has_private():
+            return '********'
+        return value
 
     def validate(self, value):
         if value is None:

--- a/src/middlewared/middlewared/schema.py
+++ b/src/middlewared/middlewared/schema.py
@@ -81,8 +81,11 @@ class Attribute(object):
                 raise Error(self.name, 'attribute required')
         return value
 
+    def has_private(self):
+        return self.private
+
     def dump(self, value):
-        if self.private:
+        if self.has_private():
             return "********"
 
         return value
@@ -467,11 +470,8 @@ class List(EnumMixin, Attribute):
                     raise Error(self.name, 'Item#{0} is not valid per list types: {1}'.format(index, found))
         return value
 
-    def dump(self, value):
-        if self.private or (self.items and any(item.private for item in self.items)):
-            return "********"
-
-        return value
+    def has_private(self):
+        return self.private or any(item.has_private() for item in self.items)
 
     def validate(self, value):
         if value is None:
@@ -573,6 +573,9 @@ class Dict(Attribute):
                     if not attr.has_default:
                         raise ValueError(f"Attribute {attr.name} is not required and does not have default value, "
                                          f"this is forbidden in strict mode")
+
+    def has_private(self):
+        return self.private or any(i.has_private() for i in self.attrs.values())
 
     def clean(self, data):
         data = super().clean(data)


### PR DESCRIPTION
This commit introduces a new method on attribute 'has_private' which ensures that if we have a dict or dicts in a list's items, where any dict has an attribute marked as private, that is respected.