### PR TITLE
NAS-105295 / 11.3 / Bug fixes for swap configuration

### DIFF
--- a/src/middlewared/middlewared/plugins/disk.py
+++ b/src/middlewared/middlewared/plugins/disk.py
@@ -1952,7 +1952,7 @@ async def devd_zfs_hook(middleware, data):
         'misc.fs.zfs.pool_destroy',
         'misc.fs.zfs.pool_import',
     ):
-        asyncio.ensure_future(middleware.call('disk.swaps_configure'))
+        middleware.call('disk.swaps_configure')
 
 
 async def _event_system_ready(middleware, event_type, args):

--- a/src/middlewared/middlewared/plugins/disk.py
+++ b/src/middlewared/middlewared/plugins/disk.py
@@ -1965,7 +1965,6 @@ async def devd_zfs_hook(middleware, data):
     # it in sync every time there is a change.
     if data.get('type') in (
         'misc.fs.zfs.config_sync',
-        'misc.fs.zfs.pool_create',
         'misc.fs.zfs.pool_destroy',
         'misc.fs.zfs.pool_import',
     ):

--- a/src/middlewared/middlewared/plugins/disk.py
+++ b/src/middlewared/middlewared/plugins/disk.py
@@ -1423,6 +1423,7 @@ class DiskService(CRUDService):
                 existing_swap_devices['mirrors'].append(i.devname)
             else:
                 existing_swap_devices['partitions'].append(i.devname)
+                used_partitions.add(i.devname.replace('.eli', ''))
 
         klass = geom.class_by_name('MIRROR')
         if klass:

--- a/src/middlewared/middlewared/plugins/disk.py
+++ b/src/middlewared/middlewared/plugins/disk.py
@@ -1473,7 +1473,7 @@ class DiskService(CRUDService):
                         # to avoid errors in the console (#27516)
                         cp = await run('savecore', '-z', '-m', '5', '/data/crash/', f'/dev/{p.name}', check=False)
                         if cp.returncode:
-                            self.middleware.logger.debug(
+                            self.middleware.logger.error(
                                 'Failed to savecore for "%s": ', f'/dev/{p.name}', cp.stderr.decode()
                             )
                         if g.name in disks:
@@ -1581,9 +1581,9 @@ class DiskService(CRUDService):
             except OSError:
                 pass
             os.symlink(f'/dev/{name}', '/dev/dumpdev')
-            cp = await run('dumpon', f'/dev/{name}')
+            cp = await run('dumpon', f'/dev/{name}', check=False)
             if cp.returncode:
-                self.middleware.logger.debug(
+                self.middleware.logger.error(
                     'Failed to specify "%s" device for crash dumps: %s', f'/dev/{name}', cp.stderr.decode()
                 )
             else:

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -704,6 +704,7 @@ class PoolService(CRUDService):
             # regenerate crontab because of scrub
             await self.middleware.call('service.restart', 'cron')
 
+        await self.middleware.call('disk.swaps_configure')
         asyncio.ensure_future(restart_services())
 
         pool = await self._get_instance(pool_id)
@@ -2497,7 +2498,7 @@ class PoolService(CRUDService):
 
         # Configure swaps after importing pools. devd events are not yet ready at this
         # stage of the boot process.
-        self.middleware.call('disk.swaps_configure')
+        self.middleware.call_sync('disk.swaps_configure')
 
         job.set_progress(100, 'Pools import completed')
 

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -2497,7 +2497,7 @@ class PoolService(CRUDService):
 
         # Configure swaps after importing pools. devd events are not yet ready at this
         # stage of the boot process.
-        self.middleware.run_coroutine(self.middleware.call('disk.swaps_configure'), wait=False)
+        self.middleware.call('disk.swaps_configure')
 
         job.set_progress(100, 'Pools import completed')
 

--- a/src/middlewared/middlewared/pytest/functional/test_0025_disk.py
+++ b/src/middlewared/middlewared/pytest/functional/test_0025_disk.py
@@ -9,7 +9,7 @@ def test_disk_query(conn):
 
 
 def test_disk_swaps_configure(conn):
-    swaps = conn.ws.call('disk.swaps_configure')
+    swaps = conn.ws.call('disk.swaps_configure', job=True)
     assert isinstance(swaps, list)
 
 
@@ -17,7 +17,7 @@ def test_disk_swaps_remove_disks(conn):
     disks = [d['name'] for d in conn.ws.call('disk.query')]
     conn.ws.call('disk.swaps_remove_disks', disks)
 
-    swaps = conn.ws.call('disk.swaps_configure')
+    swaps = conn.ws.call('disk.swaps_configure', job=True)
     assert isinstance(swaps, list)
 
 


### PR DESCRIPTION
This PR introduces following changes:
1) Fix race condition where `swaps_configure` can be called when another call to the same endpoint is already executing resulting in undesired behaviour.
2) Do not try to `savecore` for partitions which are already being used in swap.
3) Configure dump device again if current dump device is removed from swap.
4) Fix race condition where sometimes creating a pool would not result in swap being configured as we rely on zfs event to configure swap which is raised as soon as the pool is created. However, during configuration we use database to find out current pools and retrieve valid disks - but if the pool hasn't been saved yet in the database, we don't find those disks resulting in swap not being configured.