### PR TITLE
NAS-105063 / 11.3 / fix(rc.d): make ix-syncmultipaths executable and depend on ix-syncdisks (by william-gr)

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-syncmultipaths
+++ b/src/freenas/etc/ix.rc.d/ix-syncmultipaths
@@ -4,7 +4,7 @@
 #
 
 # PROVIDE: ix-syncmultipaths
-# REQUIRE: FILESYSTEMS
+# REQUIRE: FILESYSTEMS ix-syncdisks
 
 . /etc/rc.subr
 


### PR DESCRIPTION
Ticket:	NAS-105063