### PR TITLE
NAS-105557 / 12.0 / fix resolve_hostname async validator

### DIFF
--- a/src/middlewared/middlewared/async_validators.py
+++ b/src/middlewared/middlewared/async_validators.py
@@ -25,7 +25,9 @@ async def resolve_hostname(middleware, verrors, name, hostname):
                 ip(hostname)
                 return hostname
             except ValueError:
-                return socket.gethostbyname(hostname)
+                socket.gethostbyaddr(hostname)
+                result = socket.getaddrinfo(hostname, None, flags=socket.AI_CANONNAME)
+                return result[0][3]
         except Exception:
             return False
 


### PR DESCRIPTION
If you send a short-hand IP address (i.e. `192.168`) to this method, it will raise a ValueError as expected, however the `gethostbyname()` method auto-expands the IP address to `192.0.0.168`.

Furthermore, `gethostbyname()` doesn't support IPv6 which I've fixed.