### PR TITLE
NAS-105928 / 12.0 / Make sure all devices are properly expanded in a pool

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/expand.py
+++ b/src/middlewared/middlewared/plugins/pool_/expand.py
@@ -92,14 +92,14 @@ class PoolService(Service):
                     else:
                         await run('camcontrol', 'reprobe', vdev['disk'])
                         await run('gpart', 'recover', vdev['disk'])
-                        await run('gpart', 'resize', '-i', str(partition_number), vdev['disk'])
+                        await run('gpart', 'resize', '-a', '4k', '-i', str(partition_number), vdev['disk'])
 
                     if osc.IS_FREEBSD and pool['encrypt']:
                         geli_resize_cmd = (
-                            'geli', 'resize', '-s', str(part_data['size']), vdev['device']
+                            'geli', 'resize', '-a', '4k', '-s', str(part_data['size']), vdev['device']
                         )
                         rollback_cmd = (
-                            'gpart', 'resize', '-i', str(partition_number),
+                            'gpart', 'resize', '-a', '4k', '-i', str(partition_number),
                             '-s', str(part_data['size']), vdev['disk']
                         )
 


### PR DESCRIPTION
This PR introduces following changes: 
1) Where we make sure we don't try to expand spare/cache devices as that is not supported by ZFS.
2) When we try to resize a partition on expanding pool, we should use the same alignment value ( `4k` ) which was used when we formatted the disk, if we don't do that, it tries to use the disk's native size which can result in the resizing failing.
3) We resize spare/cache disks anyways because for cache, whenever the pool is going to be imported again, zfs will register the new size. For spare, whenever the spare is going to be used, the new capacity will be registered.
4) We make sure that we properly expand MIRROR/RAIDZ vdevs and bring their relevant devices online accordingly.