### PR TITLE
NAS-105536 / 12.0 / Start AD on standby controller once active successfully starts (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -1048,6 +1048,13 @@ class ActiveDirectoryService(ConfigService):
             await self.middleware.call('activedirectory.get_cache')
             if ad['verbose_logging']:
                 self.logger.debug('Successfully started AD service for [%s].', ad['domainname'])
+
+            if smb_ha_mode == "LEGACY" and (await self.middleware.call('failover.status')) == 'MASTER':
+                job.set_progress(95, 'starting active directory on standby controller')
+                try:
+                    await self.middleware.call('failover.call_remote', 'activedirectory.start')
+                except Exception:
+                    self.logger.warning('Failed to start active directory service on standby controller', exc_info=True)
         else:
             await self.set_state(DSStatus['FAULTED'])
             self.logger.warning('Server is joined to domain [%s], but is in a faulted state.', ad['domainname'])
@@ -1068,6 +1075,11 @@ class ActiveDirectoryService(ConfigService):
         await self.middleware.call('etc.generate', 'pam')
         await self.middleware.call('etc.generate', 'nss')
         await self.set_state(DSStatus['DISABLED'])
+        if (await self.middleware.call('smb.get_smb_ha_mode')) == "LEGACY" and (await self.middleware.call('failover.status')) == 'MASTER':
+            try:
+                await self.middleware.call('failover.call_remote', 'activedirectory.stop')
+            except Exception:
+                self.logger.warning('Failed to stop active directory service on standby controller', exc_info=True)
 
     @private
     def validate_credentials(self, ad=None):


### PR DESCRIPTION
"Legacy" AD configuration requires that the AD service be started and running on both controllers. Make call to standby controller to start AD once we've confirmed that it's working on the active controller.