### PR TITLE
NAS-105891 / 11.3 / Make local plugin version retrieval failure non fatal (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/jail.py
+++ b/src/middlewared/middlewared/plugins/jail.py
@@ -530,7 +530,8 @@ class PluginService(CRUDService):
         try:
             conn = sqlite3.connect(db)
         except sqlite3.Error as e:
-            raise CallError(e)
+            self.middleware.logger.error('Failed to connect to %r database : %s', db, str(e))
+            return []
 
         with conn:
             cur = conn.cursor()


### PR DESCRIPTION
This commit introduces changes where we make sure that if for any reason we are not able to retrieve version of installed plugins, we make the failure non fatal and still allow plugin.query to succeed.