### PR TITLE
NAS-104764 / 12.0 / Drop iscsi initiator tag column

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/12.0/2020-01-22_19-28_drop_iscsi_initiator_tag.py
+++ b/src/middlewared/middlewared/alembic/versions/12.0/2020-01-22_19-28_drop_iscsi_initiator_tag.py
@@ -1,0 +1,24 @@
+"""Drop iSCSI initiator tag column
+
+Revision ID: 536cbfca20e6
+Revises: f3875acb8d76
+Create Date: 2020-01-22 19:28:06.324970+00:00
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '536cbfca20e6'
+down_revision = 'f3875acb8d76'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('services_iscsitargetauthorizedinitiator', schema=None) as batch_op:
+        batch_op.drop_column('iscsi_target_initiator_tag')
+
+
+def downgrade():
+    pass

--- a/src/middlewared/middlewared/plugins/iscsi.py
+++ b/src/middlewared/middlewared/plugins/iscsi.py
@@ -1040,7 +1040,6 @@ class iSCSITargetAuthorizedInitiatorModel(sa.Model):
     __tablename__ = 'services_iscsitargetauthorizedinitiator'
 
     id = sa.Column(sa.Integer(), primary_key=True)
-    iscsi_target_initiator_tag = sa.Column(sa.Integer(), default=1)
     iscsi_target_initiator_initiators = sa.Column(sa.Text(), default="ALL")
     iscsi_target_initiator_auth_network = sa.Column(sa.Text(), default="ALL")
     iscsi_target_initiator_comment = sa.Column(sa.String(120))
@@ -1633,7 +1632,6 @@ class iSCSITargetToExtentService(CRUDService):
 class ISCSIFSAttachmentDelegate(FSAttachmentDelegate):
     name = 'iscsi'
     title = 'iSCSI Extent'
-
     service = 'iscsitarget'
 
     async def query(self, path, enabled):


### PR DESCRIPTION
This PR drops iSCSI initiator tag column as it is not being used anywhere. We use each initiator's database row id to keep track of mappings in the UI as well which was the only place it was being used before.