### PR TITLE
NAS-105790 / 11.3 / Treat NTPException as non-fatal validation error

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -837,6 +837,9 @@ class ActiveDirectoryService(ConfigService):
 
             try:
                 await self.middleware.run_in_thread(self.validate_domain, new)
+            except ntplib.NTPException:
+                self.logger.warning("NTP request to Domain Controller failed.",
+                                    exc_info=True)
             except Exception as e:
                 raise ValidationError(
                     "activedirectory_update",


### PR DESCRIPTION
In some less than perfectly configured domains NTP is not running
on the DC with the PDC emulator role. Log an error message but try
still try to join.