### PR TITLE
fix(middlewared/network): waiting dhcp

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1731,9 +1731,9 @@ class InterfaceService(CRUDService):
 
             # If there are no interfaces configured we start DHCP on all
             if not interfaces:
-                fut = await self.middleware.call('interface.autoconfigure', iface, wait_dhcp)
-                if fut is not None:
-                    dhclient_aws.append(fut)
+                dhclient_aws.append(asyncio.ensure_future(
+                    self.middleware.call('interface.autoconfigure', iface, wait_dhcp)
+                ))
             else:
                 # Destroy interfaces which are not in database
 


### PR DESCRIPTION
```
[2020/01/07 08:05:32] (WARNING) application.call_method():174 - Exception while calling interfaces.sync(*[True])
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/middlewared/main.py", line 136, in call_method
    result = await self.middleware.call_method(self, message)
  File "/usr/local/lib/python3.7/site-packages/middlewared/main.py", line 1178, in call_method
    return await self._call(message['method'], serviceobj, methodobj, params, app=app, io_thread=False)
  File "/usr/local/lib/python3.7/site-packages/middlewared/main.py", line 1126, in _call
    return await methodobj(*args)
  File "/usr/local/lib/python3.7/site-packages/middlewared/plugins/network.py", line 1747, in sync
    await asyncio.wait(dhclient_aws, timeout=30)
  File "/usr/local/lib/python3.7/asyncio/tasks.py", line 387, in wait
    fs = {ensure_future(f, loop=loop) for f in set(fs)}
  File "/usr/local/lib/python3.7/asyncio/tasks.py", line 387, in <setcomp>
    fs = {ensure_future(f, loop=loop) for f in set(fs)}
  File "/usr/local/lib/python3.7/asyncio/tasks.py", line 619, in ensure_future
    raise TypeError('An asyncio.Future, a coroutine or an awaitable is '
TypeError: An asyncio.Future, a coroutine or an awaitable is required
```