### PR TITLE
NAS-105648 / 12.0 / Add xhci tablet when adding VNC device

### DIFF
--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -399,7 +399,7 @@ class VMSupervisor:
         ahci_current_controller = controller_base.copy()
         virtio_current_controller = controller_base.copy()
 
-        for device in filter(lambda d: not isinstance(d, VNC), self.devices):
+        for device in self.devices:
             if isinstance(device, (DISK, CDROM, RAW)):
                 # We classify all devices in 2 types:
                 # 1) AHCI
@@ -703,7 +703,9 @@ class VNC(Device):
         self.web_process = None
 
     def xml(self, *args, **kwargs):
-        raise NotImplementedError
+        return create_element(
+            'controller', type='usb', model='nec-xhci'
+        ), create_element('input', type='tablet', bus='usb')
 
     def bhyve_args(self, *args, **kwargs):
         attrs = self.data['attributes']


### PR DESCRIPTION
We should add xhci tablet when adding a VNC device to ensure cursor synchronization with VNC.