### PR TITLE
NAS-105255 / 11.3 / Automatically remove ldap bindpw if kerberos principal selected

### DIFF
--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -458,10 +458,10 @@ class LDAPService(ConfigService):
                 "Bind credentials or kerberos keytab are required for an authenticated bind."
             )
         if new["bindpw"] and new["kerberos_principal"]:
-            verrors.add(
-                "ldap_update.kerberos_principal",
-                "Simultaneous keytab and password authentication are not permitted."
-            )
+            self.logger.warning("Simultaneous keytab and password authentication "
+                                "are selected. Clearing LDAP bind password.")
+            new["bindpw"] = ""
+
         if not new["basedn"]:
             verrors.add(
                 "ldap_update.basedn",


### PR DESCRIPTION
If a user has selected a kerberos principal, then it's clear that
he wants to use kerberos (and not plain-text auth). Default to
not storing passwords (or returning a validation error).