### PR TITLE
NAS-106006 / 11.3 / Improve formatting and verbosity of AD error messages

### DIFF
--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -142,7 +142,7 @@ class LDAPQuery(object):
         if issubclass(type(ex), pyldap.LDAPError) and ex.args:
             raise CallError(f"{ex.args[0].get('desc')}: "
                             f"{ex.args[0].get('info', '')}",
-                            errno.EFAULT, type(ex))
+                            errno.EFAULT, type(ex).__name__)
         else:
             raise CallError(str(ex))
 
@@ -517,23 +517,23 @@ class LDAPService(ConfigService):
 
     @private
     async def convert_ldap_err_to_verr(self, data, e, verrors):
-        if e.extra == pyldap.INVALID_CREDENTIALS:
+        if e.extra == "INVALID_CREDENTIALS":
             verrors.add('ldap_update.binddn',
                         'Remote LDAP server returned response that '
                         'credentials are invalid.')
 
-        elif e.extra == pyldap.STRONG_AUTH_NOT_SUPPORTED and data['certificate']:
+        elif e.extra == "STRONG_AUTH_NOT_SUPPORTED" and data['certificate']:
             verrors.add('ldap_update.certificate',
                         'Certificate-based authentication is not '
                         f'supported by remote LDAP server: {e.errmsg}.')
 
-        elif e.extra == pyldap.NO_SUCH_OBJECT:
+        elif e.extra == "NO_SUCH_OBJECT":
             verrors.add('ldap_update.basedn',
                         'Remote LDAP server returned "NO_SUCH_OBJECT". This may '
                         'indicate that the base DN is syntactically correct, but does '
                         'not exist on the server.')
 
-        elif e.extra == pyldap.INVALID_DN_SYNTAX:
+        elif e.extra == "INVALID_DN_SYNTAX":
             verrors.add('ldap_update.basedn',
                         'Remote LDAP server returned that the base DN is '
                         'syntactically invalid.')


### PR DESCRIPTION
Add more detailed error messages for LDAP errors during workgroup and
site auto-detection. Some of these items are common misconfigurations,
but have a security impact and so we can't change them automatically.
More custom / detailed error messages will be added in the future.

Write testjoin output to separate file so that we preserve a
history of AD join attempts. These happen relatively infrequently
(hopefully only once), but may provide helpful diagnostic information
for support.

Convert LDAPError to text in ldap plugin.