### PR TITLE
NAS-103887 / 11.3 / Save iocage configs in BE

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -1361,6 +1361,9 @@ class JailService(CRUDService):
 
     @accepts()
     def save_configs(self):
+        """
+        Save current jail/template json configuration files to Boot Environments
+        """
         if not self.iocage_set_up():
             return
         self.check_dataset_existence()


### PR DESCRIPTION
This PR introduces changes which save default/jail/template configurations in boot environment before applying an update ensuring when the user rolls back, they have a way of bringing back their iocage jails.