### PR TITLE
NAS-105304 / 11.2 / fix race with SO_REUSEADDR and TIME_WAIT

### DIFF
--- a/src/middlewared/middlewared/client/client.py
+++ b/src/middlewared/middlewared/client/client.py
@@ -95,7 +95,6 @@ class WSClient(WebSocketClient):
 
             self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
             self.sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-            self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
         raise ReserveFDException()
 


### PR DESCRIPTION
11.2-U8 on TrueNAS HA exposed a bunch of `errno 48 Address already in use` issues. The reason why this changed in 11.2-U8, is because an unrelated memory leak fix went in here: 409fca936e4eb404c179620b70aeaa6c7d232f27 and here: 117150dbda06959f262451e0bc7a7317e65b7058 which caught the exceptions properly.

The tracebacks that are being encountered all have the same callstack.
`File "/usr/local/lib/middlewared_truenas/plugins/failover.py", line 149, in call_remote
with Client(f'ws://{remote}:6000/websocket', reserved_ports=True, reserved_ports_blacklist=[860]) as c:
File "/usr/local/lib/python3.6/site-packages/middlewared/client/client.py", line 238, in _init_
self._ws.connect()
File "/usr/local/lib/python3.6/site-packages/middlewared/client/client.py", line 111, in connect
rv = super(WSClient, self).connect()
File "/usr/local/lib/python3.6/site-packages/ws4py/client/_init_.py", line 208, in connect
self.sock.connect(self.bind_addr)
OSError: [Errno 48] Address already in use`

We have passed the `sock.bind()` stage, meaning that's been successful. However, we are failing on the `sock.connect()`.

This is because we set the `SO_REUSEADDR` socket option. This allows us to re-use the same local address and port, however, we cannot connect to the same remote address and port.

The reason why we're hitting this is because of a race between the SO_REUSEADDR and the tcp state of TIME_WAIT.

A rough set of steps shows what happens on TrueNAS HA when making remote API requests.

sock.bind() -> sock.connect() -> finish sending data -> sock.close() -> socket goes into `TIME_WAIT`

The `TIME_WAIT` is expected behavior but there is a timeout involved before the kernel fully tears down that socket. Depending on the timing of when that socket goes into `TIME_WAIT` and when we `sock.bind()` OR `sock.connect()` we can get the `[errno 48]` traceback. This has been an issue for roughly 2 years based on past tickets I researched in redmine.