### PR TITLE
NAS-104097 / 11.3 / Validate that uploaded file is actually a keytab

### DIFF
--- a/gui/directoryservice/forms.py
+++ b/gui/directoryservice/forms.py
@@ -432,6 +432,9 @@ class KerberosKeytabCreateForm(ModelForm):
                     encoded = base64.b64encode(keytab_contents).decode()
                 os.unlink(filename)
 
+        with client as c:
+            c.call('kerberos.keytab.legacy_validate', encoded)
+
         return encoded
 
     def save(self):

--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -669,13 +669,12 @@ class KerberosKeytabService(CRUDService):
         'keytab_data',
         Str('name', required=True),
     ))
-    @job(lock='upload_keytab', pipes=['input'], check_pipes=False)
+    @job(lock='upload_keytab', pipes=['input'], check_pipes=True)
     async def upload_keytab(self, job, data):
         """
         Upload a keytab file. This method expects the keytab file to be uploaded using
         the /_upload/ endpoint.
         """
-        job.check_pipe("input")
         ktmem = io.BytesIO()
         await self.middleware.run_in_thread(shutil.copyfileobj, job.pipes.input.r, ktmem)
         b64kt = base64.b64encode(ktmem.getvalue())


### PR DESCRIPTION
Write out uploaded file to temporary location, validate with ktutil,
and then remove. Add new kerberos.keytab.upload method to WS API so
that users can choose to upload a keytab file, or create using a
b64encoded keytab and kerberos.keytab.create. Plumb in a legacy_validate
method into the legacy API so that we can catch keytab errors.