### PR TITLE
Fix losing IP after lease lifetime expire when switching from DHCP to static IP on Linux

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/netif_linux/address/mixin.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/address/mixin.py
@@ -21,6 +21,9 @@ class AddressMixin:
     def remove_address(self, address):
         self._address_op("del", address)
 
+    def replace_address(self, address):
+        self._address_op("replace", address)
+
     def _address_op(self, op, address):
         if isinstance(address.address, LinkAddress):
             return


### PR DESCRIPTION
This was ridiculous. I've killed all processes, I've ran sysdig (strace on all processes), I've learnt about using auditctl and capturing netlink packets using tcpdump, it was all the same: system was staying completely idle and untouched and then suddenly lost IP address, and this was all not repeatable on local VM (I have lease time much bigger than 5 minutes).

Lesson learned: I should fight the habit to use ifconfig. These lifetimes are only visible in `ip address list`.