### PR TITLE
Fix vfs object ordering and include registry

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf
@@ -412,3 +412,4 @@
       % endif
     % endfor
         registry shares = yes
+        include = registry

--- a/src/middlewared/middlewared/plugins/smb_/registry.py
+++ b/src/middlewared/middlewared/plugins/smb_/registry.py
@@ -136,7 +136,7 @@ class SharingSMBService(Service):
 
     @private
     async def order_vfs_objects(self, vfs_objects):
-        vfs_objects_special = ('shadow_copy_zfs', 'catia', 'zfs_space', 'fruit', 'streams_xattr',
+        vfs_objects_special = ('catia', 'zfs_space', 'fruit', 'streams_xattr', 'shadow_copy_zfs',
                                'noacl', 'ixnas', 'zfsacl', 'crossrename', 'recycle')
 
         vfs_objects_ordered = []


### PR DESCRIPTION
streams_xattr must come before shadow copy modules in order to
properly support previous versions of files with streams. Registry
must be included for registry shares (not including breaks fsrvp).