### PR TITLE
NAS-105445 / 12.0 / Place SMB username map generation in user etc plugin

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smbusername.map
+++ b/src/middlewared/middlewared/etc_files/local/smbusername.map
@@ -13,9 +13,8 @@
     ])
 
 %>
-
 % if users:
 % for user in users:
-    ${user['username']} = ${user['email']}
+${user['username']} = ${user['email']}
 % endfor
 % endif

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -76,6 +76,7 @@ class EtcService(Service):
 
     GROUPS = {
         'user': [
+            {'type': 'mako', 'path': 'local/smbusername.map'},
             {'type': 'mako', 'path': 'group', 'platform': 'FreeBSD'},
             {'type': 'mako', 'path': 'master.passwd', 'platform': 'FreeBSD'},
             {'type': 'py', 'path': 'pwd_db', 'platform': 'FreeBSD'},


### PR DESCRIPTION
The username map needs to be recalculated on local user account
modifications because the mapping map changes as email accounts
or "MS account" checkbox change values. Eliminate some whitespace.