### PR TITLE
NAS-105324 / 11.3 / Increase timeout for grub call to 5 seconds

### DIFF
--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -277,7 +277,8 @@ class VMSupervisor(object):
             )
 
             try:
-                await asyncio.wait_for(self.grub_proc.communicate(), 2)
+                # We wait for 5 seconds before timing out - See #105324
+                await asyncio.wait_for(self.grub_proc.communicate(), 5)
             except asyncio.TimeoutError:
                 try:
                     os.kill(self.grub_proc.pid, signal.SIGKILL)


### PR DESCRIPTION
It is possible in some cases grub takes a bit more then 2 seconds to start up especially when the system has just booted and is setting up other services.