### PR TITLE
NAS-104768 / 11.2 / Always use strong auth when binding to AD in 11.2

### DIFF
--- a/gui/directoryservice/forms.py
+++ b/gui/directoryservice/forms.py
@@ -478,7 +478,7 @@ class ActiveDirectoryForm(ModelForm):
         cdata = self.cleaned_data
         domain = cdata.get("ad_domainname")
         bindname = cdata.get("ad_bindname")
-        binddn = "%s@%s" % (bindname, domain)
+        binddn = "%s@%s" % (bindname, domain.upper())
         bindpw = cdata.get("ad_bindpw")
         site = cdata.get("ad_site")
         netbiosname = cdata.get("ad_netbiosname_a")

--- a/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
+++ b/src/freenas/usr/local/libexec/nas/generate_smb4_conf.py
@@ -843,7 +843,7 @@ def add_activedirectory_conf(client, smb4_conf):
              "yes" if ad.ad_allow_trusted_doms else "no")
 
     confset2(smb4_conf, "client ldap sasl wrapping = %s",
-             ad.ad_ldap_sasl_wrapping)
+             ad.ad_ldap_sasl_wrapping if ad.ad_ldap_sasl_wrapping != 'plain' else 'sign')
 
     confset1(smb4_conf, "template shell = /bin/sh")
     cifs_homedir = "%s/%%D/%%U" % get_cifs_homedir(client)


### PR DESCRIPTION
Use SASL_GSSAPI bind with GSSAPI_SIGN if transport is not SSL encrypted.