### PR TITLE
NAS-104269 / 11.2 / raise custom exception and log it

### DIFF
--- a/src/middlewared/middlewared/client/client.py
+++ b/src/middlewared/middlewared/client/client.py
@@ -18,9 +18,7 @@ import sys
 import threading
 import time
 import uuid
-import logging
 
-log = logging.getLogger('middlewared.client')
 
 class Event(TEvent):
 
@@ -165,7 +163,6 @@ class WSClient(WebSocketClient):
             else:
                 break
         if fd < 0:
-            log.debug('Failed to reserve a privileged port')
             raise ReserveFDException()
         return fd
 

--- a/src/middlewared/middlewared/client/client.py
+++ b/src/middlewared/middlewared/client/client.py
@@ -18,7 +18,9 @@ import sys
 import threading
 import time
 import uuid
+import logging
 
+log = logging.getLogger('middlewared.client')
 
 class Event(TEvent):
 
@@ -46,6 +48,10 @@ class Event(TEvent):
 
 
 CALL_TIMEOUT = int(os.environ.get('CALL_TIMEOUT', 60))
+
+
+class ReserveFDException(Exception):
+    pass
 
 
 class WSClient(WebSocketClient):
@@ -159,7 +165,8 @@ class WSClient(WebSocketClient):
             else:
                 break
         if fd < 0:
-            raise ValueError('Failed to reserv a privileged port')
+            log.debug('Failed to reserve a privileged port')
+            raise ReserveFDException()
         return fd
 
     def connect(self):

--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -401,6 +401,7 @@ class AlertService(Service):
                         else:
                             raise
                 except ReserveFDException:
+                    self.logger.debug('Failed to reserve a privileged port')
                     pass
 
                 except Exception:

--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -402,7 +402,6 @@ class AlertService(Service):
                             raise
                 except ReserveFDException:
                     self.logger.debug('Failed to reserve a privileged port')
-                    pass
 
                 except Exception:
                     alerts_b = [

--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -20,6 +20,7 @@ from middlewared.alert.base import (
     ProThreadedAlertService
 )
 from middlewared.alert.base import UnavailableException, AlertService as _AlertService
+from middlewared.client.client import ReserveFDException
 from middlewared.schema import Dict, Str, Bool, Int, accepts, Patch
 from middlewared.service import (
     ConfigService, CRUDService, Service, ValidationErrors,
@@ -399,6 +400,9 @@ class AlertService(Service):
                             pass
                         else:
                             raise
+                    except ReserveFDException:
+                        pass
+
                 except Exception:
                     alerts_b = [
                         Alert(title="Unable to run alert source %(source_name)r on backup node\n%(traceback)s",

--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -400,8 +400,8 @@ class AlertService(Service):
                             pass
                         else:
                             raise
-                    except ReserveFDException:
-                        pass
+                except ReserveFDException:
+                    pass
 
                 except Exception:
                     alerts_b = [


### PR DESCRIPTION
We have a customer where this ValueError is being raised in `get_reserved_portfd` so all `hardware = True` related alerts are being sent to proactive support because the customer has a gold contract. This single system has opened up > 250 support tickets with us.

All 250+ tickets are being generated because of that custom ValueError. I change it so that we raise a custom exception and simply log it.