### PR TITLE
NAS-105951 / 11.3 / Add slight optimizations for adding user accounts

### DIFF
--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -961,7 +961,6 @@ class ServiceService(CRUDService):
         await self.middleware.call("etc.generate", "user")
         await self.middleware.call('etc.generate', 'aliases')
         await self.middleware.call('etc.generate', 'sudoers')
-        await self.reload("cifs", kwargs)
 
     async def _restart_system_datasets(self, **kwargs):
         systemdataset = await self.middleware.call('systemdataset.setup')


### PR DESCRIPTION
Only alter passdb entry on user update if updated information will
impact the entry. This means changing the username, changing the "locked"
status, or changing the password.

Remove extraneous SMB service reload on user update. This behavior appears
to stem from a past age when FreeNAS user the smbpasswd backend for
samba's passdb.