### PR TITLE
Ping TC IP address if handshake check is successful

### DIFF
--- a/src/middlewared/middlewared/plugins/truecommand/update.py
+++ b/src/middlewared/middlewared/plugins/truecommand/update.py
@@ -49,8 +49,10 @@ class TruecommandService(ConfigService):
             else:
                 status_reason = 'Waiting for connection from Truecommand.'
 
-        if config['remote_address']:
-            config['remote_address'] = config['remote_address'].split('/', 1)[0]
+        config['remote_ip_address'] = config['remote_url'] = config.pop('remote_address')
+        if config['remote_ip_address']:
+            config['remote_ip_address'] = config.pop('remote_ip_address').split('/', 1)[0]
+            config['remote_url'] = f'http://{config["remote_ip_address"]}/'
 
         config.update({
             'status': self.STATUS.value,

--- a/src/middlewared/middlewared/plugins/truecommand/wireguard.py
+++ b/src/middlewared/middlewared/plugins/truecommand/wireguard.py
@@ -88,11 +88,10 @@ class TruecommandService(Service):
                     # It's possible that IP of TC changed and we just need to get up to speed with the
                     # new IP. So if we have a correct handshake, we should ping the TC IP to see if it's
                     # still reachable
-                    config = await self.middleware.call('datastore.config', 'system.truecommand')
+                    config = await self.middleware.call('truecommand.config')
                     cp = await run(
                         [
-                            'ping', '-t' if osc.IS_FREEBSD else '-w', '5',
-                            '-q', str(config['remote_address']).split('/', 1)[0]
+                            'ping', '-t' if osc.IS_FREEBSD else '-w', '5', '-q', str(config['remote_ip_address'])
                         ], check=False
                     )
                     if cp.returncode:
@@ -113,7 +112,8 @@ class TruecommandService(Service):
         connected = Status(tc_config['status']) == Status.CONNECTED
         return {
             'connected': connected,
-            'truecommand_ip': tc_config['remote_address'] if connected else None,
+            'truecommand_ip': tc_config['remote_ip_address'] if connected else None,
+            'truecommand_url': tc_config['remote_url'] if connected else None,
             'status': tc_config['status'],
             'status_reason': tc_config['status_reason'],
         }


### PR DESCRIPTION
This commit introduces changes where we ping TC ip address to determine if we have an active connection with TC. Why we do this is because it's possible TC container changed it's IP address and the keys are still valid, which means we would get a handshake from the wireguard connection but we are not connected to the TC container anymore. In this case we should get in an error state and poll the portal to see if we should be using updated address for the TC container.