### PR TITLE
NAS-105682 / 11.3 / Update directory service state to "HEALTHY" as needed in .started()

### DIFF
--- a/src/middlewared/middlewared/alert/source/active_directory.py
+++ b/src/middlewared/middlewared/alert/source/active_directory.py
@@ -18,7 +18,7 @@ class ActiveDirectoryDomainHealthAlertClass(AlertClass):
     category = AlertCategory.DIRECTORY_SERVICE
     level = AlertLevel.WARNING
     title = "Active Directory Domain Validation Failed"
-    text = "Domain validation failed with error: %(verrs)s."
+    text = "Domain validation failed with error: %(verrs)s"
 
 
 class ActiveDirectoryDomainOfflineAlertClass(AlertClass, SimpleOneShotAlertClass):

--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -1199,6 +1199,9 @@ class ActiveDirectoryService(ConfigService):
 
             raise CallError(wberr, err)
 
+        if (await self.get_state()) != 'HEALTHY':
+            await self.set_state(DSStatus['HEALTHY'])
+
         return True
 
     @private

--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -736,6 +736,9 @@ class LDAPService(ConfigService):
         except Exception as e:
             raise CallError(e)
 
+        if (await self.get_state()) != 'HEALTHY':
+            await self.set_state(DSStatus['HEALTHY'])
+
         return True
 
     @private

--- a/src/middlewared/middlewared/plugins/nis.py
+++ b/src/middlewared/middlewared/plugins/nis.py
@@ -145,6 +145,9 @@ class NISService(ConfigService):
         except asyncio.TimeoutError:
             raise CallError('nis.started check timed out after 5 seconds.')
 
+        if (await self.get_state()) != 'HEALTHY':
+            await self.set_state(DSStatus['HEALTHY'])
+
         return ret
 
     @private


### PR DESCRIPTION
Ensure that stale state cache gets updated if these calls succeed. Remove extra period (.) from end of alert message.