### PR TITLE
NAS-105281 / 12.0 / Bug fix for jail default configuration

### DIFF
--- a/src/middlewared/middlewared/plugins/jail_freebsd.py
+++ b/src/middlewared/middlewared/plugins/jail_freebsd.py
@@ -715,9 +715,10 @@ class JailService(CRUDService):
         Retrieve default configuration for iocage jails.
         """
         if not self.iocage_set_up():
-            return IOCJson.retrieve_default_props()
+            defaults = IOCJson.retrieve_default_props()
         else:
-            return self.query(filters=[['host_hostuuid', '=', 'default']], options={'get': True})
+            defaults = self.query(filters=[['host_hostuuid', '=', 'default']], options={'get': True})
+        return {k: v for k, v in defaults.items() if k not in IOCJson.default_only_props}
 
     @accepts(
         Bool('remote', default=False),


### PR DESCRIPTION
This commit fixes an issue where we exposed default props which are not changeable at a jail level, in this commit we filter out these props so that only those props are exposed which can actually be changed for a jail/plugin.