### PR TITLE
NAS-104437 / 11.2 / functools.partial has to be in global scope

### DIFF
--- a/src/middlewared/middlewared/utils/asyncio_.py
+++ b/src/middlewared/middlewared/utils/asyncio_.py
@@ -1,5 +1,4 @@
 import asyncio
-import functools
 
 
 async def asyncio_map(func, arguments, limit=None):

--- a/src/middlewared/middlewared/utils/asyncio_.py
+++ b/src/middlewared/middlewared/utils/asyncio_.py
@@ -17,6 +17,13 @@ async def asyncio_map(func, arguments, limit=None):
     return await asyncio.gather(*futures)
 
 
+def _noexec_wrapper(method, *args, **kwargs):
+    try:
+        return method(*args, **kwargs)
+    except Exception as e:
+        return e
+
+
 async def async_run_in_executor(loop, executor, method, *args, **kwargs):
     """
     Runs `method` using a concurrent.futures.Executor.
@@ -28,14 +35,9 @@ async def async_run_in_executor(loop, executor, method, *args, **kwargs):
     # As a workaround, we use a wrapper to catch exceptions before they are raised past
     # top and return them. Then we "catch" returned exceptions and re-raise them to
     # bridge the gap.
-    @functools.wraps(method)
-    def wrapped():
-        try:
-            return method(*args, **kwargs)
-        except Exception as e:
-            return e
 
-    result = await loop.run_in_executor(executor, wrapped)
+    result = await loop.run_in_executor(executor, _noexec_wrapper, method, *args, **kwargs)
+
     if isinstance(result, Exception):
         raise result
     else:


### PR DESCRIPTION
`Traceback (most recent call last):
  File "/usr/local/lib/python3.6/multiprocessing/queues.py", line 234, in _feed
    obj = _ForkingPickler.dumps(obj)
  File "/usr/local/lib/python3.6/multiprocessing/reduction.py", line 51, in dumps
    cls(buf, protocol).dump(obj)
_pickle.PicklingError: Can't pickle <function get_quota_excesses__get_props at 0x81d077d08>: it's not the same object as zfs.get_quota_excesses__get_props`

`Traceback (most recent call last):
  File "/usr/local/lib/python3.6/multiprocessing/queues.py", line 234, in _feed
    obj = _ForkingPickler.dumps(obj)
  File "/usr/local/lib/python3.6/multiprocessing/reduction.py", line 51, in dumps
    cls(buf, protocol).dump(obj)
_pickle.PicklingError: Can't pickle <function main_worker at 0x81d1fb8c8>: it's not the same object as middlewared.worker.main_worker`