### PR TITLE
NAS-104438 / 11.3 / Pass new ldap credentials to ldap.validate_credentials

### DIFF
--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -448,7 +448,7 @@ class LDAPService(ConfigService):
         port = 636 if SSL(ldap['ssl']) == SSL.USESSL else 389
         for h in ldap['hostname']:
             await self.middleware.call('ldap.port_is_listening', h, port, ldap['dns_timeout'])
-        await self.middleware.call('ldap.validate_credentials')
+        await self.middleware.call('ldap.validate_credentials', ldap)
 
     @accepts(Dict(
         'ldap_update',


### PR DESCRIPTION
LDAP module was failing to properly validate credenitals until
after they were written to the config.