### PR TITLE
NAS-104491 / 11.3 / Do not treat failure to properly configure for kerberized NFS as fatal

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -980,7 +980,13 @@ class ActiveDirectoryService(ConfigService):
                     f'nfs/{ad["netbiosname"].upper()}'
                 ])
                 if must_update_trust_pw:
-                    await self.change_trust_account_pw()
+                    try:
+                        await self.change_trust_account_pw()
+                    except Exception as e:
+                        self.logger.debug(
+                            "Failed to change trust password after setting NFS SPN: [%s]."
+                            "This may impact kerberized NFS sessions until the next scheduled trust account password change", e
+                        )
 
                 kt_id = await self.middleware.call('kerberos.keytab.store_samba_keytab')
                 if kt_id:
@@ -1277,7 +1283,8 @@ class ActiveDirectoryService(ConfigService):
         Force an update of the AD machine account password. This can be used to
         refresh the Kerberos principals in the server's system keytab.
         """
-        netads = await run([SMBCmd.NET.value, '-k', 'ads', 'changetrustpw'], check=False)
+        workgroup = (await self.middleware.call('smb.config'))['workgroup']
+        netads = await run([SMBCmd.NET.value, '-k', 'ads', '-w', workgroup, 'changetrustpw'], check=False)
         if netads.returncode != 0:
             raise CallError(
                 f"Failed to update trust password: [{netads.stderr.decode().strip()}]"


### PR DESCRIPTION
In some environments, the call to change trust password (which regenerates
the local kerberos keytab) will fail unless workgroup information is passed
to the 'net' call. In general, a failure to change the trust password
at this stage can be ignored relatively safely. It may have temporary
impact on users with kerberized NFS until the next automatic password change.
So we will catch the error, log it, and continue.