### PR TITLE
NAS-103974 / 11.3 / Fix alerts not working when active controller is node B and standby c… (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -495,9 +495,10 @@ class AlertService(Service):
         run_failover_related = False
         if not await self.middleware.call("system.is_freenas"):
             if await self.middleware.call("failover.licensed"):
-                master_node = await self.middleware.call("failover.node")
+                if await self.middleware.call("failover.node") == "B":
+                    master_node = "B"
+                    backup_node = "A"
                 try:
-                    backup_node = await self.middleware.call("failover.call_remote", "failover.node")
                     remote_version = await self.middleware.call("failover.call_remote", "system.version")
                     remote_system_state = await self.middleware.call("failover.call_remote", "system.state")
                     remote_failover_status = await self.middleware.call("failover.call_remote",


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 142f694f075f51cc2cdb4f25d391e2ac75243ac0

…ontroller is down