### PR TITLE
Shift to "CONNECTING" state if NAS is waiting for TC connection

### DIFF
--- a/src/middlewared/middlewared/plugins/truecommand/__init__.py
+++ b/src/middlewared/middlewared/plugins/truecommand/__init__.py
@@ -14,7 +14,7 @@ async def setup(middleware):
 
     status = Status((await middleware.call('datastore.config', 'system.truecommand'))['api_key_state'])
     if status == Status.CONNECTED:
-        status = Status.WAITING
+        status = Status.CONNECTING
 
     await middleware.call('truecommand.set_status', status.value)
 

--- a/src/middlewared/middlewared/plugins/truecommand/enums.py
+++ b/src/middlewared/middlewared/plugins/truecommand/enums.py
@@ -6,7 +6,6 @@ class Status(enum.Enum):
     CONNECTING = 'CONNECTING'
     DISABLED = 'DISABLED'
     FAILED = 'FAILED'
-    WAITING = 'WAITING'
 
 
 class StatusReason(enum.Enum):
@@ -14,7 +13,6 @@ class StatusReason(enum.Enum):
     CONNECTING = 'Pending Confirmation From iX Portal for Truecommand API Key.'
     DISABLED = 'Truecommand service is disabled.'
     FAILED = 'Truecommand API Key Disabled by iX Portal.'
-    WAITING = 'Waiting for connection from Truecommand.'
 
 
 class PortalResponseState(enum.Enum):

--- a/src/middlewared/middlewared/plugins/truecommand/enums.py
+++ b/src/middlewared/middlewared/plugins/truecommand/enums.py
@@ -7,6 +7,18 @@ class Status(enum.Enum):
     DISABLED = 'DISABLED'
     FAILED = 'FAILED'
 
+# In the database we save 3 states, CONNECTED/DISABLED/FAILED
+# Connected is saved when portal has approved an api key
+# Disabled is saved when TC service is disabled
+# Failed is saved when portal revokes an api key
+#
+# We report CONNECTED to the user when we have an active wireguard
+# connection with TC which is not failing a health check.
+# If portal has not approved the api key yet but has registered it
+# we report CONNECTING to the user.
+# Connecting is also reported when wireguard connection fails health
+# check
+
 
 class StatusReason(enum.Enum):
     CONNECTED = 'Truecommand service is connected.'

--- a/src/middlewared/middlewared/plugins/truecommand/enums.py
+++ b/src/middlewared/middlewared/plugins/truecommand/enums.py
@@ -6,6 +6,7 @@ class Status(enum.Enum):
     CONNECTING = 'CONNECTING'
     DISABLED = 'DISABLED'
     FAILED = 'FAILED'
+    WAITING = 'WAITING'
 
 
 class StatusReason(enum.Enum):
@@ -13,6 +14,7 @@ class StatusReason(enum.Enum):
     CONNECTING = 'Pending Confirmation From iX Portal for Truecommand API Key.'
     DISABLED = 'Truecommand service is disabled.'
     FAILED = 'Truecommand API Key Disabled by iX Portal.'
+    WAITING = 'Waiting for connection from Truecommand.'
 
 
 class PortalResponseState(enum.Enum):

--- a/src/middlewared/middlewared/plugins/truecommand/portal.py
+++ b/src/middlewared/middlewared/plugins/truecommand/portal.py
@@ -39,7 +39,7 @@ class TruecommandService(Service, TruecommandAPIMixin):
                         'api_key_state': Status.CONNECTED.value,
                     }
                 )
-                await self.middleware.call('truecommand.set_status', Status.CONNECTED.value)
+                await self.middleware.call('truecommand.set_status', Status.WAITING.value)
                 await self.middleware.call('truecommand.dismiss_alerts')
                 await self.middleware.call('truecommand.start_truecommand_service')
                 break

--- a/src/middlewared/middlewared/plugins/truecommand/portal.py
+++ b/src/middlewared/middlewared/plugins/truecommand/portal.py
@@ -39,7 +39,6 @@ class TruecommandService(Service, TruecommandAPIMixin):
                         'api_key_state': Status.CONNECTED.value,
                     }
                 )
-                await self.middleware.call('truecommand.set_status', Status.WAITING.value)
                 await self.middleware.call('truecommand.dismiss_alerts')
                 await self.middleware.call('truecommand.start_truecommand_service')
                 break
@@ -64,7 +63,7 @@ class TruecommandService(Service, TruecommandAPIMixin):
                     'system.truecommand',
                     config['id'], {
                         **{k: None for k in ('tc_public_key', 'remote_address', 'endpoint', 'wg_address')},
-                        'api_key_state': Status.DISABLED.value,
+                        'api_key_state': Status.FAILED.value,
                     }
                 )
                 await self.middleware.call('truecommand.stop_truecommand_service')

--- a/src/middlewared/middlewared/plugins/truecommand/update.py
+++ b/src/middlewared/middlewared/plugins/truecommand/update.py
@@ -38,6 +38,10 @@ class TruecommandService(ConfigService):
     async def tc_extend(self, config):
         for key in ('wg_public_key', 'wg_private_key', 'tc_public_key', 'endpoint', 'api_key_state', 'wg_address'):
             config.pop(key)
+
+        if self.STATUS == Status.WAITING and await self.middleware.call('truecommand.wireguard_connection_health'):
+            await self.set_status(Status.CONNECTED.value)
+
         config.update({
             'status': self.STATUS.value,
             'status_reason': StatusReason.__members__[self.STATUS.value].value
@@ -129,6 +133,7 @@ class TruecommandService(ConfigService):
                     'endpoint': None,
                     'tc_public_key': None,
                     'wg_address': None,
+                    'api_key_state': Status.DISABLED.value,
                 })
 
             await self.dismiss_alerts(True)


### PR DESCRIPTION
This PR introduces changes where we make sure that we only report CONNECTED when NAS has a successful connection with TC and the service passes a scheduled health check. In cases where the key has been marked as accepted by the portal but TC hasn't connected to NAS, we mark this situation as CONNECTING.