### PR TITLE
NAS-105985 / 12.0 / suppress repetitive log msgs that occur more than once in 60 secs

### DIFF
--- a/src/freenas/usr/local/etc/syslog-ng.conf.freenas
+++ b/src/freenas/usr/local/etc/syslog-ng.conf.freenas
@@ -3,7 +3,7 @@
 #
 # options
 #
-options { chain_hostnames(off); flush_lines(0); threaded(yes); use-fqdn(no); stats-freq(0); };
+options { suppress(60); chain_hostnames(off); flush_lines(0); threaded(yes); use-fqdn(no); stats-freq(0); };
 
 #
 # sources


### PR DESCRIPTION
If the same message is generated more than once within a 60 second timeframe, syslog-ng will log the 1st message and then it will suppress the other messages until they stop or a different message comes through.

This actually would have fixed the collectd spamming issues we saw early on when we implemented the rrdcached daemon.