### PR TITLE
NAS-106027 / 12.0 / turn off syslog-ng stats msgs for TN HA

### DIFF
--- a/src/freenas/usr/local/etc/syslog-ng.conf.freenas
+++ b/src/freenas/usr/local/etc/syslog-ng.conf.freenas
@@ -3,7 +3,7 @@
 #
 # options
 #
-options { chain_hostnames(off); flush_lines(0); threaded(yes); use-fqdn(no); };
+options { chain_hostnames(off); flush_lines(0); threaded(yes); use-fqdn(no); stats-freq(0); };
 
 #
 # sources


### PR DESCRIPTION
`May  6 00:10:00 169.254.10.2 syslog-ng[2610]: Log statistics; processed='destination(messages)=3', dropped='dst.udp(other_controller#0,udp,169.254.10.1:7777)=0', processed='dst.udp(other_controller#0,udp,169.254.10.1:7777)=184', queued='dst.udp(other_controller#0,udp,169.254.10.1:7777)=0', written='dst.udp(other_controller#0,udp,169.254.10.1:7777)=184', processed='destination(authlog)=4', processed='destination(lpd-errs)=0', processed='destination(daemon)=0', processed='source(this_controller)=187', processed='destination(ppp)=0', processed='destination(other_controller_file)=187', processed='destination(other_controller)=184', processed='destination(security)=0', processed='global(internal_queue_length)=0', processed='src.internal(src#3)=43', stamp='src.internal(src#3)=1588737600', processed='center(queued)=514', processed='global(payload_reallocs)=80', queued='global(scratch_buffers_count)=0', processed='destination(maillog)=0', processed='source(src)=184', processed='destination(debuglog)=0', queued='global(scratch_buffers_bytes)=0', processed='destination(consolelog)=0', processed='destination(console)=0', processed='destination(system)=0', processed='destination(nginx_error)=0', processed='global(sdata_updates)=0', processed='destination(allusers)=0', processed='destination(xferlog)=0', processed='destination(mdnsresponder)=0', processed='center(received)=371', processed='destination(nginx_access)=0', processed='global(msg_clones)=0', processed='destination(cron)=136'`

fill up the /root/syslog/controller_* files and are worthless on TN HA.