### PR TITLE
NAS-105573 / 12.0 / Add NTPD user

### DIFF
--- a/src/middlewared/middlewared/assets/account/builtin/freebsd/group
+++ b/src/middlewared/middlewared/assets/account/builtin/freebsd/group
@@ -26,6 +26,7 @@ network:*:69:
 audit:*:77:
 ladvd:*:78:
 www:*:80:
+ntpd:*:123:
 avahi:*:200:
 messagebus:*:201:
 nslcd:*:389:

--- a/src/middlewared/middlewared/assets/account/builtin/freebsd/passwd
+++ b/src/middlewared/middlewared/assets/account/builtin/freebsd/passwd
@@ -20,6 +20,7 @@ pop:*:68:6:Post Office Owner:/nonexistent:/usr/sbin/nologin
 auditdistd:*:78:77:Auditdistd unprivileged user:/var/empty:/usr/sbin/nologin
 ladvd:*:79:78:ladvd user:/var/empty:/usr/sbin/nologin
 www:*:80:80:World Wide Web Owner:/nonexistent:/usr/sbin/nologin
+ntpd:*:123:123:NTP Daemon:/var/db/ntp:/usr/sbin/nologin
 avahi:*:200:200:avahi user:/nonexistent:/usr/sbin/nologin
 messagebus:*:201:201:messagebus user:/nonexistent:/usr/sbin/nologin
 nslcd:*:389:389:Nslcd Daemon:/var/tmp/nslcd:/usr/sbin/nologin


### PR DESCRIPTION
NPTD now runs with `ntpd` user, so we create that user to ensure `ntpd` runs as desired.