### PR TITLE
NAS-103839 / 11.2 / Allow non-GSSAPI binds to LDAP in environments with a kerberos realm

### DIFF
--- a/gui/common/freenasldap.py
+++ b/gui/common/freenasldap.py
@@ -679,7 +679,7 @@ class FreeNAS_LDAP_Base(FreeNAS_LDAP_Directory):
 
         want_ssl = True if kwargs['ssl'] in [FREENAS_LDAP_USESSL, FREENAS_LDAP_USETLS] else False
         env_is_kerberized = True if self.kerberos_realm or self.keytab_principal else False
-        want_gssapi = want_ssl
+        want_gssapi = not want_ssl
         if kwargs.get('anonbind', False):
             want_gssapi = False
 

--- a/src/freenas/etc/directoryservice/rc.DS_Common
+++ b/src/freenas/etc/directoryservice/rc.DS_Common
@@ -28,6 +28,8 @@
 : ${MIDCLT="/usr/local/bin/midclt"}
 : ${JQ="/usr/local/bin/jq"}
 : ${DEFAULT_SYS_DATASET="freenas-boot"}
+: ${FREENAS_LDAP_FORCE_GSSAPI="1"}
+: ${FREENAS_LDAP_DEBUG="1"}
 
 is_unified_standby()
 {

--- a/src/freenas/etc/ix.rc.d/ix-ldap
+++ b/src/freenas/etc/ix.rc.d/ix-ldap
@@ -161,7 +161,7 @@ ldap_status()
 			do_gssapi_bind=0
 		fi
 
-		if [ -n "${realm}" -a -n "${principal}" -a -n "${do_gssapi_bind}" ]
+		if [ -n "${realm}" -a -n "${principal}" -a "${do_gssapi_bind}" == 0 ]
 		then
 			local temp=$(mktemp /tmp/tmp.XXXXXX)
 			local cmdfile=$(mktemp /tmp/tmp.XXXXXX)

--- a/src/freenas/etc/ix.rc.d/ix-ldap
+++ b/src/freenas/etc/ix.rc.d/ix-ldap
@@ -14,13 +14,13 @@ LDAP_STATUS_ALERT="/tmp/.ldap_status_alert"
 
 generate_ldapconf()
 {
-	LD_LIBRARY_PATH=/usr/local/lib /usr/local/bin/midclt call etc.generate ldap > /dev/null
+	LD_LIBRARY_PATH=/usr/local/lib /usr/local/bin/midclt call etc.generate ldap 2> /dev/null
 }
 
 generate_nss_ldapconf()
 {
 	rm -f /usr/local/etc/ldap.conf
-	LD_LIBRARY_PATH=/usr/local/lib /usr/local/bin/midclt call etc.generate nss > /dev/null
+	LD_LIBRARY_PATH=/usr/local/lib /usr/local/bin/midclt call etc.generate nss 2> /dev/null
 	ln -sf /usr/local/etc/nss_ldap.conf /usr/local/etc/ldap.conf
 }
 
@@ -134,31 +134,34 @@ ldap_status()
 		local res=1
 		local ldapsearch=/usr/local/bin/ldapsearch
 		local options=
-		local allow_gssapi_bind=0
+		local do_gssapi_bind=0
 		local default_ssl="off"
 		local force_gssapi="${FREENAS_LDAP_FORCE_GSSAPI:-1}"
 
+		# Do GSSAPI bind if SSL and Anonymous binding or
+		# disabled and we have a keytab + realm or
+		# if we have a keytab+realm and FORCE_GSSAPI is set.
 		if [ "${ldap_ssl:-$default_ssl}" = "start_tls" ]
 		then
-			allow_gssapi_bind=1
+			do_gssapi_bind=1
 			options="-Z"
 
-		elif [ "${ldap_ssl:-$default_ssl}" = "ssl" ]
+		elif [ "${ldap_ssl:-$default_ssl}" = "on" ]
 		then
-			allow_gssapi_bind=1
+			do_gssapi_bind=1
 		fi
 
 		if [ "${ldap_anonbind}" = "1" ]
 		then
-			allow_gssapi_bind=1
+			do_gssapi_bind=1
 		fi
 
-		if [ "force_gssapi" = "0" ]
+		if [ "${force_gssapi}" = "0" ]
 		then
-			allow_gssapi_bind=0
+			do_gssapi_bind=0
 		fi
 
-		if [ -n "${realm}" -a -n "${principal}" -a -n "${allow_gssapi_bind}" ]
+		if [ -n "${realm}" -a -n "${principal}" -a -n "${do_gssapi_bind}" ]
 		then
 			local temp=$(mktemp /tmp/tmp.XXXXXX)
 			local cmdfile=$(mktemp /tmp/tmp.XXXXXX)

--- a/src/freenas/etc/ix.rc.d/ix-ldap
+++ b/src/freenas/etc/ix.rc.d/ix-ldap
@@ -161,7 +161,7 @@ ldap_status()
 			do_gssapi_bind=0
 		fi
 
-		if [ -n "${realm}" -a -n "${principal}" -a "${do_gssapi_bind}" == 0 ]
+		if [ -n "${realm}" -a -n "${principal}" -a "${do_gssapi_bind}" -eq 0 ]
 		then
 			local temp=$(mktemp /tmp/tmp.XXXXXX)
 			local cmdfile=$(mktemp /tmp/tmp.XXXXXX)

--- a/src/freenas/etc/ix.rc.d/ix-ldap
+++ b/src/freenas/etc/ix.rc.d/ix-ldap
@@ -134,13 +134,31 @@ ldap_status()
 		local res=1
 		local ldapsearch=/usr/local/bin/ldapsearch
 		local options=
+		local allow_gssapi_bind=0
+		local default_ssl="off"
+		local force_gssapi="${FREENAS_LDAP_FORCE_GSSAPI:-1}"
 
-		if [ "${ldap_ssl}" = "start_tls" ]
+		if [ "${ldap_ssl:-$default_ssl}" = "start_tls" ]
 		then
+			allow_gssapi_bind=1
 			options="-Z"
+
+		elif [ "${ldap_ssl:-$default_ssl}" = "ssl" ]
+		then
+			allow_gssapi_bind=1
 		fi
 
-		if [ -n "${realm}" -a -n "${principal}" ]
+		if [ "${ldap_anonbind}" = "1" ]
+		then
+			allow_gssapi_bind=1
+		fi
+
+		if [ "force_gssapi" = "0" ]
+		then
+			allow_gssapi_bind=0
+		fi
+
+		if [ -n "${realm}" -a -n "${principal}" -a -n "${allow_gssapi_bind}" ]
 		then
 			local temp=$(mktemp /tmp/tmp.XXXXXX)
 			local cmdfile=$(mktemp /tmp/tmp.XXXXXX)


### PR DESCRIPTION
Previous behavior would always perform SASL_GSSAPI if
kerberos realm and keytab were selected in the LDAP form
in the UI. There are situations where kerberos should be
configured, but not used for actual LDAP binds. Decouple
when it makes sense to do so.

While Active Directory permits SASL binds to be performed
on an SSL/TLS-protected connection, it does not permit the
use of SASL-layer encryption/integrity verification
mechanisms on such a connection. While this restriction is
present in Active Directory on Windows 2000 Server
operating system and later, versions prior to Windows
Server 2008 operating system can fail to reject an LDAP
bind that is requesting SASL-layer encryption/integrity
verification mechanisms when that bind request is sent on a
SSL/TLS-protected connection. See MS-ADTS 5.1.1.1.2

Samba AD Domain controllers also require the following
smb.conf parameter in order to permit SASL_GSSAPI on an SSL/
TLS-protected connection:

'ldap server require strong auth = allow_sasl_over_tls'

This means that LDAP server support for SASL_GSSAPI on an SSL/
TLS-protected connection is unpredictable / undefined.

Add workaround if this combination is _required_ for environment
previous behavior can be restored by setting FREENAS_LDAP_FORCE_GSSAPI
to 1 in /etc/directoryservice/rc.DS_Common