### PR TITLE
NAS-105891 / 12.0 / Make local plugin version retrieval failure non fatal

### DIFF
--- a/src/middlewared/middlewared/plugins/jail_freebsd.py
+++ b/src/middlewared/middlewared/plugins/jail_freebsd.py
@@ -673,7 +673,8 @@ class PluginService(CRUDService):
         try:
             conn = sqlite3.connect(db)
         except sqlite3.Error as e:
-            raise CallError(e)
+            self.middleware.logger.error('Failed to connect to %r database : %s', db, str(e))
+            return []
 
         with conn:
             cur = conn.cursor()


### PR DESCRIPTION
This commit introduces changes where we make sure that if for any reason we are not able to retrieve version of installed plugins, we make the failure non fatal and still allow plugin.query to succeed.