### PR TITLE
NAS-105476 / 11.3 / Fix ordering of vfs modules for shadow copies containing streams

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4_share.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4_share.conf
@@ -44,7 +44,7 @@
             return ret
 
         def order_vfs_objects(vfs_objects):
-            vfs_objects_special = ('shadow_copy_zfs', 'catia', 'zfs_space', 'fruit', 'streams_xattr',
+            vfs_objects_special = ('catia', 'fruit', 'streams_xattr', 'shadow_copy_zfs', 'zfs_space',
                                    'noacl', 'ixnas', 'zfsacl', 'crossrename', 'recycle')
             vfs_objects_ordered = []
 


### PR DESCRIPTION
Stream parsing needs to happen before shadow copies are handled otherwise restoring files with alternate datastreams is broken.