### PR TITLE
NAS-105126 / 12.0 / Stack streams_xattr after fruit and before other modules. (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/registry.py
+++ b/src/middlewared/middlewared/plugins/smb_/registry.py
@@ -136,8 +136,9 @@ class SharingSMBService(Service):
 
     @private
     async def order_vfs_objects(self, vfs_objects):
-        vfs_objects_special = ('shadow_copy_zfs', 'catia', 'zfs_space', 'noacl', 'ixnas', 'zfsacl',
-                               'fruit', 'streams_xattr', 'crossrename', 'recycle')
+        vfs_objects_special = ('shadow_copy_zfs', 'catia', 'zfs_space', 'fruit', 'streams_xattr',
+                               'noacl', 'ixnas', 'zfsacl', 'crossrename', 'recycle')
+
         vfs_objects_ordered = []
 
         if 'fruit' in vfs_objects:


### PR DESCRIPTION
Change ordering of streams_xattr, fruit, and ACL-related modules