### PR TITLE
NAS-105970 / 12.0 / Extend null for SMB bindip into empty list (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -221,6 +221,9 @@ class SMBService(SystemServiceService):
 
         smb['loglevel'] = LOGLEVEL_MAP.get(smb['loglevel'])
 
+        if smb['bindip'] is None:
+            smb['bindip'] = []
+
         return smb
 
     async def __validate_netbios_name(self, name):


### PR DESCRIPTION
Default value for this field is currently null. Ensure in middleware
that this is properly expanded into an empty list. In 12.0 this will
be handled properly through a migration.