### PR TITLE
NAS-104437 / 11.2 / remove ctypes and use setsockopt() in WSClient

### DIFF
--- a/src/middlewared/middlewared/client/client.py
+++ b/src/middlewared/middlewared/client/client.py
@@ -67,7 +67,6 @@ class WSClient(WebSocketClient):
         for retry in range(5):
             self.sock.setsockopt(socket.IPPROTO_IP, IP_PORTRANGE, IP_PORTRANGE_LOW)
             self.sock.bind(('', 0))
-            _host, port = self.sock.getsockname()
 
             # The old socket can't be closed before we bind the new socket or
             # we have the possibility of binding to the same port.

--- a/src/middlewared/middlewared/client/client.py
+++ b/src/middlewared/middlewared/client/client.py
@@ -66,9 +66,15 @@ class WSClient(WebSocketClient):
 
         oldsock = None
 
-        for retry in range(5):
+        n_retries = 5
+        for retry in range(n_retries):
             self.sock.setsockopt(socket.IPPROTO_IP, IP_PORTRANGE, IP_PORTRANGE_LOW)
-            self.sock.bind(('', 0))
+
+            try:
+                self.sock.bind(('', 0))
+            except OSError:
+                time.sleep(0.1)
+                continue
 
             # The old socket can't be closed before we bind the new socket or
             # we have the possibility of binding to the same port.
@@ -82,7 +88,7 @@ class WSClient(WebSocketClient):
             # If we're at last pass in loop and get here, break out
             # so we don't set up a socket just to close it essentially
             # making it a NO-OP.
-            if retry == 4:
+            if retry == n_retries - 1:
                 break
 
             oldsock = self.sock

--- a/src/middlewared/middlewared/client/client.py
+++ b/src/middlewared/middlewared/client/client.py
@@ -77,14 +77,17 @@ class WSClient(WebSocketClient):
             if port not in self.reserved_ports_blacklist:
                 return
 
+            # If we're at last pass in loop and get here, break out
+            # so we don't set up a socket just to close it essentially
+            # making it a NO-OP.
+            if retry == 4:
+                break
+
             oldsock = self.sock
 
             self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
             self.sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
             self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-
-        # called in case we hit retry limit
-        oldsock.close()
 
         raise ReserveFDException()
 

--- a/src/middlewared/middlewared/client/client.py
+++ b/src/middlewared/middlewared/client/client.py
@@ -4,18 +4,14 @@ from .utils import ProgressBar
 from collections import defaultdict, namedtuple, Callable
 from threading import Event as TEvent, Lock, Thread
 from ws4py.client.threadedclient import WebSocketClient
-from ws4py.websocket import WebSocket
 
 import argparse
-from base64 import b64decode, b64encode
-import ctypes
+from base64 import b64decode
 import errno
 import os
 import pickle
 import socket
-import ssl
 import sys
-import threading
 import time
 import uuid
 
@@ -55,110 +51,42 @@ class ReserveFDException(Exception):
 class WSClient(WebSocketClient):
     def __init__(self, url, *args, **kwargs):
         self.client = kwargs.pop('client')
-        reserved_ports = kwargs.pop('reserved_ports')
-        reserved_ports_blacklist = kwargs.pop('reserved_ports_blacklist')
+        self.reserved_ports = kwargs.pop('reserved_ports', False)
+        self.reserved_ports_blacklist = kwargs.pop('reserved_ports_blacklist', None)
         self.protocol = DDPProtocol(self)
-        if not reserved_ports:
-            super(WSClient, self).__init__(url, *args, **kwargs)
-        else:
-            """
-            All this code has been copied from WebSocketClient.__init__
-            because it is not prepared to handle a custom socket via method
-            overriding. We need to use socket.fromfd in case reserved_ports
-            is specified.
-            """
-            self.url = url
-            self.host = None
-            self.scheme = None
-            self.port = None
-            self.unix_socket_path = None
-            self.resource = None
-            self.ssl_options = kwargs.get('ssl_options') or {}
-            self.extra_headers = kwargs.get('headers') or []
-            self.exclude_headers = kwargs.get('exclude_headers') or []
-            self.exclude_headers = [x.lower() for x in self.exclude_headers]
+        super(WSClient, self).__init__(url, *args, **kwargs)
 
-            if self.scheme == "wss":
-                # Prevent check_hostname requires server_hostname (ref #187)
-                if "cert_reqs" not in self.ssl_options:
-                    self.ssl_options["cert_reqs"] = ssl.CERT_NONE
+    def get_reserved_portfd(self):
+        if self.reserved_ports_blacklist is None:
+            self.reserved_ports_blacklist = []
 
-            self._parse_url()
+        # defined in net/in.h
+        IP_PORTRANGE = 19
+        IP_PORTRANGE_LOW = 2
 
-            if self.unix_socket_path:
-                sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM, 0)
-            else:
-                # Let's handle IPv4 and IPv6 addresses
-                # Simplified from CherryPy's code
-                try:
-                    family, socktype, proto, canonname, sa = socket.getaddrinfo(self.host, self.port, socket.AF_UNSPEC, socket.SOCK_STREAM, 0, socket.AI_PASSIVE)[0]
-                except socket.gaierror:
-                    family = socket.AF_INET
-                    if self.host.startswith('::'):
-                        family = socket.AF_INET6
-
-                    socktype = socket.SOCK_STREAM
-                    proto = 0
-
-                """
-                This is the line replaced to use socket.fromfd
-                """
-                reserved_fd = self.get_reserved_portfd(blacklist=reserved_ports_blacklist)
-                sock = socket.socket(family, socktype, proto, reserved_fd)
-                sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-                if hasattr(socket, 'AF_INET6') and family == socket.AF_INET6 and self.host.startswith('::'):
-                    try:
-                        sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
-                    except (AttributeError, socket.error):
-                        pass
-
-            WebSocket.__init__(self, sock, protocols=kwargs.get('protocols'),
-                               extensions=kwargs.get('extensions'),
-                               heartbeat_freq=kwargs.get('heartbeat_freq'))
-
-            self.stream.always_mask = True
-            self.stream.expect_masking = False
-            self.key = b64encode(os.urandom(16))
-            self._th = threading.Thread(target=self.run, name='WebSocketClient')
-            self._th.daemon = True
-
-    def get_reserved_portfd(self, blacklist=None):
-        """
-        Get a file descriptor with a reserved port (<=1024).
-        The port is arbitrary using the libc "rresvport" call and its tried
-        again if its within `blacklist` list.
-        """
-        if blacklist is None:
-            blacklist = []
-
-        libc = ctypes.cdll.LoadLibrary('libc.so.7')
-        port = ctypes.c_int(0)
-        pport = ctypes.pointer(port)
-        fd = libc.rresvport(pport)
         retries = 5
-        while True:
-            if retries == 0:
-                break
-            if fd < 0:
-                time.sleep(0.1)
-                fd = libc.rresvport(pport)
-                retries -= 1
-                continue
-            if pport.contents.value in blacklist:
-                oldfd = fd
-                fd = libc.rresvport(pport)
-                os.close(oldfd)
-                retries -= 1
-                continue
-            else:
-                break
-        if fd < 0:
-            raise ReserveFDException()
-        return fd
+        while retries > 0:
+            self.sock.setsockopt(socket.IPPROTO_IP, IP_PORTRANGE, IP_PORTRANGE_LOW)
+            _host, port = self.sock.getsockname()
+
+            if port not in self.reserved_ports_blacklist:
+                return
+
+            newsock = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
+            newsock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            newsock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            self.sock.close()
+            self.sock = newsock
+            retries += -1
+
+        raise ReserveFDException()
 
     def connect(self):
+        if self.reserved_ports:
+            self.get_reserved_portfd()
+
         self.sock.settimeout(10)
+
         max_attempts = 3
         for i in range(max_attempts):
             try:
@@ -388,14 +316,14 @@ class Client(object):
                 if isinstance(job.get('__callback'), Callable):
                     job['__callback'](job)
                 if mtype == 'CHANGED' and job['state'] in ('SUCCESS', 'FAILED', 'ABORTED'):
-                        # If an Event already exist we just set it to mark it finished.
-                        # Otherwise we create a new Event.
-                        # This is to prevent a race-condition of job finishing before
-                        # the client can create the Event.
-                        event = job.get('__ready')
-                        if event is None:
-                            event = job['__ready'] = Event()
-                        event.set()
+                    # If an Event already exist we just set it to mark it finished.
+                    # Otherwise we create a new Event.
+                    # This is to prevent a race-condition of job finishing before
+                    # the client can create the Event.
+                    event = job.get('__ready')
+                    if event is None:
+                        event = job['__ready'] = Event()
+                    event.set()
 
     def _jobs_subscribe(self):
         """

--- a/src/middlewared/middlewared/client/client.py
+++ b/src/middlewared/middlewared/client/client.py
@@ -69,7 +69,8 @@ class WSClient(WebSocketClient):
             self.sock.bind(('', 0))
             _host, port = self.sock.getsockname()
 
-            # close here because we previously bind() to a port in blacklist
+            # The old socket can't be closed before we bind the new socket or
+            # we have the possibility of binding to the same port.
             if retry > 0:
                 oldsock.close()
 

--- a/src/middlewared/middlewared/client/client.py
+++ b/src/middlewared/middlewared/client/client.py
@@ -84,7 +84,8 @@ class WSClient(WebSocketClient):
             self.sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
             self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
-        oldsock.close() # called in case we hit retry limit
+        # called in case we hit retry limit
+        oldsock.close()
 
         raise ReserveFDException()
 

--- a/src/middlewared/middlewared/client/client.py
+++ b/src/middlewared/middlewared/client/client.py
@@ -64,6 +64,8 @@ class WSClient(WebSocketClient):
         IP_PORTRANGE = 19
         IP_PORTRANGE_LOW = 2
 
+        oldsock = None
+
         for retry in range(5):
             self.sock.setsockopt(socket.IPPROTO_IP, IP_PORTRANGE, IP_PORTRANGE_LOW)
             self.sock.bind(('', 0))

--- a/src/middlewared/middlewared/client/client.py
+++ b/src/middlewared/middlewared/client/client.py
@@ -64,17 +64,16 @@ class WSClient(WebSocketClient):
         IP_PORTRANGE = 19
         IP_PORTRANGE_LOW = 2
 
-        oldsock = None
-
         for retry in range(5):
             self.sock.setsockopt(socket.IPPROTO_IP, IP_PORTRANGE, IP_PORTRANGE_LOW)
             self.sock.bind(('', 0))
             _host, port = self.sock.getsockname()
 
-            # Close here because we previously bind() to a port in blacklist
-            if oldsock is not None:
+            # close here because we previously bind() to a port in blacklist
+            if retry > 0:
                 oldsock.close()
 
+            _host, port = self.sock.getsockname()
             if port not in self.reserved_ports_blacklist:
                 return
 


### PR DESCRIPTION
Running this since last night and graphing CLOSED sockets as well as memory usage for middlewared and it has stayed < 200MB of resident memory.

This keeps same functionality as the ctype method.