### PR TITLE
NAS-105951 / 12.0 / Add slight optimizations for adding user accounts (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
+++ b/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
@@ -297,4 +297,4 @@ class UserService(PseudoServiceBase):
     reloadable = True
 
     async def reload(self):
-        await self.middleware.call("service.reload", "cifs")
+        pass


### PR DESCRIPTION
Only alter passdb entry on user update if updated information will
impact the entry. This means changing the username, changing the "locked"
status, or changing the password.

Remove extraneous SMB service reload on user update. This behavior appears
to stem from a past age when FreeNAS user the smbpasswd backend for
samba's passdb.