### PR TITLE
NAS-104204 / 12 / Add support more more quota types

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -4223,10 +4223,6 @@ class PoolDatasetService(CRUDService):
         )
         return filter_list(quota_list, filters, options)
 
-    @accepts()
-    async def quota_type_choices(self):
-        return ['DATASET', 'USER', 'USEROBJ', 'GROUP', 'GROUPOBJ']
-
     @accepts(
         Str('ds', required=True),
         List('quotas', items=[
@@ -4300,7 +4296,7 @@ class PoolDatasetService(CRUDService):
                     )
                     continue
 
-                if dataset_quotas.get(q['id'].lower(), None) is not None:
+                if dataset_quotas.get(q['id'].lower()) is not None:
                     verrors.add(
                         f'quotas.{i}.id',
                         f'Setting multiple values for {q["id"]} for quota_type "DATASET" is not permitted'

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -4183,19 +4183,19 @@ class PoolDatasetService(CRUDService):
         return data
 
     @accepts(
-        Str('id', required=True),
-        Str('quota_type', enum=['USER', 'GROUP']),
+        Str('ds', required=True),
+        Str('quota_type', enum=['USER', 'GROUP', 'DATASET']),
         Ref('query-filters'),
         Ref('query-options'),
     )
     @item_method
-    async def get_user_or_group_quota(self, id, quota_type, filters, options):
+    async def get_quota(self, ds, quota_type, filters, options):
         """
-        Return a list of the specified `type` of  quotas on the ZFS dataset `id`.
+        Return a list of the specified `quota_type` of  quotas on the ZFS dataset `ds`.
         Support `query-filters` and `query-options`. used_bytes and used_percentage
         may not instantly update as space is used.
 
-        Each quota entry has these fields:
+        When quota_type is not DATASET, each quota entry has these fields:
 
         `id` - the uid or gid to which the quota applies.
 
@@ -4206,52 +4206,80 @@ class PoolDatasetService(CRUDService):
         `quota` - the quota size in bytes.
 
         `used_bytes` - the amount of bytes the user has written to the dataset.
+        A value of zero means unlimited.
 
         `used_percentage` - the percentage of the user or group quota consumed.
+
+        `obj_quota` - the number of objects that may be owned by `id`.
+        A value of zero means unlimited.
+
+        'obj_used` - the nubmer of objects currently owned by `id`.
+
+        `obj_used_percent` - the percentage of the `obj_quota` currently used.
         """
-        dataset = (await self._get_instance(id))['name']
+        dataset = (await self._get_instance(ds))['name']
         quota_list = await self.middleware.call(
-            'zfs.dataset.get_user_or_group_quota', dataset, quota_type.lower()
+            'zfs.dataset.get_quota', dataset, quota_type.lower()
         )
         return filter_list(quota_list, filters, options)
 
+    @accepts()
+    async def quota_type_choices(self):
+        return ['DATASET', 'USER', 'USEROBJ', 'GROUP', 'GROUPOBJ']
+
     @accepts(
-        Str('id', required=True),
+        Str('ds', required=True),
         List('quotas', items=[
             Dict(
                 'quota_entry',
-                Str('quota_type', enum=['USER', 'GROUP'], required=True),
+                Str('quota_type',
+                    enum=['DATASET', 'USER', 'USEROBJ', 'GROUP', 'GROUPOBJ'],
+                    required=True),
                 Str('id', required=True),
-                Int('quota', required=True),
+                Int('quota_value', required=True, null=True),
             )
         ], default=[{
             'quota_type': 'USER',
             'id': '0',
-            'quota': 0
+            'quota_value': 0
         }])
     )
     @item_method
-    async def set_user_or_group_quota(self, id, data):
+    async def set_quota(self, ds, data):
         """
-        Set a user or group quota on the specified ZFS dataset. The quota limits
-        the amount of disk space consumed by files that are owned by the specified
-        users or groups.
+        There are three over-arching types of quotas for ZFS datasets.
+        1) dataset quotas and refquotas. If a DATASET quota type is specified in
+        this API call, then the API acts as a wrapper for `pool.dataset.update`.
 
-        `id` the name of the target ZFS dataset.
+        2) User and group quotas. These limit the amount of disk space consumed
+        by files that are owned by the specified users or groups. If the respective
+        "object quota" type is specfied, then the quota limits the number of objects
+        that may be owned by the specified user or group.
+
+        3) Project quotas. These limit the amount of disk space consumed by files
+        that are owned by the specified project. Project quotas are not yet implemended.
+
+        This API allows users to set multiple quotas simultaneously by submitting a
+        list of quotas. The list may contain all supported quota types.
+
+        `ds` the name of the target ZFS dataset.
 
         `quotas` specifies a list of `quota_entry` entries to apply to dataset.
 
         `quota_entry` entries have these required parameters:
 
-        `type`: specifies whether the quota applies to a user or a group.
+        `quota_type`: specifies the type of quota to apply to the dataset. Possible
+        values are USER, USEROBJ, GROUP, GROUPOBJ, and DATASET. USEROBJ and GROUPOBJ
+        quotas limit the number of objects consumed by the specified user or group.
 
-        `id`: the uid, gid, or name to which the quota applies.
+        `id`: the uid, gid, or name to which the quota applies. If quota_type is
+        'DATASET', then `id` must be either `QUOTA` or `REFQUOTA`.
 
-        `quota`: the quota size in bytes. Setting a value of `0` removes
+        `quota_value`: the quota size in bytes. Setting a value of `0` removes
         the user or group quota.
         """
         MAX_QUOTAS = 100
-        dataset = (await self._get_instance(id))['name']
+        dataset = (await self._get_instance(ds))['name']
         verrors = ValidationErrors()
         if len(data) > MAX_QUOTAS:
             verrors.add(
@@ -4260,33 +4288,69 @@ class PoolDatasetService(CRUDService):
             )
 
         quota_list = []
+        dataset_quotas = {}
+
         for i, q in enumerate(data):
             quota_type = q["quota_type"].lower()
-            if not q["id"].isdigit():
-                try:
-                    await self.middleware.call(f'{quota_type}.get_{quota_type}_obj',
-                                               {f'{quota_type}name': q["id"]})
-                except Exception:
+            if q["quota_type"] == 'DATASET':
+                if q['id'] not in ['QUOTA', 'REFQUOTA']:
                     verrors.add(
                         f'quotas.{i}.id',
-                        f'{quota_type} {q["id"]} is not valid.'
+                        f'id for quota_type DATASET must be either "QUOTA" or "REFQUOTA"'
                     )
-            else:
-                id_type = 'uid' if quota_type == 'user' else 'gid'
-                try:
-                    await self.middleware.call(f'{quota_type}.get_{quota_type}_obj',
-                                               {id_type: q["id"]})
-                except Exception:
+                    continue
+
+                if dataset_quotas.get(q['id'].lower(), None) is not None:
                     verrors.add(
                         f'quotas.{i}.id',
-                        f'{quota_type} {q["id"]} is not valid.'
+                        f'Setting multiple values for {q["id"]} for quota_type "DATASET" is not permitted'
+                    )
+                    continue
+
+                dataset_quotas.update({
+                    q['id'].lower(): q['quota_value']
+                })
+
+                continue
+
+            if q["quota_type"] not in ['PROJECT', 'PROJECTOBJ']:
+                if q['quota_value'] is None:
+                    q['quota_value'] = 'none'
+
+                if not q["id"].isdigit():
+                    try:
+                        await self.middleware.call(f'{quota_type}.get_{quota_type}_obj',
+                                                   {f'{quota_type}name': q["id"]})
+                    except Exception:
+                        verrors.add(
+                            f'quotas.{i}.id',
+                            f'{quota_type} {q["id"]} is not valid.'
+                        )
+                else:
+                    id_type = ('user', 'uid') if 'user' in quota_type else ('group', 'gid')
+                    try:
+                        await self.middleware.call(f'{id_type[0]}.get_{id_type[0]}_obj',
+                                                   {id_type[1]: q["id"]})
+                    except Exception:
+                        verrors.add(
+                            f'quotas.{i}.id',
+                            f'{quota_type} {q["id"]} is not valid.'
+                        )
+            else:
+                if not q["id"].isdigit():
+                    verrors.add(
+                        f'quotas.{i}.id',
+                        f'{quota_type} {q["id"]} must be a numeric project id.'
                     )
 
-            quota_list.append(f'{quota_type}quota@{q["id"]}={q["quota"]}')
+            quota_list.append(f'{quota_type}quota@{q["id"]}={q["quota_value"]}')
 
         verrors.check()
-        await self.middleware.call('zfs.dataset.set_user_or_group_quota',
-                                   dataset, quota_list)
+        if dataset_quotas:
+            await self.update(ds, dataset_quotas)
+
+        if quota_list:
+            await self.middleware.call('zfs.dataset.set_quota', dataset, quota_list)
 
     @accepts(Str('pool'))
     async def recommended_zvol_blocksize(self, pool):


### PR DESCRIPTION
Rename get_user_or_group_quota and set_user_or_group_quota to simply get_quota and set_quota. Add support for USEROBJQUOTA, GROUPOBJQUOTA, and DATASET quotas. Lay foundation for project quotas as well, but don't expose yet. DATASET quotas are a wrapper around existing code related to dataset quota and refquota.