### PR TITLE
NAS-104149 / 11.3 / Lock recursive permissions changes into target directory

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -379,12 +379,15 @@ class FilesystemService(Service):
         return flagset
 
     def _winacl(self, path, action, uid, gid, options):
+        chroot_dir = os.path.dirname(path)
+        target = os.path.basename(path)
         winacl = subprocess.run([
             '/usr/local/bin/winacl',
             '-a', action,
             '-O', str(uid), '-G', str(gid),
             '-rx' if options['traverse'] else '-r',
-            '-p', path], check=False, capture_output=True
+            '-c', chroot_dir,
+            '-p', target], check=False, capture_output=True
         )
         if winacl.returncode != 0:
             CallError(f"Winacl {action} on path {path} failed with error: [{winacl.stderr.decode().strip()}]")


### PR DESCRIPTION
Remove FTS_LOGICAL flag. chroot the winacl process into the parent directory or the target.  Add an option for CLI users to perform a test-run of the permissions reset.