### PR TITLE
NAS-104471 / 11.2 / fix proactive support ticket generation spam

### DIFF
--- a/src/middlewared/middlewared/alert/source/volume_status.py
+++ b/src/middlewared/middlewared/alert/source/volume_status.py
@@ -1,4 +1,8 @@
+import logging
+
 from middlewared.alert.base import Alert, AlertLevel, AlertSource
+
+log = logging.getLogger("volume_status_alert")
 
 
 class VolumeStatusAlertSource(AlertSource):
@@ -37,7 +41,10 @@ class VolumeStatusAlertSource(AlertSource):
 
     async def enabled(self):
         if not (await self.middleware.call("system.is_freenas")):
-            status = await self.middleware.call("notifier.failover_status")
-            return status in ("MASTER", "SINGLE")
-
+            try:
+                status = await self.middleware.call("notifier.failover_status")
+                return status in ("MASTER", "SINGLE")
+            except Exception:
+                log.debug('notifier.failover_status failed with error: {e}')
+                return False
         return True

--- a/src/middlewared/middlewared/alert/source/volume_status.py
+++ b/src/middlewared/middlewared/alert/source/volume_status.py
@@ -44,7 +44,7 @@ class VolumeStatusAlertSource(AlertSource):
             try:
                 status = await self.middleware.call("notifier.failover_status")
                 return status in ("MASTER", "SINGLE")
-            except Exception:
-                log.debug('notifier.failover_status failed with error: {e}')
+            except Exception as e:
+                log.debug(f'notifier.failover_status failed with error: {e}')
                 return False
         return True


### PR DESCRIPTION
iX support is continually getting proactive support tickets opened up (100's over the past week or so for this one customer because they are in production and cannot make any changes to their system) with the following traceback.

`* Unable to run alert source 'VolumeStatus'
Traceback (most recent call last):
File "/usr/local/lib/python3.6/site-packages/middlewared/plugins/alert.py", line 469, in __run_source
alerts = (await alert_source.check()) or []
File "/usr/local/lib/python3.6/site-packages/middlewared/plugins/../alert/source/volume_status.py", line 11, in check
if not await self.enabled():
File "/usr/local/lib/python3.6/site-packages/middlewared/plugins/../alert/source/volume_status.py", line 40, in enabled
status = await self.middleware.call("notifier.failover_status")
File "/usr/local/lib/python3.6/site-packages/middlewared/main.py", line 1102, in call
return await self._call(name, serviceobj, methodobj, params, app=app, pipes=pipes, io_thread=True)
File "/usr/local/lib/python3.6/site-packages/middlewared/main.py", line 1060, in _call
return await run_method(methodobj, *args)
File "/usr/local/lib/python3.6/site-packages/middlewared/main.py", line 1006, in run_in_thread
return await self.loop.run_in_executor(executor, functools.partial(method, *args, **kwargs))
File "/usr/local/lib/python3.6/concurrent/futures/thread.py", line 56, in run
result = self.fn(*self.args, **self.kwargs)
File "/usr/local/www/freenasUI/failover/notifier.py", line 115, in failover_status
'SELECT '
sqlite3.OperationalError: database is locked`