### PR TITLE
NAS-103895 / 12 / "allocation roundup size" was deprecated in Samba 4.11

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf
@@ -105,7 +105,6 @@
                 'aio max threads': '2',
                 'deadtime': '15',
                 'max log size': '51200',
-                'allocation roundup size': '0',
                 'load printers': 'No',
                 'printing': 'bsd',
                 'disable spoolss': 'Yes',


### PR DESCRIPTION
Remove this parameter from config. New default in Samba is 0.
This change reduces log spam.