### PR TITLE
NAS-104248 / 11.3 / Disable support for SMB EAs by default

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4_share.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4_share.conf
@@ -173,7 +173,8 @@
                     "nfs4:chown": "true",
                     "nfs4:acedup": "merge",
                     "aio write size": "0",
-                    "mangled names": "illegal"
+                    "mangled names": "illegal",
+                    "ea support": "false",
                 })
 
                 for param in share['auxsmbconf'].splitlines():


### PR DESCRIPTION
Disabling EA support improves readdir performance by a significant
margin in testing. These are for legacy EAs. Support for alternate
data streams and DOSATTRIB xattrs is not impacted by turning this off.