### PR TITLE
NAS-106062 / 12.0 / fix syslog-ng binding to all ints on TN HA

### DIFF
--- a/src/middlewared/middlewared/etc_files/syslogd.py
+++ b/src/middlewared/middlewared/etc_files/syslogd.py
@@ -110,15 +110,25 @@ def generate_ha_syslog(middleware):
         syslog_conf = f.read()
 
     syslog_conf += textwrap.dedent(f"""\
+
+
         #
         # filter smbd related messages across HA syslog connection
         #
         filter f_not_smb {{ not program("smbd"); }};
 
 
+        #
+        # syslog-ng TrueNAS HA configuration
+        #
         source this_controller {{
-            udp(ip({controller_ip}) port({controller_port}));
-            udp(default-facility(syslog) default-priority(emerg));
+            network(
+                localip("{controller_ip}")
+                port({controller_port})
+                transport("udp")
+                default-facility(syslog)
+                default-priority(emerg)
+            );
         }};
 
         log {{
@@ -126,10 +136,25 @@ def generate_ha_syslog(middleware):
             destination(other_controller_file);
         }};
 
-        destination other_controller_file {{ file("{controller_file}"); }};
-        destination other_controller {{ udp("{controller_other_ip}" port({controller_port})); }};
+        destination other_controller_file {{
+            file("{controller_file}");
+        }};
 
-        log {{ source(src); filter(f_not_smb); filter(f_not_mdnsresponder); filter(f_not_nginx); destination(other_controller); }};
+        destination other_controller {{
+            network(
+                "{controller_other_ip}"
+                port({controller_port})
+                transport("udp")
+            );
+        }};
+
+        log {{
+            source(src);
+            filter(f_not_smb);
+            filter(f_not_mdnsresponder);
+            filter(f_not_nginx);
+            destination(other_controller);
+        }};
     """)
 
     with open("/etc/local/syslog-ng.conf", "w") as f:


### PR DESCRIPTION
When specifying a listening port on syslog-ng, if you do not specify the `network()` driver it will bind to all available interfaces by default.

This change does 2 things.

1. use the network() driver to prevent syslog-ng from binding to all interfaces
2. change the formatting of the entries so the config file is more readable