### PR TITLE
NAS-105328 / 12.0 / Correctly split for rsync extra args

### DIFF
--- a/src/middlewared/middlewared/plugins/rsync.py
+++ b/src/middlewared/middlewared/plugins/rsync.py
@@ -29,7 +29,6 @@ import asyncssh
 import contextlib
 import glob
 import os
-import re
 import shlex
 
 from middlewared.async_validators import check_path_resides_within_volume
@@ -256,7 +255,7 @@ class RsyncTaskService(CRUDService):
 
     @private
     async def rsync_task_extend(self, data, context):
-        data['extra'] = list(filter(None, re.split(r"\s+", data["extra"])))
+        data['extra'] = shlex.split(data['extra'].replace('"', r'"\"').replace("'", r'"\"'))
         for field in ('mode', 'direction'):
             data[field] = data[field].upper()
         Cron.convert_db_format_to_schedule(data)


### PR DESCRIPTION
This commit introduces changes where we fix a case when we used to split on space which broke rsync extra args containing spaces.
An example:
So `--rsync-path="sudo rsync" --some-other-flag` is a valid argument, which if we split on space would make it wrong as we would be splitting between `sudo` and `rsync` too.
With these changes, we use escape single and double quotes to have double quotes around them,
This arg `--rsync-path="sudo rsync" --rsync-path='sudo rsync'` is converted to `--rsync-path="sudo rsync" --rsync-path="sudo rsync"`.