### PR TITLE
NAS-105129 / 12.0 / Generate nginx configuration after interfaces have synced

### DIFF
--- a/debian/debian/ix-netif.service
+++ b/debian/debian/ix-netif.service
@@ -11,6 +11,7 @@ Conflicts=systemd-networkd.service
 [Service]
 Type=oneshot
 ExecStart=midclt -t 120 call interfaces.sync true
+ExecStartPost=midclt call etc.generate nginx
 StandardOutput=null
 
 [Install]

--- a/debian/debian/postinst
+++ b/debian/debian/postinst
@@ -2,3 +2,4 @@
 
 # It unconfigures interfaces we've just configured even if it is instructed to do not touch anything
 systemctl disable systemd-networkd
+#DEBHELPER#


### PR DESCRIPTION
This PR introduces following changes:

1) Fixes enabling of truenas ix* services by ensuring `DEBHELPER` placeholder is added to postinstall script of virtual package truenas. Not having it there means that the auto generated  snippets weren't added to postinst because we had overridden postinst script and a placeholder didn't exist for debhelper to add the auto generated snippets required for starting/enabling services after installation.
2) Generate nginx configuration after interfaces have synced