### PR TITLE
NAS-105325 / 12.0 / Fix setusercontext not setting user auxiliary groups (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/utils/osc/freebsd/user_context.py
+++ b/src/middlewared/middlewared/utils/osc/freebsd/user_context.py
@@ -24,6 +24,7 @@ def setusercontext(user):
     lc = libutil.login_getpwclass(pwnam)
     os.setgid(passwd.pw_gid)
     if lc and lc[0]:
+        libc.initgroups(user.encode('ascii'), passwd.pw_gid)
         libutil.setusercontext(
             lc, pwnam, passwd.pw_uid, ctypes.c_uint(0x07ff)  # 0x07ff LOGIN_SETALL
         )
@@ -31,7 +32,7 @@ def setusercontext(user):
     else:
         os.setgid(passwd.pw_gid)
         libc.setlogin(user)
-        libc.initgroups(user, passwd.pw_gid)
+        libc.initgroups(user.encode('ascii'), passwd.pw_gid)
         os.setuid(passwd.pw_uid)
 
     try:


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x b56d3595b5b1e56d0219a863736d8ee05d9e2a18

