### PR TITLE
NAS-105196 / 11.3 / Improve tolerance for high-latency connections in AD plugin

### DIFF
--- a/src/middlewared/middlewared/plugins/directoryservices.py
+++ b/src/middlewared/middlewared/plugins/directoryservices.py
@@ -67,7 +67,7 @@ class DirectoryServices(Service):
         `HEALTHY` Directory Service is enabled, and last status check has passed.
         """
         try:
-            return (await self.middleware.call('cache.get', 'DS_State'))
+            return (await self.middleware.call('cache.get', 'DS_STATE'))
         except KeyError:
             ds_state = {}
             for srv in DSType:

--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -690,22 +690,6 @@ class ServiceService(CRUDService):
         await self._service("ladvd", "stop", force=True, **kwargs)
         await self._service("ladvd", "restart", **kwargs)
 
-    async def _started_activedirectory(self, **kwargs):
-        return await self.middleware.call('activedirectory.started'), []
-
-    async def _start_activedirectory(self, **kwargs):
-        return await self.middleware.call('activedirectory.start'), []
-
-    async def _stop_activedirectory(self, **kwargs):
-        return await self.middleware.call('activedirectory.stop'), []
-
-    async def _restart_activedirectory(self, **kwargs):
-        await self.middleware.call('kerberos.stop'), []
-        return await self.middleware.call('activedirectory.start'), []
-
-    async def _reload_activedirectory(self, **kwargs):
-        await self._service("winbindd", "reload", quiet=True, **kwargs)
-
     async def _restart_syslogd(self, **kwargs):
         await self.middleware.call("etc.generate", "syslogd")
         await self._system("/etc/local/rc.d/syslog-ng restart")


### PR DESCRIPTION
- Remove unnecessary checks in validate_crendentials()
- Background actual AD start() and return job_id with config in
  activedirectory.update()
- Make socket timeout configurable.
- Safely handle situation where AD domain is misconfigured and
  lacks a server with the PDC Emulator FSMO role.