### PR TITLE
NAS-104617 / 11.3 / Prevent enumeration of user and group list on anonymous connections

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf
@@ -129,6 +129,8 @@
                 pc.update({'guest account': db['cifs']['guest']})
             if db['guest_enabled']:
                 pc.update({'map to guest': 'Bad User'})
+            else:
+                pc.update({'restrict anonymous': '2'})
             if db['cifs']['ntlmv1_auth']:
                 pc.update({'ntlm auth': 'Yes'})
                 pc.update({'client ntlmv2 auth': 'No'})


### PR DESCRIPTION
Some security scanners have started to flag this as an issue. Disable
anyonmous IPC$ access unless guest shares are enabled.