### PR TITLE
Generate smb4.conf if needed during smb_configure

### DIFF
--- a/src/middlewared/middlewared/etc_files/smb_configure.py
+++ b/src/middlewared/middlewared/etc_files/smb_configure.py
@@ -27,6 +27,9 @@ def get_config(middleware):
     """
     Set basic configuration
     """
+    if not os.path.exists(SMBPath.GLOBALCONF.platform()):
+        middleware.call_sync("etc.generate", "smb")
+
     conf = {}
     conf['systemdataset'] = middleware.call_sync('systemdataset.config')
     if conf['systemdataset']['path'] is None:

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -769,8 +769,8 @@ class SharingSMBService(CRUDService):
                     kv = param.split('=', 1)
                     ret[kv[0].strip()] = kv[1].strip()
                 except Exception:
-                    self.logger.debug("[%s] contains invalid auxiliary parameter: [%s]",
-                                      aux['name'], param)
+                    self.logger.debug("Share contains invalid auxiliary parameter: [%s]",
+                                      param)
             return ret
 
         if direction == 'FROM':


### PR DESCRIPTION
If for some reason /usr/local/etc/smb4.conf is deleted, then
etc.generate smb_configure will fail.

Fix traceback in smb.update when smb.conf has invalid aux parameter.