### PR TITLE
NAS-105059 / 11.3 / fix(middlewared/disk): do not use expiring disks for multipath (by william-gr)

### DIFF
--- a/src/middlewared/middlewared/plugins/disk.py
+++ b/src/middlewared/middlewared/plugins/disk.py
@@ -1365,6 +1365,7 @@ class DiskService(CRUDService):
                     ['disk_name', 'in', _disks],
                     ['disk_multipath_member', 'in', _disks],
                 ]],
+                ['disk_expiretime', '=', None],
             ])
             if qs:
                 diskobj = qs[0]


### PR DESCRIPTION
Ticket:	NAS-105059