### PR TITLE
NAS-104663 / 12.0 / Donot check vcenter migrations when determining newer config

### DIFF
--- a/src/middlewared/middlewared/plugins/config.py
+++ b/src/middlewared/middlewared/plugins/config.py
@@ -134,7 +134,7 @@ class ConfigService(Service):
                 )
                 new_numsouth = cur.fetchone()[0]
                 cur.execute(
-                    "SELECT COUNT(*) FROM django_migrations WHERE app != 'freeadmin'"
+                    "SELECT COUNT(*) FROM django_migrations WHERE app != 'freeadmin' and app != 'vcp'"
                 )
                 new_num = cur.fetchone()[0]
                 cur.close()
@@ -148,7 +148,7 @@ class ConfigService(Service):
                 )
                 numsouth = cur.fetchone()[0]
                 cur.execute(
-                    "SELECT COUNT(*) FROM django_migrations WHERE app != 'freeadmin'"
+                    "SELECT COUNT(*) FROM django_migrations WHERE app != 'freeadmin' and app != 'vcp'"
                 )
                 num = cur.fetchone()[0]
                 cur.close()
@@ -159,9 +159,9 @@ class ConfigService(Service):
                         'Failed to upload config, version newer than the '
                         'current installed.'
                     )
-        except Exception:
+        except Exception as e:
             os.unlink(config_file_name)
-            raise CallError('The uploaded file is not valid.')
+            raise CallError(f'The uploaded file is not valid: {e}')
 
         shutil.move(config_file_name, '/data/uploaded.db')
         if bundle:


### PR DESCRIPTION
This commit fixes an issue where when we uploaded a config of a system which was upgraded to 11.3 from 11.2 and the host currently is a 11.3 fresh install system, db checks fail as we took into account vcenter app migrations which made the uploaded config invalid by declaring it newer then the current one.