### PR TITLE
NAS-105445 / 11.3 / Place SMB username map generation in user etc plugin (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smbusername.map
+++ b/src/middlewared/middlewared/etc_files/local/smbusername.map
@@ -13,9 +13,8 @@
     ])
 
 %>
-
 % if users:
 % for user in users:
-    ${user['username']} = ${user['email']}
+${user['username']} = ${user['email']}
 % endfor
 % endif

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -64,6 +64,7 @@ class EtcService(Service):
             {'type': 'mako', 'path': 'group'},
             {'type': 'mako', 'path': 'master.passwd'},
             {'type': 'py', 'path': 'pwd_db'},
+            {'type': 'mako', 'path': 'local/smbusername.map'},
         ],
         'kerberos': [
             {'type': 'mako', 'path': 'krb5.conf'},
@@ -167,7 +168,6 @@ class EtcService(Service):
             {'type': 'mako', 'path': 'local/smb4_share.conf'},
         ],
         'smb_configure': [
-            {'type': 'mako', 'path': 'local/smbusername.map'},
             {'type': 'py', 'path': 'smb_configure'},
         ],
         'snmpd': [


### PR DESCRIPTION
The username map needs to be recalculated on local user account
modifications because the mapping map changes as email accounts
or "MS account" checkbox change values. Eliminate some whitespace.