### PR TITLE
NAS-104846 / 11.3 / Gracefully handle case where plugin repository might be misconfigured (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -413,7 +413,9 @@ class PluginService(CRUDService):
                 )
             except Exception as e:
                 resource_list = []
-                self.middleware.logger.debug(f'Failed to retrieve plugins for {options["plugin_repository"]}: {e}')
+                self.middleware.logger.debug(
+                    'Failed to retrieve plugins for %s: %s', options['plugin_repository'], str(e)
+                )
 
         for plugin in resource_list:
             plugin.update({
@@ -457,7 +459,9 @@ class PluginService(CRUDService):
             index = plugins_obj.retrieve_plugin_index_data(plugins_obj.git_destination)
 
         if options['plugin'] not in index:
-            raise CallError(f'{options["plugin"]} not found')
+            raise CallError(
+                f'{options["plugin"]} not found, likely because local plugin repository is corrupted.'
+            )
         return {
             'plugin': options['plugin'],
             'properties': {**IOCPlugin.DEFAULT_PROPS, **index[options['plugin']].get('properties', {})}

--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -407,9 +407,13 @@ class PluginService(CRUDService):
         else:
             self.middleware.call_sync('jail.check_dataset_existence')
             plugins_versions_data = IOCPlugin(branch=branch, git_repository=plugin_repository).fetch_plugin_versions()
-            resource_list = ioc.IOCage(skip_jails=True).fetch(
-                list=True, plugins=True, header=False, branch=branch, git_repository=options['plugin_repository']
-            )
+            try:
+                resource_list = ioc.IOCage(skip_jails=True).fetch(
+                    list=True, plugins=True, header=False, branch=branch, git_repository=options['plugin_repository']
+                )
+            except Exception as e:
+                resource_list = []
+                self.middleware.logger.debug(f'Failed to retrieve plugins for {options["plugin_repository"]}: {e}')
 
         for plugin in resource_list:
             plugin.update({


### PR DESCRIPTION
This PR introduces changes where we gracefully handle the case when plugin repository is misconfigured and we don't either have the INDEX or plugin's manifest file.