### PR TITLE
NAS-105428 / 12.0 / Preserve slot address for NIC device

### DIFF
--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -458,6 +458,8 @@ class VMSupervisor:
                     }
 
                 device_xml = device.xml(child_element=create_element('address', **address_dict))
+            elif isinstance(device, NIC):
+                device_xml = device.xml(slot=pci_slot())
             else:
                 device_xml = device.xml()
 
@@ -650,6 +652,7 @@ class NIC(Device):
                         'mac', address=self.data['attributes']['mac'] if
                         self.data['attributes'].get('mac') else self.random_mac()
                     ),
+                    create_element('address', type='pci', slot=str(kwargs['slot'])),
                 ]
             }
         )


### PR DESCRIPTION
This commit introduces changes where we make sure that for a NIC device, we manually specify the slot address so that it is consistent for users upgrading from 11.3. The order of devices is maintained as it was in 11.3 to ensure that we have no disruptions on that end.