### PR TITLE
NAS-105004 / 12.0 / Only generate ADISK advertisement if service is running (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/avahi/avahi_services.py
+++ b/src/middlewared/middlewared/etc_files/local/avahi/avahi_services.py
@@ -116,8 +116,22 @@ class mDNSService(object):
 
         if self.service == 'ADISK':
             iindex = [AvahiConst.AVAHI_IF_UNSPEC]
-            afp_shares = self.middleware.call_sync('sharing.afp.query', [('timemachine', '=', True)])
-            smb_shares = self.middleware.call_sync('sharing.smb.query', [('timemachine', '=', True)])
+            afp_is_running = any(filter_list(
+                self.service_info, [('service', '=', 'afp'), ('state', '=', 'RUNNING')]
+            ))
+            smb_is_running = any(filter_list(
+                self.service_info, [('service', '=', 'cifs'), ('state', '=', 'RUNNING')]
+            ))
+
+            if afp_is_running:
+                afp_shares = self.middleware.call_sync('sharing.afp.query', [('timemachine', '=', True)])
+            else:
+                afp_shares = []
+            if smb_is_running:
+                smb_shares = self.middleware.call_sync('sharing.smb.query', [('timemachine', '=', True)])
+            else:
+                smb_shares = []
+
             afp = set([(x['name'], x['path']) for x in afp_shares])
             smb = set([(x['name'], x['path']) for x in smb_shares])
             if len(afp | smb) == 0:


### PR DESCRIPTION
Fix behavior where spurious _adisk._tcp. advertisement was being generated while AFP was stopped.