### PR TITLE
Disallow creating raidz vdevs for special/dedup devices

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -487,14 +487,14 @@ class PoolService(CRUDService):
             List('special', items=[
                 Dict(
                     'specialvdevs',
-                    Str('type', enum=['RAIDZ1', 'RAIDZ2', 'RAIDZ3', 'MIRROR', 'STRIPE'], required=True),
+                    Str('type', enum=['MIRROR', 'STRIPE'], required=True),
                     List('disks', items=[Str('disk')], required=True),
                 ),
             ]),
             List('dedup', items=[
                 Dict(
                     'dedupvdevs',
-                    Str('type', enum=['RAIDZ1', 'RAIDZ2', 'RAIDZ3', 'MIRROR', 'STRIPE'], required=True),
+                    Str('type', enum=['MIRROR', 'STRIPE'], required=True),
                     List('disks', items=[Str('disk')], required=True),
                 ),
             ]),


### PR DESCRIPTION
For now we disallow creating `raidz` vdevs with special/dedup devices as `zpool` command line explicitly denies it, however api allows us creating those. With some discussion with OS team, there shouldn't be any technical issues with using `raidz` but it's better not to if it's explicitly stopped via command line.