### PR TITLE
NAS-104579 / 12.0 / Shell choices fixes

### DIFF
--- a/nas_ports/freenas/freenas-files/Makefile
+++ b/nas_ports/freenas/freenas-files/Makefile
@@ -72,6 +72,7 @@ do-install:
 	#
 	${CP} -a ${WRKSRC}/freenas/ ${STAGEDIR}/
 	(cd ${STAGEDIR}; ${FIND} . \( -type f -o -type l \) \
+		| ${GREP} -v "/netcli.sh" \
 		| ${SED} -e 's,^\./,,g' \
 		| ${AWK} '{print length, $$0}' | ${SORT} -rn \
 		| ${AWK} '{$$1=""; sub(/^[ \t]+/, ""); print $$0}' >> ${TMPPLIST})

--- a/nas_ports/freenas/freenas-files/pkg-plist
+++ b/nas_ports/freenas/freenas-files/pkg-plist
@@ -1,1 +1,1 @@
-@shell etc/netcli.sh
+@shell /etc/netcli.sh

--- a/src/middlewared/middlewared/alembic/versions/12.0/2020-01-15_21-13_fix_shell_choices.py
+++ b/src/middlewared/middlewared/alembic/versions/12.0/2020-01-15_21-13_fix_shell_choices.py
@@ -1,0 +1,29 @@
+"""Fix user shell choices
+
+Revision ID: a7f13f81a210
+Revises: 133f2d9049d2
+Create Date: 2020-01-15 21:13:01.570666+00:00
+
+"""
+import json
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'a7f13f81a210'
+down_revision = '133f2d9049d2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    conn.execute('UPDATE account_bsdUsers SET bsdusr_shell = ? WHERE bsdusr_shell = ?', (
+        '/etc/netcli.sh', '//etc/netcli.sh'
+    ))
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/alembic/versions/12.0/2020-01-15_21-13_fix_shell_choices.py
+++ b/src/middlewared/middlewared/alembic/versions/12.0/2020-01-15_21-13_fix_shell_choices.py
@@ -5,8 +5,6 @@ Revises: 133f2d9049d2
 Create Date: 2020-01-15 21:13:01.570666+00:00
 
 """
-import json
-
 from alembic import op
 
 

--- a/src/middlewared/middlewared/alembic/versions/12.0/2020-01-15_21-13_fix_shell_choices.py
+++ b/src/middlewared/middlewared/alembic/versions/12.0/2020-01-15_21-13_fix_shell_choices.py
@@ -1,7 +1,7 @@
 """Fix user shell choices
 
-Revision ID: a7f13f81a210
-Revises: 133f2d9049d2
+Revision ID: f3875acb8d76
+Revises: 39a133a04496
 Create Date: 2020-01-15 21:13:01.570666+00:00
 
 """
@@ -9,8 +9,8 @@ from alembic import op
 
 
 # revision identifiers, used by Alembic.
-revision = 'a7f13f81a210'
-down_revision = '133f2d9049d2'
+revision = 'f3875acb8d76'
+down_revision = '39a133a04496'
 branch_labels = None
 depends_on = None
 

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -713,6 +713,11 @@ class UserService(CRUDService):
                 'The ":" character is not allowed in a "Full Name".'
             )
 
+        if 'shell' in data and data['shell'] not in await self.middleware.call('user.shell_choices', pk):
+            verrors.add(
+                f'{schema}.shell', 'Please select a valid shell.'
+            )
+
     async def __set_password(self, data):
         if 'password' not in data:
             return

--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -496,14 +496,14 @@ class UserService(CRUDService):
 
         return pk
 
-    @accepts(Int('oid', default=None))
-    def shell_choices(self, oid=None):
+    @accepts(Int('user_id', default=None))
+    def shell_choices(self, user_id=None):
         """
         Return the available shell choices to be used in `user.create` and `user.update`.
 
-        If `oid` is provided, shell choices are filtered to ensure the user can access the shell choices provided.
+        If `user_id` is provided, shell choices are filtered to ensure the user can access the shell choices provided.
         """
-        user = self.middleware.call_sync('user.get_instance', oid) if oid else None
+        user = self.middleware.call_sync('user.get_instance', user_id) if user_id else None
         with open('/etc/shells', 'r') as f:
             shells = [x.rstrip() for x in f.readlines() if x.startswith('/')]
         return {


### PR DESCRIPTION
This PR introduces following changes:

1) Exposes a knob to ensure that consumers of middlewared are able to retrieve shell choices by specifying a user id. This ensures that netcli is not returned for non-root users.
2) Fixes a bug where` netcli.sh` path in `/etc/shells` would have double `//` in the start.
3) Migration for existing users having invalid `netcli.sh` value for shell.
4) Add validation for shell for users create/update