### PR TITLE
NAS-103923 / 11.2 / Fix parsing of ds config files

### DIFF
--- a/gui/common/system.py
+++ b/gui/common/system.py
@@ -102,7 +102,7 @@ def get_freenas_var_ds_config(f, var):
 
     for entry in ds_config:
         if entry.startswith(var):
-            return entry.lstrip(f'{var}=')[:-1]
+            return entry[len(var) + 1:-1]
 
     return False
 


### PR DESCRIPTION
We need to slice rather than lstrip. Variables are of form "var=", also remove trailing new line.