### PR TITLE
NAS-105471 / 12.0 / When fibrechannel is licensed, keep ctld running on passive node even…

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/event.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/event.py
@@ -743,8 +743,7 @@ class FailoverService(Service):
                 ):
                     verb = 'restart'
                     if i == 'iscsitarget':
-                        iscsicfg = self.run_call('iscsi.global.config')
-                        if iscsicfg and iscsicfg['alua'] is False:
+                        if not self.run_call('iscsi.global.alua_enabled'):
                             verb = 'stop'
 
                     ret = self.run_call('datastore.query', 'services.services', [('srv_service', '=', i)])


### PR DESCRIPTION
… if alua is disabled