### PR TITLE
NAS-105585 / 12.0 / Add more special handling for legacy AD configuration (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf
@@ -230,6 +230,8 @@
                 })
                 if db['truenas_conf']['smb_ha_mode'] == 'UNIFIED':
                     pc.update({'ads dns update': 'No'})
+                elif db['truenas_conf']['smb_ha_mode'] == "LEGACY":
+                    pc.update({'kerberos method': 'secrets only'})
                 if not db['ad']['disable_freenas_cache']:
                     pc.update({'winbind enum users': 'Yes'})
                     pc.update({'winbind enum groups': 'Yes'})

--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -1540,6 +1540,11 @@ class ActiveDirectoryService(ConfigService):
 
         await self.middleware.call('datastore.delete', 'directoryservice.kerberosrealm', ad['kerberos_realm'])
         await self.middleware.call('activedirectory.stop')
+        if smb_ha_mode == 'LEGACY' and (await self.middleware.call('failover.status')) == 'MASTER':
+            try:
+                await self.middleware.call('failover.call_remote', 'activedirectory.leave', [data])
+            except Exception:
+                self.logger.warning("Failed to leave AD domain on passive storage controller.", exc_info=True)
 
         self.logger.debug("Successfully left domain: %s", ad['domainname'])
 

--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -938,6 +938,10 @@ class KerberosKeytabService(CRUDService):
         ad_state = await self.middleware.call('activedirectory.get_state')
         if ad_state == 'DISABLED' or not os.path.exists(keytab['SYSTEM'].value):
             return
+
+        if (await self.middleware.call("smb.get_smb_ha_mode")) == "LEGACY":
+            return
+
         if await self.middleware.call('cache.has_key', 'KEYTAB_MTIME'):
             old_mtime = await self.middleware.call('cache.get', 'KEYTAB_MTIME')
 


### PR DESCRIPTION
- Run the AD leave on passive as well as active to ensure computer objects are cleaned up.
- Don't configure samba to generate entries in system keytab for the storage controller.
- Skip keytab synchronization (because we don't have samba principals).