### PR TITLE
NAS-105072 / 12.0 / Correctly redirect host port in nginx

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf
@@ -161,7 +161,7 @@ http {
         add_header X-XSS-Protection "1";
 
         location / {
-            rewrite ^.* /ui/ redirect;
+            rewrite ^.* $scheme://$http_host/ui/ redirect;
         }
 
         location /progress {


### PR DESCRIPTION
This commit fixes a bug where we redirected to port 80 by default and thus not respecting the port. To be specific, this caused issues when we have port forwarding to FN UI, the forwarded port on the host got emitted by nginx rewrite rule.