### PR TITLE
NAS-105356 / 12.0 / Update zilstat for OpenZFS 2.0

### DIFF
--- a/src/freenas/usr/local/bin/zilstat
+++ b/src/freenas/usr/local/bin/zilstat
@@ -216,7 +216,7 @@ profile:::tick-1sec
 	line = LINES;
 }
 
- fbt::txg_quiesce:entry
+ openzfs::txg-quiescing
  /OPT_txg == 1 && POOL == args[0]->dp_spa->spa_name && line == 0/
  {
 	OPT_time  ? printf("%-20s ", "TIME")  : 1;
@@ -263,7 +263,7 @@ profile:::tick-1sec
 	line--;
  }
 
-fbt::txg_quiesce:entry
+openzfs::txg-quiescing
 /OPT_txg == 1 && POOL == args[0]->dp_spa->spa_name/
 {
         secs <= 0 ? secs=1 : 1;
@@ -300,7 +300,7 @@ fbt::txg_quiesce:entry
  {
 	exit(0);
  }
- fbt::txg_quiesce:entry
+ openzfs::txg-quiescing
  /OPT_txg == 1 && counts == 0/
  {
     exit(0);


### PR DESCRIPTION
Use openzfs::txg-quiescing probe instead of fbt::txg_quiesce.

Jira: NAS-105356