### PR TITLE
Convert UIDs to usernames rather than groupnames in zfs.get_quota

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -549,7 +549,7 @@ class ZFSDatasetService(CRUDService):
                 entry['obj_used_percent'] = entry['obj_used'] / entry['obj_quota'] * 100
 
             try:
-                if quota_type == 'USER':
+                if entry['quota_type'] == 'USER':
                     entry['name'] = (
                         self.middleware.call_sync('user.get_user_obj',
                                                   {'uid': entry['id']})


### PR DESCRIPTION
This one slipped by because the test set had users with primary
groups with identical names, and the default idmap backends for
AD support ID_TYPE_BOTH.