### PR TITLE
NAS-105443 / 11.3 / Get list of SMB IP addresses from interface.ip_in_use (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf
@@ -78,7 +78,17 @@
             smbpasswd by default connects to 127.0.0.1 as an SMB client. For this reason, localhost is added
             to the list of bind ip addresses here.
             """
-            if db['cifs']['bindip']:
+            allowed_ips = middleware.call_sync('smb.bindip_choices')
+            validated_bind_ips = []
+            for address in db['cifs']['bindip']:
+                if allowed_ips.get(address):
+                    validated_bind_ips.append(interface)
+                else:
+                    middleware.logger.warning("IP address [%s] is no longer in use "
+                                              "and should be removed from SMB configuration.",
+                                              interface)
+
+            if validated_bind_ips:
                 bindips = (db['cifs']['bindip'])
                 bindips.insert(0, "127.0.0.1")
                 pc.update({'interfaces': " ".join(bindips)})

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -138,9 +138,8 @@ class SMBService(SystemServiceService):
         Addresses assigned by DHCP are excluded from the results.
         """
         choices = {}
-        for i in await self.middleware.call('interface.query'):
-            for alias in i['aliases']:
-                choices[alias['address']] = alias['address']
+        for i in await self.middleware.call('interface.ip_in_use'):
+            choices[i['address']] = i['address']
         return choices
 
     @accepts()


### PR DESCRIPTION
- Get full list of addresses
- Validate user-provided addresses at smb.conf generation time
  to avoid having stale IP address prevent SMB access.