### PR TITLE
Make sure slots to be used by VM are pre-determined

### DIFF
--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -704,7 +704,9 @@ class VNC(Device):
 
     def xml(self, *args, **kwargs):
         return create_element(
-            'controller', type='usb', model='nec-xhci'
+            'controller', type='usb', model='nec-xhci', attribute_dict={
+                'children': [create_element('address', type='pci', slot='30')]
+            }
         ), create_element('input', type='tablet', bus='usb')
 
     def bhyve_args(self, *args, **kwargs):


### PR DESCRIPTION
This commit introduced changes where we ensure that when tablet is added for VNC, libvirt does not automatically assign a slot but we do that by specifying a slot. This helps if we want to use some other slots via command line bhyve arguments, a use case is PCI passthrough devices wchich libvirt is not supporting yet for bhyve driver and we would be using command line args. If we don't have slots pre-defined, they could potentially clash with the ones we want to use with passthrough devies.