### PR TITLE
Fix error: pathspec 'freenas/11.3-stable' did not match any file(s) k…

### DIFF
--- a/.travis/flake8.sh
+++ b/.travis/flake8.sh
@@ -14,6 +14,8 @@ echo $num_errors_after
 if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
 git checkout HEAD~
 else
+git remote set-branches origin ${TRAVIS_BRANCH}
+git fetch --depth 1 origin ${TRAVIS_BRANCH}
 git checkout ${TRAVIS_BRANCH}
 fi
 


### PR DESCRIPTION
Travis new error checks does not work, it fails to check out original branch due to repo being shallow copy:
```
+git checkout freenas/11.3-stable
error: pathspec 'freenas/11.3-stable' did not match any file(s) known to git
```
and compares PR code with itself.