### PR TITLE
installer: Fix uefi serial first boot

### DIFF
--- a/src/freenas-installer/etc/install.sh
+++ b/src/freenas-installer/etc/install.sh
@@ -410,7 +410,10 @@ save_serial_settings()
 	# Do nothing if we booted with video as the primary console.
 	return 0
 	;;
-    $SERIAL_ONLY|$SER_VID_BOTH)
+    $SERIAL_ONLY)
+	local console="comconsole"
+	;;
+    $SER_VID_BOTH)
 	if [ "$(kenv console)" = "comconsole" ]; then
 	    # We used the serial boot menu entry and efi has a serial port.
 	    # Enable only comconsole so loader output is not duplicated.


### PR DESCRIPTION
When we have booted with only a serial console, enable only comconsole
in loader.conf.local for the first boot, to avoid potentially doubling
the loader output when efi is a serial console (such as in bhyve).

Middleware correctly generates loader.conf.local with only comconsole
enabled on subsequent boots.