### PR TITLE
NAS-103867 / 11.3 / Bug fixes for NIC VM device

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1432,12 +1432,13 @@ class InterfaceService(CRUDService):
         interfaces = self.middleware.call_sync('interface.query')
         choices = {i['name']: i['description'] or i['name'] for i in interfaces}
         for interface in interfaces:
+            if interface['description'] and interface['description'] != interface['name']:
+                choices[interface['name']] = f'{interface["name"]}: {interface["description"]}'
+
             for exclude in options['exclude']:
                 if interface['name'].startswith(exclude):
                     choices.pop(interface['name'], None)
                     continue
-            if interface['description'] and interface['description'] != interface['name']:
-                choices[interface['name']] = f'{interface["name"]}: {interface["description"]}'
             if not options['lag_ports']:
                 if interface['type'] == 'LINK_AGGREGATION':
                     for port in interface['lag_ports']:

--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -1274,9 +1274,7 @@ class VMDeviceService(CRUDService):
         """
         Available choices for NIC Attach attribute.
         """
-        return self.middleware.call_sync('interface.choices', {
-            'exclude': ['bridge', 'epair', 'tap', 'vnet'],
-        })
+        return self.middleware.call_sync('interface.choices', {'exclude': ['epair', 'tap', 'vnet']})
 
     @accepts()
     def vnc_bind_choices(self):

--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -394,6 +394,17 @@ class VMSupervisor(object):
         if tapname == attach_iface:
             raise CallError(f'VM cannot bridge with its own interface ({tapname}).')
 
+        interfaces = netif.list_interfaces()
+        if attach_iface and attach_iface not in interfaces:
+            raise CallError(f'Unable to find {attach_iface} interface.')
+        elif attach_iface and attach_iface.startswith('bridge'):
+            bridge = interfaces[attach_iface]
+            self.set_iface_mtu(bridge, tap)
+            bridge.add_member(tapname)
+            if netif.InterfaceFlags.UP not in bridge.flags:
+                bridge.up()
+            return
+
         if attach_iface is None:
             # XXX: backward compatibility prior to 11.1-RELEASE.
             try:


### PR DESCRIPTION
This PR fixes the following issues:

1) Makes sure correct choices are returned by `interface.choices`
2) Allow retrieving bridge for VM NIC attach choices
3) Make sure if user selected interface is a bridge interface, VM properly starts with the selected bridge interface