### PR TITLE
NAS-105679 / 11.3 / fix(ixdiagnose): disable trace (by william-gr)

### DIFF
--- a/src/freenas/usr/local/bin/ixdiagnose
+++ b/src/freenas/usr/local/bin/ixdiagnose
@@ -107,7 +107,6 @@ done
 # Make our staging directory.
 # We will then make a directory called ixdiagnose under it
 # so that the tarball extracts nicely.
-set -x
 if [ -z "${topdir}" ] ; then
 	topdir=`env TMPDIR="${tmpdir}" mktemp -d -t ixdiagnose`
 else


### PR DESCRIPTION
This may fill up stderr blocking writes while middleware is reading stdout.

Ticket:	NAS-105679