### PR TITLE
NAS-105440 / 11.3 / Check for path before generating SMB share

### DIFF
--- a/src/middlewared/middlewared/etc_files/afpd.py
+++ b/src/middlewared/middlewared/etc_files/afpd.py
@@ -132,6 +132,10 @@ def render(service, middleware):
     cf_contents.append("\n")
 
     for share in middleware.call_sync('datastore.query', 'sharing.afp_share', [['afp_enabled', '=', True]]):
+        if not os.path.exists(share['afp_path']):
+            middleware.logger.warning("Path [%s] to share [%s] does not exist",
+                                      share["afp_path"], share["afp_name"])
+            continue
         share = Struct(share)
         if share.afp_home:
             cf_contents.append("[Homes]\n")

--- a/src/middlewared/middlewared/etc_files/local/smb4_share.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4_share.conf
@@ -69,6 +69,11 @@
         def parse_db_config(db):
             pc = {}
             for share in db['shares']:
+                if not os.path.exists(share['path']):
+                    middleware.logger.warning('Path [%s] to share [%s] does not exist',
+                                              share['path'], share['name'])
+                    continue
+
                 """
                     Special behavior is needed for [homes]:
                     We append %U (authenticated username) to the share path


### PR DESCRIPTION
SMB share presence can cause user confusion if pool is encrypted and locked (or path is otherwise unavailable).