### PR TITLE
NAS-104166 / 11.3 / Stop jails on pool export

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -1513,7 +1513,7 @@ class JailFSAttachmentDelegate(FSAttachmentDelegate):
         else:
             if not activated_pool:
                 return results
-            if query_dataset.startswith(os.path.join(activated_pool, 'iocage')):
+            if activated_pool == query_dataset or query_dataset.startswith(os.path.join(activated_pool, 'iocage')):
                 for j in await self.middleware.call('jail.query', [('state', '=', 'up')]):
                     results.append({'id': j['host_hostuuid']})
 

--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -1525,7 +1525,7 @@ class JailFSAttachmentDelegate(FSAttachmentDelegate):
     async def delete(self, attachments):
         for attachment in attachments:
             try:
-                await self.middleware.call('jail.stop', attachment['id'])
+                await self.middleware.call('jail.stop', attachment['id'], True)
             except Exception:
                 self.middleware.logger.warning('Unable to jail.stop %r', attachment['id'], exc_info=True)
 


### PR DESCRIPTION
This PR introduces changes to make sure we stop jails when terminating processes for a given dataset ( if applicable ).