### PR TITLE
NAS-104596 / 11.3 / Do not create pwenc secret file during update

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-update
+++ b/src/freenas/etc/ix.rc.d/ix-update
@@ -52,6 +52,9 @@ handle_error()
 
 	rm -f $NEED_UPDATE_SENTINEL
 	mv ${FREENAS_CONFIG}.bak ${FREENAS_CONFIG}
+	if [ -f /data/pwenc_secret.bak ]; then
+		mv /data/pwenc_secret.bak /data/pwenc_secret
+	fi
 	if [ -f $CD_UPGRADE_SENTINEL ]; then
 		rm $CD_UPGRADE_SENTINEL
 		cat <<EOF
@@ -111,6 +114,14 @@ db_update()
 	if [ -f /data/uploaded.db ]; then
 		echo "Moving uploaded config to ${FREENAS_CONFIG}"
 		mv /data/uploaded.db ${FREENAS_CONFIG}
+		if [ -f /data/pwenc_secret_uploaded ]; then
+			if [ -f /data/pwenc_secret ]; then
+				echo "Saving current pwenc secret to /data/pwenc_secret.bak"
+				cp /data/pwenc_secret /data/pwenc_secret.bak
+			fi
+			echo "Moving uploaded pwenc secret to /data/pwenc_secret"
+			mv /data/pwenc_secret_uploaded /data/pwenc_secret
+		fi
 		IS_UPLOAD=1
 	fi
 

--- a/src/middlewared/middlewared/plugins/config.py
+++ b/src/middlewared/middlewared/plugins/config.py
@@ -163,6 +163,8 @@ class ConfigService(Service):
                             shutil.move(
                                 os.path.join(file_path, key_path), os.path.join(destination, key_path)
                             )
+                    elif filename == 'pwenc_secret':
+                        shutil.move(file_path, '/data/pwenc_secret_uploaded')
                     else:
                         shutil.move(file_path, destination)
 


### PR DESCRIPTION
This commit fixes an issue where we create pwenc_secret file again during the phase where the system requires update.