### PR TITLE
NAS-105015 / 11.3 / Prevent users from enabling multiple shadow copy modules

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -815,6 +815,13 @@ class SharingSMBService(CRUDService):
                     f'The "noacl" VFS module is incompatible with the extended ACL on {data["path"]}.'
                 )
 
+        if 'shadow_copy2' in data['vfsobjects'] and data['shadowcopy']:
+            verrors.add(
+                f'{schema_name}.name',
+                'vfs_shadow_copy2 is incompatible with the built-in shadow copy module. Either '
+                'deselect "shadowcopy" or remove shadow_copy2 from vfsobjects list.'
+            )
+
         if data.get('name') and data['name'].lower() in ['global', 'homes', 'printers']:
             verrors.add(
                 f'{schema_name}.name',


### PR DESCRIPTION
For 11.3 vfs_shadow_copy2 is exposed to end-users to provide an
avenue for reverting to legacy behavior in case of discovery of
show-stopping bug in shadow_copy_zfs. This will be removed in 12.0.
If users enable this and shadow_copy_zfs through the "shadowcopy"
checkbox then previous versions will not work. Raise a validation
error to prevent this configuration.