### PR TITLE
NAS-105340 / 12.0 / Show middleware version on startup (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -6,7 +6,7 @@ from .pipe import Pipes, Pipe
 from .restful import RESTfulAPI
 from .schema import Error as SchemaError
 from .service_exception import adapt_exception, CallError, CallException, ValidationError, ValidationErrors
-from .utils import osc, start_daemon_thread, LoadPluginsMixin
+from .utils import osc, start_daemon_thread, sw_version, LoadPluginsMixin
 from .utils.debug import get_frame_details, get_threads_stacks
 from .utils.lock import SoftHardSemaphore, SoftHardSemaphoreLimit
 from .utils.io_thread_pool_executor import IoThreadPoolExecutor
@@ -760,6 +760,7 @@ class Middleware(LoadPluginsMixin, RunInThreadMixin):
         self.logger = logger.Logger(
             'middlewared', debug_level, log_format
         ).getLogger()
+        self.logger.info('Starting %s middleware', sw_version())
         self.crash_reporting = logger.CrashReporting()
         self.crash_reporting_semaphore = asyncio.Semaphore(value=2)
         self.loop_debug = loop_debug


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 6e89677fe91229e1456111e16cdff119e068294d

Reason is that it's not always clear which middleware version emitted specific log errors