### PR TITLE
NAS-105726 / 12.0 / loader.conf: Increase size of kernel stacks

### DIFF
--- a/src/freenas/boot/loader.conf
+++ b/src/freenas/boot/loader.conf
@@ -27,6 +27,10 @@ ipmi_load="YES"
 # Load the ZFS module
 openzfs_load="YES"
 
+# We can have some pretty deep stacks in ZFS.  Increase the stack size to
+# avoid double faults.
+kern.kstack_pages=16
+
 # Load some hardware modules that don't fit into kernel.
 if_bnxt_load="YES"
 if_qlxgbe_load="YES"


### PR DESCRIPTION
We can have some pretty deep stacks in ZFS.  Increase the stack size to
avoid double faults.

Ticket: https://jira.ixsystems.com/browse/NAS-105726