### PR TITLE
NAS-105800 / 11.3 / Don't change individual job progress (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -852,11 +852,11 @@ class CoreService(Service):
                 error = None
 
                 if isinstance(msg, Job):
-                    job = msg
+                    b_job = msg
                     msg = await msg.wait()
 
-                    if job.error:
-                        error = job.error
+                    if b_job.error:
+                        error = b_job.error
 
                 statuses.append({"result": msg, "error": error})
             except Exception as e:


### PR DESCRIPTION
We set bulk job's progress via `job` variable, but each time the loop executes, we change the value of `job` variable which results in a completed job but with inconsistent progress reporting.