### PR TITLE
NAS-105374 / 12.0 / Default to advertising ipv4 and ipv6 in avahi-daemon.conf

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/avahi/avahi-daemon.conf
+++ b/src/middlewared/middlewared/etc_files/local/avahi/avahi-daemon.conf
@@ -14,16 +14,16 @@
 # USA.
 # See avahi-daemon.conf(5).
 <%
-    def ipv4_enabled():
-        return any(middleware.call_sync('interface.ip_in_use', {'ipv4': True, 'ipv6': False}))
+    ipv4_enabled = any(middleware.call_sync('interface.ip_in_use', {'ipv4': True, 'ipv6': False}))
 
-    def ipv6_enabled():
-        return any(middleware.call_sync('interface.ip_in_use', {'ipv4': False, 'ipv6': True}))
+    ipv6_enabled = any(middleware.call_sync('interface.ip_in_use', {'ipv4': False, 'ipv6': True}))
 %>
 
 [server]
-use-ipv4=${"yes" if ipv4_enabled() else "no"}
-use-ipv6=${"yes" if ipv6_enabled() else "no"}
+%if ipv4_enabled or ipv6_enabled:
+use-ipv4=${"yes" if ipv4_enabled else "no"}
+use-ipv6=${"yes" if ipv6_enabled else "no"}
+%endif
 ratelimit-interval-usec=1000000
 ratelimit-burst=1000
 enable-dbus=no

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1804,7 +1804,7 @@ class InterfaceService(CRUDService):
     )
     def ip_in_use(self, choices=None):
         """
-        Get all IPv4 / Ipv6 from all valid interfaces, excluding bridge, tap and epair.
+        Get all IPv4 / Ipv6 from all valid interfaces, excluding tap and epair.
 
         `loopback` will return loopback interface addresses.
 
@@ -1830,7 +1830,7 @@ class InterfaceService(CRUDService):
 
         """
         list_of_ip = []
-        ignore_nics = ['bridge', 'tap', 'epair', 'pflog']
+        ignore_nics = ['tap', 'epair', 'pflog']
         if not choices['loopback']:
             ignore_nics.append('lo')
         ignore_nics = tuple(ignore_nics)


### PR DESCRIPTION
If for some reason we fail to detect ipv4 or ipv6 addresses, fall back to avahi defaults.