### PR TITLE
NAS-106049 / 11.3 / Fix errors tracebacks during system dataset migration

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -351,7 +351,7 @@ class SMBService(SystemServiceService):
             return
 
         disallowed_list = ['USERS', 'ADMINISTRATORS', 'GUESTS']
-        existing_groupmap = await self.middleware.call('smb.groupmap_list')
+        existing_groupmap = await self.groupmap_list()
         for user in (await self.middleware.call('user.query')):
             disallowed_list.append(user['username'].upper())
         for g in existing_groupmap.values():
@@ -360,6 +360,7 @@ class SMBService(SystemServiceService):
         if group.upper() in disallowed_list:
             self.logger.debug('Setting group map for %s is not permitted', group)
             return False
+
         gm_add = await run(
             [SMBCmd.NET.value, '-d', '0', 'groupmap', 'add', 'type=local', f'unixgroup={group}', f'ntgroup={group}'],
             check=False


### PR DESCRIPTION
Export of pool and related system dataset migration triggered
two tracebacks. One regression in smb_configure
caused by groupmap_list output format changes and the other
in reporting setup due to failure to check whether symlink
already exists.