### PR TITLE
NAS-104216 / 11.2 / ensure 'progressfile' isn't empty

### DIFF
--- a/src/middlewared/middlewared/plugins/replication.py
+++ b/src/middlewared/middlewared/plugins/replication.py
@@ -52,7 +52,6 @@ class ReplicationService(CRUDService):
         progressfile = f'/tmp/.repl_progress_{data["id"]}'
         if os.path.exists(progressfile):
             with open(progressfile, 'r') as f:
-                f.seek(0)
                 pid = f.read().strip()
 
             if len(pid) > 0:

--- a/src/middlewared/middlewared/plugins/replication.py
+++ b/src/middlewared/middlewared/plugins/replication.py
@@ -52,14 +52,18 @@ class ReplicationService(CRUDService):
         progressfile = f'/tmp/.repl_progress_{data["id"]}'
         if os.path.exists(progressfile):
             with open(progressfile, 'r') as f:
-                pid = int(f.read())
-            title = await self.middleware.call('notifier.get_proc_title', pid)
-            if title:
-                reg = re.search(r'sending (\S+) \((\d+)%', title)
-                if reg:
-                    data['status'] = f'Sending {reg.groups()[0]}s {reg.groups()[1]}s'
-                else:
-                    data['status'] = 'Sending'
+                f.seek(0)
+                pid = f.read().strip()
+
+            if len(pid) > 0:
+                pid = int(pid)
+                title = await self.middleware.call('notifier.get_proc_title', pid)
+                if title:
+                    reg = re.search(r'sending (\S+) \((\d+)%', title)
+                    if reg:
+                        data['status'] = f'Sending {reg.groups()[0]}s {reg.groups()[1]}s'
+                    else:
+                        data['status'] = 'Sending'
 
         if 'status' not in data:
             data['status'] = data['lastresult'].get('msg')


### PR DESCRIPTION
NAS-104216

`* Active Controller - Unable to run alert source 'Replication'
Traceback (most recent call last):
File "/usr/local/lib/python3.6/site-packages/middlewared/plugins/alert.py", line 469, in __run_source
alerts = (await alert_source.check()) or []
.....`
`
File "/usr/local/lib/python3.6/site-packages/middlewared/plugins/replication.py", line 55, in replication_extend
pid = int(f.read())
ValueError: invalid literal for int() with base 10: ''`