### PR TITLE
NAS-105954 / 12.0 / Generate SSH config after syncing interfaces

### DIFF
--- a/debian/debian/ix-netif.service
+++ b/debian/debian/ix-netif.service
@@ -12,6 +12,7 @@ Conflicts=systemd-networkd.service
 Type=oneshot
 ExecStart=midclt -t 120 call interfaces.sync true
 ExecStartPost=midclt call etc.generate nginx
+ExecStartPost=midclt call etc.generate ssh
 StandardOutput=null
 
 [Install]

--- a/src/freenas/etc/ix.rc.d/ix-netif
+++ b/src/freenas/etc/ix.rc.d/ix-netif
@@ -229,6 +229,8 @@ netif_start()
 	echo "Generating configuration for web interface"
 	/usr/local/bin/midclt call etc.generate 'nginx' > /dev/null
 
+	echo "Generating configuration for SSH"
+	/usr/local/bin/midclt call etc.generate 'ssh' > /dev/null
 }
 
 name="ix-netif"

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -258,7 +258,7 @@ class EtcService(Service):
     }
 
     SKIP_LIST = [
-        'system_dataset', 'mdns', 'syslogd', 'nginx'
+        'system_dataset', 'mdns', 'syslogd', 'nginx', 'ssh',
     ] + (['ttys'] if osc.IS_LINUX else [])
 
     class Config:


### PR DESCRIPTION
This commit introduces changes where we generate SSH configuration after syncing interfaces as binded SSH interfaces at boot time have no ips and they are not reflected in the ssh configuration when it's generated at boot.