### PR TITLE
Prevent SMB syslog spam and generate separate auth_audit log

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf
@@ -124,7 +124,7 @@
                 'directory name cache size': '0',
                 'nsupdate command': '/usr/local/bin/samba-nsupdate -g',
                 'unix charset': db['cifs']['unixcharset'],
-                'log level': db['loglevel'],
+                'log level': f"{db['loglevel']} auth_json_audit:3@/var/log/samba4/auth_audit.log",
                 'obey pam restrictions': 'True' if pam_is_required(db) else 'False',
             })
             if osc.IS_FREEBSD:
@@ -136,8 +136,11 @@
                     'username map cache time': '60',
                 })
 
-            if not db['cifs']['syslog']:
+            if db['cifs']['syslog']:
+                pc.update({'logging': f'syslog@{"3" if int(db["loglevel"]) > 3 else db["loglevel"]} file'})
+            else:
                 pc.update({'logging': 'file'})
+
             if db['cifs']['enable_smb1']:
                 pc.update({'server min protocol': 'NT1'})
             else:


### PR DESCRIPTION
When SMB is configured to log to syslog, prevent the verbosity being
sent to the syslog server from exceeding 3. This is almost certainly
a user misconfiguration. Local file logging will still be at the
expected level.

Write authentication attempts to a separate log file:
/var/log/samba4/auth_audit.log. Expose reading it as a possible
infolevel when calling "smb.status".