### PR TITLE
NAS-105679 / 12.0 / fix(ixdiagnose): disable trace

### DIFF
--- a/src/freenas/usr/local/bin/ixdiagnose
+++ b/src/freenas/usr/local/bin/ixdiagnose
@@ -114,7 +114,6 @@ done
 # Make our staging directory.
 # We will then make a directory called ixdiagnose under it
 # so that the tarball extracts nicely.
-set -x
 if [ -z "${topdir}" ] ; then
 	topdir=`env TMPDIR="${tmpdir}" mktemp -d -t ixdiagnose`
 else


### PR DESCRIPTION
This may fill up stderr blocking writes while middleware is reading stdout.

Ticket:	NAS-105679