### PR TITLE
Fix share_to_smbconf - path_suffix with domain

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/registry.py
+++ b/src/middlewared/middlewared/plugins/smb_/registry.py
@@ -209,7 +209,7 @@ class SharingSMBService(Service):
         conf = {}
 
         if data['home'] and gl['ad_enabled']:
-            data['path_suffix'] = '%d/%U'
+            data['path_suffix'] = '%D/%U'
         elif data['home']:
             data['path_suffix'] = '%U'
 


### PR DESCRIPTION
Domain variable is %D not %d
%d is for server process id
Src: https://www.samba.org/samba/docs/using_samba/ch06.html#samba2-CHP-6-TABLE-2