### PR TITLE
NAS-105295 / 12.0 / Bug fixes for swap configuration (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/dumpdev_freebsd.py
+++ b/src/middlewared/middlewared/plugins/disk_/dumpdev_freebsd.py
@@ -15,5 +15,11 @@ class DiskService(Service):
             except OSError:
                 pass
             os.symlink(f'/dev/{name}', '/dev/dumpdev')
-            await run('dumpon', f'/dev/{name}')
+            cp = await run('dumpon', f'/dev/{name}', check=False)
+            if cp.returncode:
+                self.middleware.logger.error(
+                    'Failed to specify "%s" device for crash dumps: %s', f'/dev/{name}', cp.stderr.decode()
+                )
+            else:
+                self.middleware.logger.debug('Configured "%s" device for crash dumps.', f'/dev/{name}')
         return True

--- a/src/middlewared/middlewared/plugins/disk_/swap_remove.py
+++ b/src/middlewared/middlewared/plugins/disk_/swap_remove.py
@@ -1,3 +1,6 @@
+import os
+
+from middlewared.utils.osc import IS_LINUX
 from middlewared.service import private, Service
 from middlewared.utils import run
 
@@ -38,9 +41,19 @@ class DiskService(Service):
                     await self.middleware.call('disk.destroy_swap_mirror', mirror['name'])
                     destroyed_mirror = True
 
+        configure_swap = False
         for p in providers.values():
             devname = p['encrypted_provider'] or p['path']
             if devname in swap_devices:
                 await run('swapoff', devname)
             if p['encrypted_provider']:
                 await self.middleware.call('disk.remove_encryption', p['encrypted_provider'])
+            if not IS_LINUX and os.path.realpath('/dev/dumpdev') == p['path']:
+                configure_swap = True
+                try:
+                    os.unlink('/dev/dumpdev')
+                except OSError:
+                    pass
+
+        if configure_swap:
+            await self.middleware.call('disk.swaps_configure')

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -697,6 +697,7 @@ class PoolService(CRUDService):
             # regenerate crontab because of scrub
             await self.middleware.call('service.restart', 'cron')
 
+        await self.middleware.call('disk.swaps_configure')
         asyncio.ensure_future(restart_services())
 
         pool = await self.get_instance(pool_id)

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -1678,7 +1678,7 @@ class PoolService(CRUDService):
         # stage of the boot process.
         if osc.IS_FREEBSD:
             # For now let's make this FreeBSD specific as we may very well be getting zfs events here in linux
-            self.middleware.run_coroutine(self.middleware.call('disk.swaps_configure'), wait=False)
+            self.middleware.call_sync('disk.swaps_configure')
 
         job.set_progress(100, 'Pools import completed')
 

--- a/src/middlewared/middlewared/plugins/zfs_/zfs_events.py
+++ b/src/middlewared/middlewared/plugins/zfs_/zfs_events.py
@@ -137,7 +137,6 @@ async def devd_zfs_hook(middleware, data):
         await middleware.call('cache.pop', CACHE_POOLS_STATUSES)
     elif data.get('type') in (
         'misc.fs.zfs.config_sync',
-        'misc.fs.zfs.pool_create',
         'misc.fs.zfs.pool_destroy',
         'misc.fs.zfs.pool_import',
     ):
@@ -167,7 +166,6 @@ async def zfs_events(middleware, data):
         await middleware.call('cache.pop', CACHE_POOLS_STATUSES)
     elif event_id in (
         'sysevent.fs.zfs.config_sync',
-        'sysevent.fs.zfs.pool_create',
         'sysevent.fs.zfs.pool_destroy',
         'sysevent.fs.zfs.pool_import',
     ):

--- a/src/middlewared/middlewared/plugins/zfs_/zfs_events.py
+++ b/src/middlewared/middlewared/plugins/zfs_/zfs_events.py
@@ -8,7 +8,6 @@ from middlewared.alert.base import (
 from middlewared.utils import osc, start_daemon_thread
 
 CACHE_POOLS_STATUSES = 'system.system_health_pools'
-EVENT_LOCK = asyncio.Lock()
 
 SCAN_THREADS = {}
 
@@ -145,7 +144,7 @@ async def devd_zfs_hook(middleware, data):
         # Swap must be configured only on disks being used by some pool,
         # for this reason we must react to certain types of ZFS events to keep
         # it in sync every time there is a change.
-        asyncio.ensure_future(middleware.call('disk.swaps_configure'))
+        await middleware.call('disk.swaps_configure')
 
 
 async def zfs_events(middleware, data):
@@ -172,8 +171,7 @@ async def zfs_events(middleware, data):
         'sysevent.fs.zfs.pool_destroy',
         'sysevent.fs.zfs.pool_import',
     ):
-        async with EVENT_LOCK:
-            await middleware.call('disk.swaps_configure')
+        await middleware.call('disk.swaps_configure')
 
 
 def setup(middleware):

--- a/src/middlewared/middlewared/pytest/functional/test_0025_disk.py
+++ b/src/middlewared/middlewared/pytest/functional/test_0025_disk.py
@@ -9,7 +9,7 @@ def test_disk_query(conn):
 
 
 def test_disk_swaps_configure(conn):
-    swaps = conn.ws.call('disk.swaps_configure')
+    swaps = conn.ws.call('disk.swaps_configure', job=True)
     assert isinstance(swaps, list)
 
 
@@ -17,7 +17,7 @@ def test_disk_swaps_remove_disks(conn):
     disks = [d['name'] for d in conn.ws.call('disk.query')]
     conn.ws.call('disk.swaps_remove_disks', disks)
 
-    swaps = conn.ws.call('disk.swaps_configure')
+    swaps = conn.ws.call('disk.swaps_configure', job=True)
     assert isinstance(swaps, list)
 
 


### PR DESCRIPTION
This PR introduces following changes:

1) Fix race condition where `swaps_configure` can be called when another call to the same endpoint is already executing resulting in undesired behaviour.
2) Configure dump device again if current dump device is removed from swap.
3) Fix race condition where sometimes creating a pool would not result in swap being configured as we rely on zfs event to configure swap which is raised as soon as the pool is created. However, during configuration we use database to find out current pools and retrieve valid disks - but if the pool hasn't been saved yet in the database, we don't find those disks resulting in swap not being configured.