### PR TITLE
NAS-104708 / 11.3 / Generate nginx configuration after interfaces have synced (by sonicaj)

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-netif
+++ b/src/freenas/etc/ix.rc.d/ix-netif
@@ -232,6 +232,8 @@ netif_start()
 		_interface_config > /etc/rc.conf.network
 		killall -ALRM sh
 	fi
+	echo "Generating configuration for web interface"
+	/usr/local/bin/midclt call etc.generate 'nginx' > /dev/null
 
 }
 

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -204,7 +204,7 @@ class EtcService(Service):
         ]
     }
 
-    SKIP_LIST = ['system_dataset', 'collectd', 'syslogd', 'smb_configure']
+    SKIP_LIST = ['system_dataset', 'collectd', 'syslogd', 'smb_configure', 'nginx']
 
     class Config:
         private = True

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -1096,7 +1096,7 @@ async def _event_system(middleware, event_type, args):
     global SYSTEM_SHUTTING_DOWN
     if args['id'] == 'ready':
         SYSTEM_READY = True
-    if args['id'] == 'shutting-down':
+    if args['id'] == 'shutdown':
         SYSTEM_SHUTTING_DOWN = True
 
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 22797ef4bfb3dd0f40b5024d66b9fb0d79dec94d
    git cherry-pick -x eb447d4ecbe48e59b53ad4e6b9a1045fa90fab2d

This PR introduces changes to ensure that we generate nginx configuration after interfaces have synced.