### PR TITLE
NAS-105492 / 11.3 / Make multiple LDAP samba domains non-fatal (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -752,7 +752,8 @@ class LDAPService(ConfigService):
             raise CallError(f'ldap.get_workgroup timed out after {ldap["timeout"]} seconds.', errno.ETIMEDOUT)
 
         if len(ret) > 1:
-            raise CallError(f'Multiple Samba Domains detected in LDAP environment: {ret}', errno.EINVAL)
+            self.logger.warning('Multiple Samba Domains detected in LDAP environment '
+                                'auto-configuration of workgroup map have failed: %s', ret)
 
         ret = ret[0]['data']['sambaDomainName'][0] if ret else []
 


### PR DESCRIPTION
Make middleware a little more tolerant of misconfigured LDAP samba
schema. Guess that the first SambaDomain is the correct one.