### PR TITLE
NAS-105072 / 11.3 / Correctly redirect host port in nginx (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf
+++ b/src/middlewared/middlewared/etc_files/local/nginx/nginx.conf
@@ -148,7 +148,7 @@ http {
         add_header X-XSS-Protection "1";
 
         location / {
-            rewrite ^.* /ui/ redirect;
+            rewrite ^.* $scheme://$http_host/ui/ redirect;
         }
 
         location ~ ^/(${'legacy|plugins|' if enable_legacy_ui else ''}api/v1.0)/ {


### PR DESCRIPTION
This commit fixes a bug where we redirected to port 80 by default and thus not respecting the port. To be specific, this caused issues when we have port forwarding to FN UI, the forwarded port on the host got emitted by nginx rewrite rule.