### PR TITLE
NAS-105660 / 11.3 / Fix alert classes registered twice as some modules are loaded twice.

### DIFF
--- a/src/middlewared/middlewared/alert/base.py
+++ b/src/middlewared/middlewared/alert/base.py
@@ -32,8 +32,9 @@ class AlertClassMeta(type):
 
             cls.name = cls.__name__.replace("AlertClass", "")
 
-            AlertClass.classes.append(cls)
-            AlertClass.class_by_name[cls.name] = cls
+            if cls.name not in AlertClass.class_by_name:
+                AlertClass.classes.append(cls)
+                AlertClass.class_by_name[cls.name] = cls
 
 
 class AlertClass(metaclass=AlertClassMeta):


### PR DESCRIPTION
Should not be the case in 12