### PR TITLE
NAS-103867 / 12 / Bug fixes for NIC VM device (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1531,12 +1531,13 @@ class InterfaceService(CRUDService):
         interfaces = self.middleware.call_sync('interface.query')
         choices = {i['name']: i['description'] or i['name'] for i in interfaces}
         for interface in interfaces:
+            if interface['description'] and interface['description'] != interface['name']:
+                choices[interface['name']] = f'{interface["name"]}: {interface["description"]}'
+
             for exclude in options['exclude']:
                 if interface['name'].startswith(exclude):
                     choices.pop(interface['name'], None)
                     continue
-            if interface['description'] and interface['description'] != interface['name']:
-                choices[interface['name']] = f'{interface["name"]}: {interface["description"]}'
             if not options['lag_ports']:
                 if interface['type'] == 'LINK_AGGREGATION':
                     for port in interface['lag_ports']:

--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -1639,9 +1639,7 @@ class VMDeviceService(CRUDService):
         """
         Available choices for NIC Attach attribute.
         """
-        return self.middleware.call_sync('interface.choices', {
-            'exclude': ['bridge', 'epair', 'tap', 'vnet'],
-        })
+        return self.middleware.call_sync('interface.choices', {'exclude': ['epair', 'tap', 'vnet']})
 
     @accepts()
     def vnc_bind_choices(self):


### PR DESCRIPTION
This PR fixes the following issues:

1) Makes sure correct choices are returned by `interface.choices`
2) Allow retrieving bridge for VM NIC attach choices
3) Make sure if user selected interface is a bridge interface, VM properly starts with the selected bridge interface
4) Ensures pre start vms are rollbacked in case we have a failure for one device