### PR TITLE
NAS-104853 / 11.3 / Fix looking up iscsi authentication group not being found (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi.py
+++ b/src/middlewared/middlewared/plugins/iscsi.py
@@ -1268,7 +1268,7 @@ class iSCSITargetService(CRUDService):
                 verrors.add(f'{schema_name}.groups.{i}.auth', 'Authentication group is required for '
                                                               'CHAP and CHAP Mutual')
             elif group['auth'] and group['authmethod'] == 'CHAP_MUTUAL':
-                auth = await self.middleware.call('iscsi.auth.query', [('id', '=', group['auth'])])
+                auth = await self.middleware.call('iscsi.auth.query', [('tag', '=', group['auth'])])
                 if not auth:
                     verrors.add(f'{schema_name}.groups.{i}.auth', 'Authentication group not found', errno.ENOENT)
                 else:


### PR DESCRIPTION
This commit fixes an issue where we failed validation by trying to look up authentication groups via id whereas the consumer expects it to use via tag