### PR TITLE
NAS-104437 / 12.0 / remove ctypes and use setsockopt() in WSClient (by yocalebo) (by bugclerk)

### DIFF
--- a/src/middlewared/middlewared/client/client.py
+++ b/src/middlewared/middlewared/client/client.py
@@ -60,19 +60,14 @@ class WSClient(WebSocketClient):
     def __init__(self, url, *args, **kwargs):
         self.client = kwargs.pop('client')
         self.reserved_ports = kwargs.pop('reserved_ports', False)
-        self.reserved_ports_blacklist = kwargs.pop('reserved_ports_blacklist', None)
         self.protocol = DDPProtocol(self)
         super(WSClient, self).__init__(url, *args, **kwargs)
 
     def get_reserved_portfd(self):
-        if self.reserved_ports_blacklist is None:
-            self.reserved_ports_blacklist = []
 
         # defined in net/in.h
         IP_PORTRANGE = 19
         IP_PORTRANGE_LOW = 2
-
-        oldsock = None
 
         n_retries = 5
         for retry in range(n_retries):
@@ -80,35 +75,19 @@ class WSClient(WebSocketClient):
 
             try:
                 self.sock.bind(('', 0))
+                return
             except OSError:
                 time.sleep(0.1)
                 continue
 
-            # The old socket can't be closed before we bind the new socket or
-            # we have the possibility of binding to the same port.
-            if retry > 0:
-                oldsock.close()
-
-            _host, port = self.sock.gethostname()
-            if port not in self.reserved_ports_blacklist:
-                return
-
-            # If we're at last pass in loop and get here, break out
-            # so we don't set up a socket just to close it essentially
-            # making it a NO-OP.
-            if retry == n_retries - 1:
-                break
-
-            oldsock = self.sock
-
-            self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
-            self.sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-            self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-
         raise ReserveFDException()
 
     def connect(self):
+        if self.reserved_ports:
+            self.get_reserved_portfd()
+
         self.sock.settimeout(10)
+
         max_attempts = 3
         for i in range(max_attempts):
             try:
@@ -246,14 +225,10 @@ class CallTimeout(ClientException):
 
 class Client(object):
 
-    def __init__(
-        self, uri=None, reserved_ports=False, reserved_ports_blacklist=None,
-        py_exceptions=False,
-    ):
+    def __init__(self, uri=None, reserved_ports=False, py_exceptions=False):
         """
         Arguments:
-           :reserved_ports(bool): whether the connection should origin using a reserved port (<= 1024)
-           :reserved_ports_blacklist(list): list of ports that should not be used as origin
+           :reserved_ports(bool): should the local socket used a reserved port
         """
         self._calls = {}
         self._jobs = defaultdict(dict)
@@ -266,23 +241,17 @@ class Client(object):
             uri = 'ws+unix:///var/run/middlewared.sock'
         self._closed = Event()
         self._connected = Event()
-        try:
-            self._ws = WSClient(
-                uri,
-                client=self,
-                reserved_ports=reserved_ports,
-                reserved_ports_blacklist=reserved_ports_blacklist,
-            )
-            if 'unix://' in uri:
-                self._ws.resource = '/websocket'
-            self._ws.connect()
-            self._connected.wait(10)
-            if not self._connected.is_set():
-                raise ClientException('Failed connection handshake')
-        except Exception:
-            if hasattr(self, '_ws'):
-                del self._ws
-            raise
+        self._ws = WSClient(
+            uri,
+            client=self,
+            reserved_ports=reserved_ports,
+        )
+        if 'unix://' in uri:
+            self._ws.resource = '/websocket'
+        self._ws.connect()
+        self._connected.wait(10)
+        if not self._connected.is_set():
+            raise ClientException('Failed connection handshake')
 
     def __enter__(self):
         return self

--- a/src/middlewared/middlewared/etc_files/ctld.py
+++ b/src/middlewared/middlewared/etc_files/ctld.py
@@ -402,6 +402,12 @@ def set_ctl_ha_peer(middleware):
     with contextlib.suppress(IndexError):
         if middleware.call_sync("iscsi.global.alua_enabled"):
             node = middleware.call_sync("failover.node")
+            # 999 is the port used by ALUA on the heartbeat interface
+            # on TrueNAS HA systems. Because of this, we set
+            # net.inet.ip.portrange.lowfirst=998 to ensure local
+            # websocket connections do not have the opportunity
+            # to interfere.
+            sysctl.filter("net.inet.ip.portrange.lowfirst")[0].value = 998
             if node == "A":
                 sysctl.filter("kern.cam.ctl.ha_peer")[0].value = "listen 169.254.10.1"
             if node == "B":


### PR DESCRIPTION
Running this since last night and graphing CLOSED sockets as well as memory usage for middlewared and it has stayed < 200MB of resident memory.

This keeps same functionality as the ctype method.