### PR TITLE
Add flag to ignore model specific registers in libvirt

### DIFF
--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -297,7 +297,7 @@ class VMSupervisor:
                 'features', attribute_dict={
                     'children': [
                         create_element('acpi'),
-                        create_element('apic'),
+                        create_element('msrs', unknown='ignore'),
                     ]
                 }
             ),


### PR DESCRIPTION
( keeping in line with 11.3 )