### PR TITLE
QE-258 Removing idmap_backend from activedirectory testing

### DIFF
--- a/tests/runtest.py
+++ b/tests/runtest.py
@@ -173,7 +173,7 @@ def get_tests():
 for i in get_tests():
     if testName is not None and testName != i:
         continue
-    call([f"py.test-{version}", "--junitxml",
+    call([f"py.test-{version}", "-v", "--junitxml",
           f"{results_xml}{i}_tests_result.xml"] + (
               ["-k", testexpr] if testexpr else []
     ) + [f"api2/{i}.py"])


### PR DESCRIPTION
replaced config import * and to use try and expect activedirectory testing