### PR TITLE
Fix smb.getparm for registry config

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -225,8 +225,11 @@ class SMBService(SystemServiceService):
         conditions without returning the parameter's value.
         """
         try:
-            res = param.LoadParm(SMBPath.GLOBALCONF.platform()).get(parm, section)
-            return res
+            if section.upper() == 'GLOBAL':
+                return param.LoadParm(SMBPath.GLOBALCONF.platform()).get(parm, section)
+            else:
+                return self.middleware.call_sync('sharing.smb.reg_getparm', section, parm)
+
         except Exception as e:
             raise CallError(f'Attempt to query smb4.conf parameter [{parm}] failed with error: {e}')
 


### PR DESCRIPTION
param.LoadParm().get() in samba doesn't return values for registry shares.
Have smb.getparm call "net conf getparm" for non-global sections, and give
same return types as param.LoadParm().get().