### PR TITLE
NAS-105240 / 11.3 / Allow setting EKU sever extension for server certs

### DIFF
--- a/src/middlewared/middlewared/plugins/crypto.py
+++ b/src/middlewared/middlewared/plugins/crypto.py
@@ -360,7 +360,8 @@ class CryptoKeyService(Service):
     @accepts(
         Patch(
             'certificate_cert_info', 'generate_certificate_signing_request',
-            ('rm', {'name': 'lifetime'})
+            ('rm', {'name': 'lifetime'}),
+            ('rm', {'name': 'server_auth_eku'}),
         )
     )
     def generate_certificate_signing_request(self, data):
@@ -1739,6 +1740,7 @@ class CertificateAuthorityService(CRUDService):
             'certificate_create', 'ca_create',
             ('edit', _set_enum('create_type')),
             ('rm', {'name': 'dns_mapping'}),
+            ('rm', {'name': 'server_auth_eku'}),
             register=True
         )
     )

--- a/src/middlewared/middlewared/plugins/crypto.py
+++ b/src/middlewared/middlewared/plugins/crypto.py
@@ -33,6 +33,7 @@ CERT_TYPE_CSR = 0x20
 
 CERT_ROOT_PATH = '/etc/certificates'
 CERT_CA_ROOT_PATH = '/etc/certificates/CA'
+NOT_VALID_AFTER = 825
 RE_CERTIFICATE = re.compile(r"(-{5}BEGIN[\s\w]+-{5}[^-]+-{5}END[\s\w]+-{5})+", re.M | re.S)
 
 
@@ -319,7 +320,7 @@ class CryptoKeyService(Service):
                 'common_name': 'localhost',
                 'email_address': 'info@ixsystems.com'
             },
-            'lifetime': 3600
+            'lifetime': NOT_VALID_AFTER
         })
         key = self.generate_private_key({
             'serialize': False,
@@ -579,7 +580,9 @@ class CryptoKeyService(Service):
         # Lifetime represents no of days
         # Let's normalize lifetime value
         not_valid_before = datetime.datetime.utcnow()
-        not_valid_after = datetime.datetime.utcnow() + datetime.timedelta(days=options.get('lifetime') or 3600)
+        not_valid_after = datetime.datetime.utcnow() + datetime.timedelta(
+            days=options.get('lifetime') or NOT_VALID_AFTER
+        )
 
         # Let's normalize `san`
         san = x509.SubjectAlternativeName([


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x c875d3fb9a0d93c0aaf1660b6bc7d818f5f70002
    git cherry-pick -x 02de4076f466cde3627879b7dd6c5a47da7c7851

This PR introduces changes where we update the default value of `not_valid_after` attribute of a digital certificate conforming to https://support.apple.com/en-us/HT210176.

It should be noted that we allow specifying EKU extension, so certificates should set them themselves based on their usage, i.e `SERVER_AUTH`/`CLIENT_AUTH` as it's required for server certificates now.
