### PR TITLE
NAS-105558 / 12.0 / add ResolveHostOrIp validator

### DIFF
--- a/src/middlewared/middlewared/alert/source/update.py
+++ b/src/middlewared/middlewared/alert/source/update.py
@@ -68,7 +68,6 @@ class HasUpdateAlertSource(ThreadedAlertSource):
         if not path:
             return
 
-
         updates = None
         try:
             if PendingUpdates:

--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -578,7 +578,7 @@ class ServicePartBaseMeta(ServiceBase):
             else:
                 original_argspec = inspect.getfullargspec(original_method)
             if original_argspec != inspect.getfullargspec(new_method):
-                raise RuntimeError(f"Signature for method {name!r} does not match between {klass!r} and it's base " 
+                raise RuntimeError(f"Signature for method {name!r} does not match between {klass!r} and it's base "
                                    f"{base!r}")
 
             copy_function_metadata(original_method, new_method)

--- a/src/middlewared/middlewared/validators.py
+++ b/src/middlewared/middlewared/validators.py
@@ -3,10 +3,28 @@ import ipaddress
 import re
 from urllib.parse import urlparse
 import uuid
+import socket
 
 from zettarepl.snapshot.task.naming_schema import validate_snapshot_naming_schema
 
 EMAIL_REGEX = re.compile(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)")
+
+
+class ResolveHostOrIp:
+    def __call__(self, value):
+        if value is None:
+            return
+
+        try:
+            try:
+                ip = ipaddress.ip_address(value)
+                return ip
+            except ValueError:
+                socket.gethostbyaddr(value)
+                result = socket.getaddrinfo(value, None, flags=AI_CANONNAME)
+                return result[0][3]
+        except Exception as e:
+            raise ValueError(f'Unable to resolve {value} or invalid IP address: {e}')
 
 
 class Email:

--- a/src/middlewared/middlewared/validators.py
+++ b/src/middlewared/middlewared/validators.py
@@ -20,8 +20,12 @@ class ResolveHostOrIp:
                 ip = ipaddress.ip_address(value)
                 return ip
             except ValueError:
+                # gethostbyaddr() is called here so that if a short-hand IP
+                # is provided (i.e. `192.168`), gethostbyaddr will raise the
+                # exception as intended. The getaddrinfo will auto-expand
+                # short-hand IP addresses which isn't desired.
                 socket.gethostbyaddr(value)
-                result = socket.getaddrinfo(value, None, flags=AI_CANONNAME)
+                result = socket.getaddrinfo(value, None, flags=socket.AI_CANONNAME)
                 return result[0][3]
         except Exception as e:
             raise ValueError(f'Unable to resolve {value} or invalid IP address: {e}')


### PR DESCRIPTION
I need a synchronous method for validating Hosts or IPs for the gluster peer API. This class does that and is directly based off the `resolve_hostname` method in the `async_validators` module (which I've also pushed a PR to fix a problem).