### PR TITLE
NAS-104269 / 11.3 / raise custom exception and log it (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/client/client.py
+++ b/src/middlewared/middlewared/client/client.py
@@ -55,6 +55,10 @@ class Event(TEvent):
 CALL_TIMEOUT = int(os.environ.get('CALL_TIMEOUT', 60))
 
 
+class ReserveFDException(Exception):
+    pass
+
+
 class WSClient(WebSocketClient):
     def __init__(self, url, *args, **kwargs):
         self.client = kwargs.pop('client')
@@ -166,7 +170,7 @@ class WSClient(WebSocketClient):
             else:
                 break
         if fd < 0:
-            raise ValueError('Failed to reserv a privileged port')
+            raise ReserveFDException()
         return fd
 
     def connect(self):

--- a/src/middlewared/middlewared/plugins/alert.py
+++ b/src/middlewared/middlewared/plugins/alert.py
@@ -24,6 +24,7 @@ from middlewared.alert.base import (
     ProThreadedAlertService,
 )
 from middlewared.alert.base import UnavailableException, AlertService as _AlertService
+from middlewared.client.client import ReserveFDException
 from middlewared.schema import Any, Bool, Dict, Int, Str, accepts, Patch, Ref
 from middlewared.service import (
     ConfigService, CRUDService, Service, ValidationErrors,
@@ -565,6 +566,8 @@ class AlertService(Service):
                             pass
                         else:
                             raise
+                except ReserveFDException:
+                    self.logger.debug('Failed to reserve a privileged port')
                 except Exception:
                     alerts_b = [
                         Alert(AlertSourceRunFailedOnBackupNodeAlertClass,


### PR DESCRIPTION
We have a customer where this ValueError is being raised in `get_reserved_portfd` so all `hardware = True` related alerts are being sent to proactive support because the customer has a gold contract. This single system has opened up > 250 support tickets with us.

All 250+ tickets are being generated because of that custom ValueError. I change it so that we raise a custom exception and simply log it.