### PR TITLE
NAS-105768 / 12.0 / Fix serial console settings

### DIFF
--- a/src/freenas/boot/loader.conf
+++ b/src/freenas/boot/loader.conf
@@ -3,6 +3,7 @@
 #
 product="TrueNAS"
 autoboot_delay="5"
+loader_color="YES"
 loader_logo="TrueNAS"
 loader_menu_title="Welcome to TrueNAS"
 loader_brand="TrueNAS"


### PR DESCRIPTION
The installer tries to detect when we are booting from the serial
console menu entry so it can persist that choice in loader.conf.

With TN12 the efi console driver in loader now has built in support
for the EFI serial protocol.  Enabling comconsole and efi both at the
same time leads to doubled output on the serial port when firmware
presents a serial port via EFI.  In some cases the efi serial console
can be disabled by turning off console redirection in system firmware.
In other cases, such as in bhyve, efi only has a serial console and
there is no video console.  There is also hardware (X-series) which only
has access to BIOS via serial console redirection, so it cannot be
disabled.

Don't enable efi console when we are doing a UEFI installation and
console was set to comconsole.  The efi console automatically uses the serial
port which may duplicate comconsole output.  We need to use comconsole
because efi does not necessarily have access to the selected serial port
and the port and speed cannot be configured.

When generating loader.conf.local, check if efi ConOut has a serial port
and if so do not enable the efi console in loader.

Also enable loader_color in loader.conf, which enables ANSI code output
in loader so that terminal settings can be reset to a clean state when
loader is initializing.  This fixes some common issues with the menu
not being visible after earlier boot stages leave the terminal in a
weird state.