### PR TITLE
NAS-105954 / 11.3 / Generate SSH config after syncing interfaces (by sonicaj)

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-netif
+++ b/src/freenas/etc/ix.rc.d/ix-netif
@@ -235,6 +235,8 @@ netif_start()
 	echo "Generating configuration for web interface"
 	/usr/local/bin/midclt call etc.generate 'nginx' > /dev/null
 
+	echo "Generating configuration for SSH"
+	/usr/local/bin/midclt call etc.generate 'ssh' > /dev/null
 }
 
 name="ix-netif"

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -204,7 +204,7 @@ class EtcService(Service):
         ]
     }
 
-    SKIP_LIST = ['system_dataset', 'collectd', 'syslogd', 'smb_configure', 'nginx']
+    SKIP_LIST = ['system_dataset', 'collectd', 'syslogd', 'smb_configure', 'nginx', 'ssh']
 
     class Config:
         private = True


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 349ff71db9043f025f223444bc5b60afeec2d1c5

This commit introduces changes where we generate SSH configuration after syncing interfaces as binded SSH interfaces at boot time have no ips and they are not reflected in the ssh configuration when it's generated at boot.