### PR TITLE
NAS-105836 / 11.3 / Gracefully handle unexpected LDAP schemas (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -319,17 +319,20 @@ class LDAPQuery(object):
         res = []
         for r in results:
             parsed_data = {}
-            for k, v in r[1].items():
-                try:
-                    v = list(i.decode() for i in v)
-                except Exception:
-                    v = list(str(i) for i in v)
-                parsed_data.update({k: v})
+            if len(r) > 1 and isinstance(r[1], dict):
+                for k, v in r[1].items():
+                    try:
+                        v = list(i.decode() for i in v)
+                    except Exception:
+                        v = list(str(i) for i in v)
+                    parsed_data.update({k: v})
 
-            res.append({
-                'dn': r[0],
-                'data': parsed_data
-            })
+                res.append({
+                    'dn': r[0],
+                    'data': parsed_data
+                })
+            else:
+                self.logger.debug("Unable to parse results: %s", r)
 
         return res
 


### PR DESCRIPTION
Windows LDAP servers (AD environment) have slightly different return to query for SambaDomain than we see on OpenLDAP server. Log a debug message with the contents that we failed to parse and then move on. In the future, it may make sense to add a validation error to redirect users to the AD form if a query to rootDSE shows it's an AD DC.