### PR TITLE
NAS-104983 / 11.3 / Bug fix for select option (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/utils/__init__.py
+++ b/src/middlewared/middlewared/utils/__init__.py
@@ -52,8 +52,6 @@ def django_modelobj_serialize(middleware, obj, extend=None, extend_context=None,
             name = origname[len(field_prefix):]
         else:
             name = origname
-        if select and name not in select:
-            continue
         try:
             value = getattr(obj, origname)
         except Exception as e:
@@ -79,7 +77,11 @@ def django_modelobj_serialize(middleware, obj, extend=None, extend_context=None,
             data = middleware.call_sync(extend, data, extend_context_value)
         else:
             data = middleware.call_sync(extend, data)
-    return data
+
+    if not select:
+        return data
+    else:
+        return {k: v for k, v in data.items() if k in select}
 
 
 def Popen(args, **kwargs):


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x c4829f13326fceb82864a5c616940d555f6a9bcf

This commit fixes an issue where we selected fields before going through extending phase while retrieving objects which resulted in extend phase not working for most services as it is dependent on keys which might not be present in the data as it had already been pruned.