### PR TITLE
NAS-105024 / 11.3 / Only add NFS SPN entries to AD if kerberized NFSv4 is enabled

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -1242,6 +1242,13 @@ class ActiveDirectoryService(ConfigService):
 
     @private
     async def _net_ads_setspn(self, spn_list):
+        """
+        Only automatically add NFS SPN entries on domain join
+        if kerberized nfsv4 is enabled.
+        """
+        if not (await self.middleware.call('nfs.config'))['v4_krb']:
+            return False
+
         for spn in spn_list:
             netads = await run([
                 SMBCmd.NET.value, '-k', 'ads', 'setspn',


### PR DESCRIPTION
In some AD domains the attempt to change trust password after
adding NFS SPN entries (to regenerate the kerberos keytab) fails.

Switch to only perform this operation if absolutely needed
(kerberized NFSv4 is enabled). In future, samba / netads should
just automatically append these entries on initial domain join.