### PR TITLE
NAS-105068 / 12.0 / Correctly show partition number in freebsd for disks

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/disk_info_freebsd.py
+++ b/src/middlewared/middlewared/plugins/disk_/disk_info_freebsd.py
@@ -49,7 +49,7 @@ class DiskService(Service, DiskInfoBase):
                     'partition_uuid': part_uuid.text if part_uuid is not None else None,
                 }
                 part_no = RE_DISKPART.match(part['name'])
-                if part_no:
+                if part_no and part_no.group(2):
                     part['partition_number'] = int(part_no.group(2)[1:])
                 if os.path.exists(f'{part["path"]}.eli'):
                     part['encrypted_provider'] = f'{part["path"]}.eli'


### PR DESCRIPTION
Some drives might have partition names like da0s1, this commit fixes an issue where we didn't anticipate this format.