### PR TITLE
NAS-106003 / 11.3 / Bug fix for user update via api v1

### DIFF
--- a/gui/account/forms.py
+++ b/gui/account/forms.py
@@ -353,6 +353,8 @@ class bsdUsersForm(ModelForm):
         return mode or None
 
     def clean_bsdusr_sshpubkey(self):
+        if 'bsdusr_sshpubkey' not in self.data:
+            return self.fields['bsdusr_sshpubkey'].initial
         ssh = self.cleaned_data.get('bsdusr_sshpubkey', '')
         ssh = ssh.strip(' ').strip('\n')
         ssh = re.sub(r'[ ]{2,}', ' ', ssh, re.M)


### PR DESCRIPTION
This commit fixes an issue where if a PUT request was made and ssh pubkey was not supplied for the user, the user would be left with a blank ssh pubkey because cleaned data does not get the initial value set in the charfield.