### PR TITLE
NAS-105032 / 11.3 / Provide mechanism for querying all disk temps simultaneously.

### DIFF
--- a/src/freenas/usr/local/lib/collectd_pyplugins/disktemp.py
+++ b/src/freenas/usr/local/lib/collectd_pyplugins/disktemp.py
@@ -41,12 +41,7 @@ class DiskTemp(object):
         collectd.info('Initializing "disktemp" plugin')
         try:
             with Client() as c:
-                self.disks = [disk['devname'] for disk in c.call('disk.query', [['devname', '!=', None],
-                                                                                ['togglesmart', '=', True],
-                                                                                # Polling for disk temperature does
-                                                                                # not allow them to go to sleep
-                                                                                # automatically
-                                                                                ['hddstandby', '=', 'ALWAYS ON']])]
+                self.disks = c.call('disk.disks_for_temperature_monitoring')
                 self.smartctl_args = c.call('disk.smartctl_args_for_devices', self.disks)
                 self.powermode = c.call('smart.config')['powermode']
         except Exception:

--- a/src/middlewared/middlewared/plugins/disk.py
+++ b/src/middlewared/middlewared/plugins/disk.py
@@ -719,6 +719,18 @@ class DiskService(CRUDService):
 
         return None
 
+    @private
+    async def disks_for_temperature_monitoring(self):
+        return [
+            disk['devname']
+            for disk in await self.query([['devname', '!=', None],
+                                          ['togglesmart', '=', True],
+                                          # Polling for disk temperature does
+                                          # not allow them to go to sleep
+                                          # automatically
+                                          ['hddstandby', '=', 'ALWAYS ON']])
+        ]
+
     @accepts(
         List('names', items=[Str('name')]),
         Str('powermode', enum=SMARTCTL_POWERMODES, default=SMARTCTL_POWERMODES[0]),
@@ -728,6 +740,8 @@ class DiskService(CRUDService):
         """
         Returns temperatures for a list of device `names` using specified S.M.A.R.T. `powermode`.
         """
+        if len(names) == 0:
+            names = await self.disks_for_temperature_monitoring()
 
         if not smartctl_args:
             smartctl_args = await self.smartctl_args_for_devices(names)


### PR DESCRIPTION
Return temperatures for all disks if disk.temperatures is passed an empty list.