### PR TITLE
NAS-105795 / 12.0 / Delete SMB group mappings by SID value rather than NT group (by anodos325)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-    - 3.6
+    - 3.8
 
 install:
     - sudo apt-get -qq update

--- a/src/middlewared/middlewared/plugins/smb_/sid.py
+++ b/src/middlewared/middlewared/plugins/smb_/sid.py
@@ -69,7 +69,7 @@ class SMBService(Service):
     @private
     async def fixsid(self, groupmap=None):
         if groupmap is None:
-            groupmap = await self.groupmap_list()
+            groupmap = (await self.middleware.call('smb.groupmap_list').values())
 
         conf = await self.middleware.call('smb.config')
         well_known_SID_prefix = "S-1-5-32"


### PR DESCRIPTION
If for some reason Samba's group_mapping.tdb ends up with a stale
entry, removal by NT group name can be impossible. Convert return
of smb.groupmap_list to dictionary keyed by unix group name. Use
this return to convert unix group name to SID to then perform the
groupmap deletion.