### PR TITLE
Add tc-stats port, version 0.1. This replaces the trueview_stats.sh

### DIFF
--- a/nas_ports/freenas/py-middlewared/Makefile
+++ b/nas_ports/freenas/py-middlewared/Makefile
@@ -73,6 +73,7 @@ RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}ws4py>0:www/py-ws4py@${PY_FLAVOR} \
 		freenas-pkgtools>0:freenas/freenas-pkgtools \
 		freenas-migrate93>0:freenas/freenas-migrate93 \
 		freenas-migrate113>0:freenas/freenas-migrate113 \
+		tc-stats>0:freenas/tc-stats \
 		${PYTHON_PKGNAMEPREFIX}iocage>0:sysutils/iocage@${PY_FLAVOR} \
 		git-lite>0:devel/git-lite \
 		oath-toolkit>0:security/oath-toolkit \

--- a/nas_ports/freenas/tc-stats/Makefile
+++ b/nas_ports/freenas/tc-stats/Makefile
@@ -1,0 +1,25 @@
+# $FreeBSD$
+
+PORTNAME=	tc-stats	
+PORTVERSION=	0.1
+DISTVERSIONPREFIX=	v
+
+CATEGORIES=	freenas
+VALID_CATEGORIES+=	freenas
+
+MAINTAINER=	dev@ixsystems.com
+COMMENT=	TrueCommand Stats Collection Engine
+
+NO_BUILD=	YES
+
+USE_GITHUB=     yes
+GH_ACCOUNT=     freenas
+GH_PROJECT=     truecommand-stats
+
+.include <bsd.port.pre.mk>
+
+do-install:
+	mkdir -p ${STAGEDIR}${PREFIX}/bin
+	${INSTALL_PROGRAM} ${WRKSRC}/binaries/freebsd/trueview-stats ${STAGEDIR}${PREFIX}/bin/trueview_stats.sh
+
+.include <bsd.port.post.mk>

--- a/nas_ports/freenas/tc-stats/distinfo
+++ b/nas_ports/freenas/tc-stats/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1585919805
+SHA256 (freenas-truecommand-stats-v0.1_GH0.tar.gz) = 2b93c47d90d100b5b4a0c0f4828e71d0fa8adcd3c3fc37ab2fca69abc3dbe77a
+SIZE (freenas-truecommand-stats-v0.1_GH0.tar.gz) = 3058035

--- a/nas_ports/freenas/tc-stats/pkg-descr
+++ b/nas_ports/freenas/tc-stats/pkg-descr
@@ -1,0 +1,1 @@
+TrueCommand stats engine for TrueNAS

--- a/nas_ports/freenas/tc-stats/pkg-plist
+++ b/nas_ports/freenas/tc-stats/pkg-plist
@@ -1,0 +1,1 @@
+bin/trueview_stats.sh


### PR DESCRIPTION
script with a small GO binary that is faster and more robust to
collect stats from TrueNAS / FreeNAS.