### PR TITLE
NAS-104032 / 11.3 / Update SSL constant in ldap.py

### DIFF
--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -197,7 +197,7 @@ class LDAPQuery(object):
 
                     ldap.set_option(ldap.OPT_X_TLS_NEWCTX, 0)
 
-                if SSL(self.ldap['ssl']) == SSL.USETLS:
+                if SSL(self.ldap['ssl']) == SSL.USESTARTTLS:
                     try:
                         self._handle.start_tls_s()
 


### PR DESCRIPTION
I missed a minor difference between LDAP and AD forms when changing to use common enums for SSL parameters.