### PR TITLE
NAS-106010 / 12.0 / Fix activedirectory.set_kerberos_servers

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -1057,14 +1057,15 @@ class ActiveDirectoryService(ConfigService):
         return ret
 
     @private
-    def get_kerberos_servers(self):
+    def get_kerberos_servers(self, ad=None):
         """
         This returns at most 3 kerberos servers located in our AD site. This is to optimize
         kerberos configuration for locations where kerberos servers may span the globe and
         have equal DNS weighting. Since a single kerberos server may represent an unacceptable
         single point of failure, fall back to relying on normal DNS queries in this case.
         """
-        ad = self.middleware.call_sync('activedirectory.config')
+        if ad is None:
+            ad = self.middleware.call_sync('activedirectory.config')
         AD_DNS = ActiveDirectory_DNS(conf=ad, logger=self.logger)
         krb_kdc = AD_DNS.get_n_working_servers(SRV['KERBEROSDOMAINCONTROLLER'], 3)
         krb_admin_server = AD_DNS.get_n_working_servers(SRV['KERBEROS'], 3)
@@ -1076,18 +1077,22 @@ class ActiveDirectoryService(ConfigService):
             if len(servers) == 1:
                 return None
 
-        return {'krb_kdc': kdc, 'krb_admin_server': admin_server, 'krb_kpasswd_server': kpasswd}
+        return {
+            'krb_kdc': ' '.join(kdc),
+            'krb_admin_server': ' '.join(admin_server),
+            'krb_kpasswd_server': ' '.join(kpasswd)
+        }
 
     @private
-    def set_kerberos_servers(self, ad):
+    def set_kerberos_servers(self, ad=None):
         if not ad:
-            ad = self.config()
-        site_indexed_kerberos_servers = self.middleware.call_sync('get_kerberos_servers')
+            ad = self.middleware.call_sync('activedirectory.config')
+        site_indexed_kerberos_servers = self.get_kerberos_servers(ad)
         if site_indexed_kerberos_servers:
             self.middleware.call_sync(
                 'datastore.update',
                 'directoryservice.kerberosrealm',
-                ad['kerberos_realm']['id'],
+                ad['kerberos_realm'],
                 site_indexed_kerberos_servers
             )
             self.middleware.call_sync('etc.generate', 'kerberos')


### PR DESCRIPTION
We set site-specific kerberos servers if the NAS is located in
a non-default AD site and there are more than three DCs in the
site. This caused a testing escape and corresponding regression
after some changes to other parts of the AD plugin.

- Pass AD config from set_kerberos_servers() to get_kerberos_servers()
  to avoid an extra unnecessary call to get the config.
- Fix a few typos
- Ensure that servers are added as a space-separated list for
  datastore insertion.