### PR TITLE
NAS-105906 / 11.3 / Only try to retrieve attachments for pools which are in available state (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -2281,7 +2281,7 @@ class PoolService(CRUDService):
         share, asking for confirmation.
         """
         pool = await self._get_instance(oid)
-        return await self.middleware.call('pool.dataset.attachments', pool['name'])
+        return await self.middleware.call('pool.dataset.attachments_with_path', pool['path'])
 
     @item_method
     @accepts(Int('id'))
@@ -3193,9 +3193,12 @@ class PoolDatasetService(CRUDService):
           }
         ]
         """
-        result = []
         dataset = await self._get_instance(oid)
-        path = self.__attachments_path(dataset)
+        return await self.attachments_with_path(self.__attachments_path(dataset))
+
+    @private
+    async def attachments_with_path(self, path):
+        result = []
         if path:
             for delegate in self.attachment_delegates:
                 attachments = {"type": delegate.title, "service": delegate.service, "attachments": []}


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x ddc25a47bcd9c1b318b2b5b32e635c1777e2d662

If a pool is offline/faulted, we can't retrieve the data on those pools and in this case we should just return an empty list when trying to get attachments on the pool.