### PR TITLE
NAS-105535 / 12.0 / Gather more verbose share ACL information in debug

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/smb_freebsd/smb.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/smb_freebsd/smb.sh
@@ -134,8 +134,8 @@ smb_func()
 	smbstatus -L | head -50
 	section_footer
 	
-	section_header "ACLs - 'sharesec --view-all'"
-	sharesec --view-all
+	section_header "ACLs - 'midclt call smb.sharesec.query'"
+	midclt call smb.sharesec.query | jq
 	section_footer
 
 	section_header "Local users in passdb.tdb"


### PR DESCRIPTION
If winbindd is running this will convert SIDs (often not helpful) into names (somewhat more helpful).