### PR TITLE
NAS-104035 / 11.3 / Add auto-configuration for kerberized NFS in AD environments

### DIFF
--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -725,6 +725,19 @@ class KerberosKeytabService(CRUDService):
 
         return keytab_entries
 
+    @accepts()
+    async def system_keytab_list(self):
+        """
+        Returns content of system keytab (/etc/krb5.keytab).
+        """
+        kt_list = await self._ktutil_list()
+        parsed = []
+        for entry in kt_list:
+            entry['date'] = time.mktime(entry['date'])
+            parsed.append(entry)
+
+        return parsed
+
     @private
     async def _get_nonsamba_principals(self, keytab_list):
         """

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -10,7 +10,7 @@ import sysctl
 from middlewared.common.attachment import FSAttachmentDelegate
 from middlewared.schema import accepts, Bool, Dict, Dir, Int, IPAddr, List, Patch, Str
 from middlewared.validators import Range
-from middlewared.service import private, CRUDService, SystemServiceService, ValidationErrors
+from middlewared.service import private, CRUDService, SystemServiceService, ValidationError, ValidationErrors
 from middlewared.utils.asyncio_ import asyncio_map
 from middlewared.utils.path import is_child
 
@@ -107,6 +107,28 @@ class NFSService(SystemServiceService):
                         "Enabling kerberos authentication on TrueNAS HA requires setting the virtual hostname and "
                         "domain"
                     )
+
+        if new["v4"] and new["v4_krb"] and await self.middleware.call('activedirectory.get_state') != "DISABLED":
+            """
+            In environments with kerberized NFSv4 enabled, we need to tell winbindd to not prefix
+            usernames with the short form of the AD domain. Directly update the db and regenerate
+            the smb.conf to avoid having a service disruption due to restarting the samba server.
+            """
+            if await self.middleware.call('smb.get_smb_ha_mode') == 'LEGACY':
+                raise ValidationError(
+                    'nfs_update.v4_krb',
+                    'Enabling kerberos authentication on TrueNAS HA requires '
+                    'the system dataset to be located on a data pool.'
+                )
+            ad = await self.middleware.call('activedirectory.config')
+            await self.middleware.call(
+                'datastore.update',
+                'directoryservice.activedirectory',
+                ad['id'],
+                {'ad_use_default_domain': True}
+            )
+            await self.middleware.call('etc.generate', 'smb')
+            await self.middleware.call('service.reload', 'cifs')
 
         if not new["v4"] and new["v4_v3owner"]:
             verrors.add("nfs_update.v4_v3owner", "This option requires enabling NFSv4")


### PR DESCRIPTION
Auto-register kerberos nfs spn. Configure winbindd to use default domain.