### PR TITLE
Make sure pwenc plugin is setup before other plugins

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -849,6 +849,9 @@ class Middleware(LoadPluginsMixin, RunInThreadMixin):
                 'auth',
                 # We need to register all services because pseudo-services can still be used by plugins setup functions
                 'service',
+                # We need to run pwenc first to ensure we have secret setup to work for encrypted fields which
+                # might be used in the setup functions.
+                'pwenc',
                 # We run boot plugin first to ensure we are able to retrieve
                 # BOOT POOL during system plugin initialization
                 'boot',


### PR DESCRIPTION
This commit introduces changes to ensure we setup pwenc plugin before others because other plugin's setup functions can make use of encryption/decryption which will fail if pwenc has not setup secret.