### PR TITLE
Adjust defaults for SMB shares

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/registry.py
+++ b/src/middlewared/middlewared/plugins/smb_/registry.py
@@ -213,7 +213,7 @@ class SharingSMBService(Service):
             data['path_suffix'] = '%U'
 
         conf['path'] = '/'.join([data['path'], data['path_suffix']]) if data['path_suffix'] else data['path']
-        data['vfsobjects'] = []
+        data['vfsobjects'] = ['aio_fbsd']
         if data['comment']:
             conf["comment"] = data['comment']
         if not data['browsable']:
@@ -279,9 +279,6 @@ class SharingSMBService(Service):
 
         conf.update({
             "nfs4:chown": "true",
-            "nfs4:acedup": "merge",
-            "aio write size": "0",
-            "mangled names": "illegal",
             "ea support": "false",
         })
 


### PR DESCRIPTION
mangled names now defaults to "illegal" in upstream and nfs4:acedup
defaults to "merge". Use new AIO module by default (FreeBSD POSIX AIO).
This is early version before merging in libtevent changes.