### PR TITLE
NAS-104356 / 11.3 / Make sure we don't error out with multiple iocage pools

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -1280,7 +1280,7 @@ class JailService(CRUDService):
     def activate(self, pool):
         """Activates a pool for iocage usage, and deactivates the rest."""
         pool = self.middleware.call_sync('pool.query', [['name', '=', pool]], {'get': True})
-        iocage = ioc.IOCage(reset_cache=True)
+        iocage = ioc.IOCage(reset_cache=True, activate=True)
         try:
             iocage.activate(pool['name'])
         except Exception as e:


### PR DESCRIPTION
When we import a pool, it's possible that pool was already configured with iocage. In this case if system had a pool configured before we imported this pool, system gives preference to the already configured pool. User can of course later change this to whichever pool he/she wants configured with iocage