### PR TITLE
NAS-105336 / 11.3 / Allow internal UNIX socket authentication for plugins that run in sep… (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -808,6 +808,8 @@ class Middleware(LoadPluginsMixin, RunInThreadMixin):
             plugin, function = plugin__function
 
             beginning = [
+                # Allow internal UNIX socket authentication for plugins that run in separate pools
+                'auth',
                 # We need to run system plugin setup's function first because when system boots, the right
                 # timezone is not configured. See #72131
                 'system',


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 54594ccf00bd13c13adfa9e7fec5dd4a91b24e19

…arate pools