### PR TITLE
Validate home directory path is unlocked during user creation

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -420,7 +420,7 @@ class UserService(CRUDService):
                 try:
                     # Strip ACL before chmod. This is required when aclmode = restricted
                     setfacl = subprocess.run(['/bin/setfacl', '-b', user['home']], check=False)
-                    if setfacl.returncode != 0:
+                    if setfacl.returncode != 0 and setfacl.stderr:
                         self.logger.debug('Failed to strip ACL: %s', setfacl.stderr.decode())
                     os.chmod(user['home'], int(home_mode, 8))
                 except OSError:
@@ -700,6 +700,11 @@ class UserService(CRUDService):
                         f'{schema}.home',
                         f'The path for the home directory "({data["home"]})" '
                         'must include a volume or dataset.'
+                    )
+                elif await self.middleware.call('filesystem.path_is_encrypted', data['home']):
+                    verrors.add(
+                        f'{schema}.home',
+                        'Path component for "Home Directory" is currently encrypted and locked'
                     )
 
         if 'home_mode' in data:

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -5,6 +5,7 @@ import errno
 import json
 import logging
 from datetime import datetime, time, timedelta
+from pathlib import Path
 import os
 import psutil
 import re
@@ -3063,6 +3064,28 @@ class PoolDatasetService(CRUDService):
         if not dataset[0]['properties']['origin']['value']:
             raise CallError('Only cloned datasets can be promoted.', errno.EBADMSG)
         return await self.middleware.call('zfs.dataset.promote', id)
+
+    @private
+    async def from_path(self, path, check_parents):
+        p = Path(path)
+        if not p.is_absolute():
+            raise CallError(f"[{path}] is not an absolute path.", errno.EINVAL)
+
+        if not p.exists() and check_parents:
+            for parent in p.parents:
+                if parent.exists():
+                    p = parent
+                    break
+
+        ds_name = await self.middleware.call("zfs.dataset.path_to_dataset", p.as_posix())
+        if not ds_name:
+            raise CallError(f"Failed to convert path [{path}] to ZFS dataset.")
+
+        return await self.middleware.call(
+            "pool.dataset.query",
+            [("id", "=", ds_name)],
+            {"get": True}
+        )
 
     @accepts(
         Str('id', required=True),

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -501,6 +501,16 @@ class ZFSDatasetService(CRUDService):
         if not ds.encrypted:
             raise CallError(f'{id} is not encrypted')
 
+    def path_to_dataset(self, path):
+        with libzfs.ZFS() as zfs:
+            try:
+                zh = zfs.get_dataset_by_path(path)
+                ds_name = zh.name
+            except libzfs.ZFSException:
+                ds_name = None
+
+        return ds_name
+
     def get_quota(self, ds, quota_type):
         if quota_type == 'dataset':
             dataset = self.query([('id', '=', ds)], {'get': True})


### PR DESCRIPTION
If dataset is locked and a path component of the user home directory
specified during dataset creation, then we may end up creating
a home dir that gets mounted over when the dataset is unlocked.

Add a function to check whether a given path contains a component that
is locked. Depending on how creative users are with symbolic links,
in the future we may need to add checks for both paths.