### PR TITLE
NAS-105171 / 11.3 / Donot escape '%' for cron job tasks (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/cron.py
+++ b/src/middlewared/middlewared/plugins/cron.py
@@ -29,7 +29,7 @@ class CronJobService(CRUDService):
                     schedule['minute'], schedule['hour'], schedule['dom'], schedule['month'],
                     schedule['dow'], user,
                     'PATH="/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/root/bin"',
-                    command.replace('\n', '').replace('%', r'\%'),
+                    command.replace('\n', ''),
                     '> /dev/null' if stdout else '', '2> /dev/null' if stderr else ''
                 )
             )


### PR DESCRIPTION
This commit introduces changes to not escape  character because it had significance in crontab which we don't use anymore for executing commands directly and instead middlewared handles it where this character does not need to be escaped.