### PR TITLE
fix(middlewared/filesystem): increase file_receive size limit

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -206,7 +206,7 @@ class FilesystemService(Service):
     @private
     @accepts(
         Str('path'),
-        Str('content', max_length=512000),
+        Str('content', max_length=2048000),
         Dict(
             'options',
             Bool('append', default=False),


### PR DESCRIPTION
This is used in failover plugin to transfer database.