### PR TITLE
Add path to acl_is_trivial error message

### DIFF
--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -417,7 +417,7 @@ class FilesystemService(Service):
         a path on a tmpfs filesystem).
         """
         if not os.path.exists(path):
-            raise CallError('Path not found.', errno.ENOENT)
+            raise CallError(f'Path not found [{path}].', errno.ENOENT)
 
         has_nfs4_acl_support = os.pathconf(path, 64)
         if not has_nfs4_acl_support:


### PR DESCRIPTION
In some error situations this may be the first message greeting users. It should include the path.