### PR TITLE
NAS-105508 / 11.3 / Make failure to remove computer object from AD non-fatal (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -1495,7 +1495,7 @@ class ActiveDirectoryService(ConfigService):
 
         netads = await run([SMBCmd.NET.value, '-U', data['username'], '-k', 'ads', 'leave'], check=False)
         if netads.returncode != 0:
-            raise CallError(f"Failed to leave domain: [{netads.stderr.decode()}]")
+            self.logger.warning("Failed to leave domain: %s", netads.stderr.decode())
 
         if smb_ha_mode != 'LEGACY':
             krb_princ = await self.middleware.call(


### PR DESCRIPTION
Deleting the AD computer object is a secondary goal. Log the event
if we fail, but continue with cleaning up kerberos information.