### PR TITLE
NAS-104628 / 11.3 / Fix swap allocation issues

### DIFF
--- a/src/middlewared/middlewared/plugins/disk.py
+++ b/src/middlewared/middlewared/plugins/disk.py
@@ -1399,7 +1399,16 @@ class DiskService(CRUDService):
 
         used_partitions = set()
         swap_devices = []
+        boot_disks = await self.middleware.call('boot.get_disks')
         disks = [i async for i in await self.middleware.call('pool.get_disks')]
+        disks.extend(boot_disks)
+        existing_swap_devices = {'mirrors': [], 'partitions': []}
+        for i in getswapinfo():
+            if i.devname.startswith('mirror/'):
+                existing_swap_devices['mirrors'].append(i.devname)
+            else:
+                existing_swap_devices['partitions'].append(i.devname)
+
         klass = geom.class_by_name('MIRROR')
         if klass:
             for g in klass.geoms:


### PR DESCRIPTION
This PR introduces following fixes:

1) Make sure boot disks are used for swap if they have swap partition available.
2) Only try to configure swap for a mirror if it's not already being used for swap
3) Make sure single partition is able to turn into a mirror if same size other partition is available
4) Ensure mirrors + partitions at the same time is not possible for swap space giving priority to the former when it exists.