### PR TITLE
fix(middlewared/network): actual interface should not be deleted on call

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1499,9 +1499,6 @@ class InterfaceService(CRUDService):
             'datastore.delete', 'network.interfaces', [('int_interface', '=', oid)]
         )
 
-        # Let's finally delete the interface
-        await self.middleware.call('interface.destroy', oid)
-
         return oid
 
     @accepts()


### PR DESCRIPTION
Our network changes should only be made once they are they manually
committed/synced.