### PR TITLE
NAS-106044 / 12.0 / fix fenced on TN HA systems

### DIFF
--- a/src/fenced/fenced/disks.py
+++ b/src/fenced/fenced/disks.py
@@ -88,12 +88,12 @@ class Disks(dict):
 
         def callback(i, fs, failed):
             try:
-                host_key, remote_keys = i.result()
+                host_key, remote_key = i.result()
+                remote_keys.update(remote_key)
                 if host_key is None:
                     failed.add(fs[i])
                     return
                 keys.add(host_key)
-                remote_keys.union(remote_keys)
             except Exception:
                 failed.add(fs[i])
 


### PR DESCRIPTION
The issue is that fenced was not detecting when remote keys changed because the `get_keys` method is returning the `failed_keys` in the place of `remote_keys` in the tuple.