### PR TITLE
NAS-104140 / 11.2 / Validate path supplied to mp_change_permission

### DIFF
--- a/gui/middleware/notifier.py
+++ b/gui/middleware/notifier.py
@@ -1338,6 +1338,9 @@ class notifier(metaclass=HookMetaclass):
         if isinstance(path, bytes):
             path = path.decode('utf-8')
 
+        if not os.path.realpath(path).startswith('/mnt'):
+            raise MiddlewareError("mp_change_permissions - path not permitted: %s" % path)
+
         winacl = os.path.join(path, ACL_WINDOWS_FILE)
         macacl = os.path.join(path, ACL_MAC_FILE)
         winexists = (ACL.get_acl_ostype(path) == ACL_FLAGS_OS_WINDOWS)

--- a/gui/sharing/forms.py
+++ b/gui/sharing/forms.py
@@ -63,7 +63,7 @@ class CIFS_ShareForm(MiddlewareModelForm, ModelForm):
             self.fields['cifs_default_permissions'].initial = False
             self._original_cifs_vfsobjects = self.instance.cifs_vfsobjects
         else:
-            self.fields['cifs_default_permissions'].initial = True
+            self.fields['cifs_default_permissions'].initial = False
             self._original_cifs_vfsobjects = []
 
         key_order(self, 4, 'cifs_default_permissions', instance=True)

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -327,14 +327,14 @@ class SharingSMBService(CRUDService):
         List('vfsobjects', default=['zfs_space', 'zfsacl', 'streams_xattr']),
         Int('storage_task'),
         Str('auxsmbconf'),
-        Bool('default_permissions'),
+        Bool('default_permissions', default=False),
         register=True
     ))
     async def do_create(self, data):
         verrors = ValidationErrors()
         path = data['path']
 
-        default_perms = data.pop('default_permissions', True)
+        default_perms = data.pop('default_permissions', False)
 
         await self.clean(data, 'sharingsmb_create', verrors)
         await self.validate(data, 'sharingsmb_create', verrors)


### PR DESCRIPTION
We shouldn't change permissions for paths that aren't under /mnt.
Also change default for SMB apply default perms to False.