### PR TITLE
NAS-104645 / 11.3 / Do not attempt to remove machine account keytab in legacy HA mode

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -1455,6 +1455,7 @@ class ActiveDirectoryService(ConfigService):
         """
         ad = await self.config()
         principal = f'{data["username"]}@{ad["domainname"]}'
+        smb_ha_mode = await self.middleware.call('smb.get_smb_ha_mode')
         ad_kinit = await Popen(
             ['/usr/bin/kinit', '--renewable', '--password-file=STDIN', principal],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE
@@ -1467,12 +1468,14 @@ class ActiveDirectoryService(ConfigService):
         if netads.returncode != 0:
             raise CallError(f"Failed to leave domain: [{netads.stderr.decode()}]")
 
-        krb_princ = await self.middleware.call(
-            'kerberos.keytab.query',
-            [('name', '=', 'AD_MACHINE_ACCOUNT')],
-            {'get': True}
-        )
-        await self.middleware.call('kerberos.keytab.delete', krb_princ['id'])
+        if smb_ha_mode != 'LEGACY':
+            krb_princ = await self.middleware.call(
+                'kerberos.keytab.query',
+                [('name', '=', 'AD_MACHINE_ACCOUNT')],
+                {'get': True}
+            )
+            await self.middleware.call('kerberos.keytab.delete', krb_princ['id'])
+
         await self.middleware.call('datastore.delete', 'directoryservice.kerberosrealm', ad['kerberos_realm'])
         await self.middleware.call('activedirectory.stop')
 


### PR DESCRIPTION
Middleware doesn't use a machine account keytab in Legacy HA mode.