### PR TITLE
NAS-104985 / 12.0 / Fix S3 https bug NAS-104985

### DIFF
--- a/src/middlewared/middlewared/etc_files/rc.conf.py
+++ b/src/middlewared/middlewared/etc_files/rc.conf.py
@@ -311,6 +311,7 @@ def s3_config(middleware, context):
     s3 = middleware.call_sync('s3.config')
     yield f'minio_disks="{s3["storage_path"]}"'
     yield f'minio_address="{s3["bindip"]}:{s3["bindport"]}"'
+    yield 'minio_certs="/usr/local/etc/minio/certs"'
     browser = 'MINIO_BROWSER=off \\\n' if not s3['browser'] else ''
     yield (
         'minio_env="\\\n'


### PR DESCRIPTION
Add the Minio certs directory to rc.conf.py to fix the S3 https issue NAS-104985.