### PR TITLE
Put ix-zfs at the top of rcorder in order to set up system dataset an…

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-zfs
+++ b/src/freenas/etc/ix.rc.d/ix-zfs
@@ -5,7 +5,7 @@
 
 # PROVIDE: ix-zfs
 # REQUIRE: hostid mountcritlocal
-# BEFORE: zfs
+# BEFORE: FILESYSTEMS var
 
 . /etc/rc.subr
 


### PR DESCRIPTION
…d generate collectd and syslog configuration before starting everything else