### PR TITLE
NAS-105231 / 12.0 / Prevent users from setting an ACL that lacks inheritable entries (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -826,6 +826,7 @@ class FilesystemService(Service):
             a.strip()
             a.apply(data['path'])
         else:
+            inheritable_is_present = False
             cleaned_acl = []
             lockace_is_present = False
             for entry in dacl:
@@ -843,7 +844,14 @@ class FilesystemService(Service):
                     )
                 if ace['tag'] == 'EVERYONE' and self.__convert_to_basic_permset(ace['perms']) == 'NOPERMS':
                     lockace_is_present = True
+                elif ace['flags'].get('DIRECTORY_INHERIT') or ace['flags'].get('FILE_INHERIT'):
+                    inheritable_is_present = True
+
                 cleaned_acl.append(ace)
+
+            if not inheritable_is_present:
+                raise CallError('At least one inheritable ACL entry is required', errno.EINVAL)
+
             if options['canonicalize']:
                 cleaned_acl = self.canonicalize_acl_order(cleaned_acl)
 


### PR DESCRIPTION
This ACl combination is always a mistake and shouldn't be permitted.