### PR TITLE
NAS-105557 / 12.0 / fix resolve_hostname method

### DIFF
--- a/src/middlewared/middlewared/async_validators.py
+++ b/src/middlewared/middlewared/async_validators.py
@@ -25,7 +25,9 @@ async def resolve_hostname(middleware, verrors, name, hostname):
                 ip(hostname)
                 return hostname
             except ValueError:
-                return socket.gethostbyname(hostname)
+                socket.gethostbyaddr(hostname)
+                result = socket.getaddrinfo(hostname, None, flags=socket.AI_CANNONNAME)
+                return result[0][3]
         except Exception:
             return False
 


### PR DESCRIPTION
If you were to send `192.168` to this method, it would fail the ip check and raise a ValueError but then it would be expanded to `192.0.0.168` by the `gethostbyname()` call. This fixes that problem and furthermore, this method did not support IPv6 which I've fixed too.