### PR TITLE
NAS-105965 / 12.0 / fix rollback operation on TN HA

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
@@ -1618,7 +1618,7 @@ async def hook_license_update(middleware, *args, **kwargs):
     await middleware.call('service.restart', 'failover')
     await middleware.call('failover.status_refresh')
 
-async def hook_pre_rollback_setup_ha(middleware, *args, **kwargs):
+async def hook_post_rollback_setup_ha(middleware, *args, **kwargs):
     """
     This hook needs to be run after a NIC rollback operation and before
     an `interfaces.sync` operation on a TrueNAS HA system
@@ -1860,7 +1860,7 @@ async def setup(middleware):
     middleware.register_hook('pool.post_change_passphrase', hook_pool_change_passphrase, sync=False)
     middleware.register_hook('interface.pre_sync', interface_pre_sync_hook, sync=True)
     middleware.register_hook('interface.post_sync', hook_setup_ha, sync=True)
-    middleware.register_hook('interface.pre_rollback', hook_pre_rollback_setup_ha, sync=True)
+    middleware.register_hook('interface.post_rollback', hook_post_rollback_setup_ha, sync=True)
     middleware.register_hook('pool.post_create_or_update', hook_setup_ha, sync=True)
     middleware.register_hook('pool.post_create_or_update', hook_sync_geli, sync=True)
     middleware.register_hook('pool.post_export', hook_pool_export, sync=True)

--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
@@ -1618,16 +1618,18 @@ async def hook_license_update(middleware, *args, **kwargs):
     await middleware.call('service.restart', 'failover')
     await middleware.call('failover.status_refresh')
 
-async def hook_post_rollback_setup_ha(middleware, *args, **kwargs):
+async def hook_pre_rollback_setup_ha(middleware, *args, **kwargs):
     """
-    This hook needs to be run after a NIC rollback operation is run
-    on a TrueNAS HA system
+    This hook needs to be run after a NIC rollback operation and before
+    an `interfaces.sync` operation on a TrueNAS HA system
     """
     if not await middleware.call('failover.licensed'):
         return
 
-    if await middleware.call('failover.status') == 'UNKNOWN':
-        middleware.logger.debug('[HA] Failed to contact standby controller')
+    try:
+        await middleware.call('failover.call_remote', 'core.ping')
+    except Exception:
+        middleware.logger.debug('[HA] Failed to contact standby controller', exc_info=True)
         return
 
     await middleware.call('failover.send_database')
@@ -1858,7 +1860,7 @@ async def setup(middleware):
     middleware.register_hook('pool.post_change_passphrase', hook_pool_change_passphrase, sync=False)
     middleware.register_hook('interface.pre_sync', interface_pre_sync_hook, sync=True)
     middleware.register_hook('interface.post_sync', hook_setup_ha, sync=True)
-    middleware.register_hook('rollback.post_sync', hook_post_rollback_setup_ha, sync=True)
+    middleware.register_hook('interface.pre_rollback', hook_pre_rollback_setup_ha, sync=True)
     middleware.register_hook('pool.post_create_or_update', hook_setup_ha, sync=True)
     middleware.register_hook('pool.post_create_or_update', hook_sync_geli, sync=True)
     middleware.register_hook('pool.post_export', hook_pool_export, sync=True)

--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
@@ -1618,6 +1618,21 @@ async def hook_license_update(middleware, *args, **kwargs):
     await middleware.call('service.restart', 'failover')
     await middleware.call('failover.status_refresh')
 
+async def hook_post_rollback_setup_ha(middleware, *args, **kwargs):
+    """
+    This hook needs to be run after a NIC rollback operation is run
+    on a TrueNAS HA system
+    """
+    if not await middleware.call('failover.licensed'):
+        return
+
+    if await middleware.call('failover.status') == 'UNKNOWN':
+        middleware.logger.debug('[HA] Failed to contact standby controller')
+        return
+
+    await middleware.call('failover.send_database')
+
+    middleware.logger.debug('[HA] Successfully sent database to standby controller')
 
 async def hook_setup_ha(middleware, *args, **kwargs):
 
@@ -1843,6 +1858,7 @@ async def setup(middleware):
     middleware.register_hook('pool.post_change_passphrase', hook_pool_change_passphrase, sync=False)
     middleware.register_hook('interface.pre_sync', interface_pre_sync_hook, sync=True)
     middleware.register_hook('interface.post_sync', hook_setup_ha, sync=True)
+    middleware.register_hook('rollback.post_sync', hook_post_rollback_setup_ha, sync=True)
     middleware.register_hook('pool.post_create_or_update', hook_setup_ha, sync=True)
     middleware.register_hook('pool.post_create_or_update', hook_sync_geli, sync=True)
     middleware.register_hook('pool.post_export', hook_pool_export, sync=True)

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -637,6 +637,13 @@ class InterfaceService(CRUDService):
         for i in self._original_datastores['laggmembers']:
             await self.middleware.call('datastore.insert', 'network.lagginterfacemembers', i)
 
+        # Since all entries are deleted from the network tables, this
+        # breaks `failover.status` on TrueNAS HA systems. This means the
+        # following `datastore.insert` operations fail because we can't
+        # determine the Active/Standby controller.
+        if await self.middleware.call('failover.licensed'):
+            await self.middleware.call('failover.sync_to_peer')
+
         self._original_datastores.clear()
 
     async def __check_failover_disabled(self):

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -682,7 +682,7 @@ class InterfaceService(CRUDService):
         # This breaks `failover.status` on TrueNAS HA systems.
         # Because of this, we need to manually sync the database to the standby
         # controller.
-        await self.middleware.call_hook('interfaces.pre_rollback')
+        await self.middleware.call_hook('interface.pre_rollback')
 
         await self.sync()
 

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -641,8 +641,7 @@ class InterfaceService(CRUDService):
         # breaks `failover.status` on TrueNAS HA systems. This means the
         # following `datastore.insert` operations fail because we can't
         # determine the Active/Standby controller.
-        if await self.middleware.call('failover.licensed'):
-            await self.middleware.call('failover.sync_to_peer')
+        await self.middleware.call_hook('rollback.post_sync')
 
         self._original_datastores.clear()
 

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -682,7 +682,7 @@ class InterfaceService(CRUDService):
         # This breaks `failover.status` on TrueNAS HA systems.
         # Because of this, we need to manually sync the database to the standby
         # controller.
-        await self.middleware.call_hook('interface.pre_rollback')
+        await self.middleware.call_hook('interface.post_rollback')
 
         await self.sync()
 


### PR DESCRIPTION
This is the path of least resistance and ensures the databases are sync'ed after rollback changes. I've tried to write code that actually compares values of db and the changes that need to be rolled back but that becomes infinitely complex and is bound for errors. I'm okay with this fix because this only occurs on HA systems and only when a rollback takes place.