### PR TITLE
NAS-105795 / 11.3 / Delete SMB group mappings by SID value rather than NT group

### DIFF
--- a/src/middlewared/middlewared/etc_files/smb_configure.py
+++ b/src/middlewared/middlewared/etc_files/smb_configure.py
@@ -285,7 +285,7 @@ def fixsid(middleware, conf, groupmap):
 def validate_group_mappings(middleware, conf):
     groupmap = middleware.call_sync('smb.groupmap_list')
     if groupmap:
-        sids_fixed = fixsid(middleware, conf, groupmap)
+        sids_fixed = fixsid(middleware, conf, groupmap.values())
         if not sids_fixed:
             groupmap = []
     groups = get_groups(middleware)


### PR DESCRIPTION
If for some reason Samba's group_mapping.tdb ends up with a stale
entry, removal by NT group name can be impossible. Convert return
of smb.groupmap_list to dictionary keyed by unix group name. Use
this return to convert unix group name to SID to then perform the
groupmap deletion.