### PR TITLE
NAS-103833 / 11.3 / Add error handling for duplicate gids when doing smb.groupmap_add

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -853,13 +853,13 @@ class GroupService(CRUDService):
 
         try:
             await self.middleware.call('smb.groupmap_add', data['name'])
-        except Exception as e:
+        except Exception:
             """
             Samba's group mapping database does not allow duplicate gids.
             Unfortunately, we don't get a useful error message at -d 0.
             """
             if not allow_duplicate_gid:
-                raise e
+                raise
             else:
                 self.logger.debug('Refusing to generate duplicate gid mapping in group_mapping.tdb: %s -> %s',
                                   data['name'], data['gid'])


### PR DESCRIPTION
Samba's group mapping database maps unix groups to nt groups. It doesn't allow duplicate
generating entries for groups with duplicate gids.  Add some error handling for when
smb.groupmap_add encounters this situation.

Unfortunately, net groupmap add doesn't output to stderr at -d 0 when it encounters
duplicate gids. Wrap smb.groupmap_add in a try / except and only
raise exception if allow_duplicate_gids is False. This indicates
a different error condition.