### PR TITLE
NAS-102720 / 11.3 / Disable SMB username map if AD is enabled

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf
@@ -127,7 +127,7 @@
                 'enable web service discovery': 'True'
             })
 
-            if len(middleware.call_sync('user.query', [('microsoft_account', '=', True)])) > 0:
+            if not db['ad']['enable'] and middleware.call_sync('user.query', [('microsoft_account', '=', True)], {"count": True}):
                 pc.update({
                     'username map': '/usr/local/etc/smbusername.map',
                     'username map cache time': '60',


### PR DESCRIPTION
The presence of a username map can cause group membership and
permissions errors in AD environments. The "microsoft account"
feature was added for the benefit of home users and serves little
purpose when AD is enabled.