### PR TITLE
NAS-104934 / 12.0 / Remove 30 second CAM boot delay

### DIFF
--- a/src/freenas/boot/loader.conf
+++ b/src/freenas/boot/loader.conf
@@ -8,9 +8,6 @@ loader_menu_title="Welcome to FreeNAS"
 loader_brand="FreeNAS"
 loader_version=" "
 
-# Workaround slow to attach USB boot devices
-kern.cam.boot_delay="30000"
-
 # If the machine dies at boot before /etc/rc.d/sysctl is run, let the user do
 # something.
 debug.debugger_on_panic=1

--- a/src/middlewared/middlewared/etc_files/loader.py
+++ b/src/middlewared/middlewared/etc_files/loader.py
@@ -18,7 +18,6 @@ def generate_loader_config(middleware):
         generate_user_loader_config,
         generate_debugkernel_loader_config,
         generate_ha_loader_config,
-        generate_boot_delay_config,
         generate_ec2_config,
     ]
     if middleware.call_sync("system.is_freenas"):
@@ -89,12 +88,6 @@ def generate_xen_loader_config(middleware):
     if proc.returncode == 0 and proc.stdout.strip() == b"HVM domU":
         return ['hint.hpet.0.clock="0"']
 
-    return []
-
-
-def generate_boot_delay_config(middleware):
-    if sysctl.filter("kern.vm_guest")[0].value != "none":
-        return ['kern.cam.boot_delay="0"']
     return []
 
 


### PR DESCRIPTION
This should no longer be necessary.