### PR TITLE
NAS-104884 / 12.0 / Fix failure to remove non-samba principals (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -783,7 +783,7 @@ class KerberosKeytabService(CRUDService):
             for line in kt_list_output.splitlines():
                 fields = line.split()
                 if len(fields) >= 4 and fields[0] != 'Vno':
-                    if fields['1'] == 'unknown':
+                    if fields[1] == 'unknown':
                         self.logger.warning('excluding unknown encryption type %s from keytab choices', fields[2])
                         continue
 
@@ -845,17 +845,21 @@ class KerberosKeytabService(CRUDService):
         """
         Delete all keytab entries from the tmp keytab that are not samba entries.
         """
+        seen_principals = []
         for i in to_delete:
+            if i['principal'] in seen_principals:
+                continue
+
             ktutil_remove = await run([
                 '/usr/sbin/ktutil',
                 '-k', keytab['SAMBA'].value,
                 'remove',
-                '-p', i['principal'],
-                '-e', i['type']],
+                '-p', i['principal']],
                 check=False
             )
+            seen_principals.append(i['principal'])
             if ktutil_remove.stderr.decode():
-                raise CallError(f"ktutil_remove [{keytab['SAMBA'].value}]: {ktutil_remove.stderr.decode()}")
+                raise CallError(f"ktutil_remove failed for [{i}]: {ktutil_remove.stderr.decode()}")
 
     @private
     async def kerberos_principal_choices(self):


### PR DESCRIPTION
When a foreign non-samba kerberos keytab contains multiple kvnos for
same principal and enctype middleware fails to remove. In this case,
we only need to remove the non-SMB principals so switch to removing
based exclusively on principal name rather than combination of
principal and enctype (and skip principals we've already seen).