### PR TITLE
Add validation for smb usernames and groupnames

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -678,7 +678,7 @@ class UserService(CRUDService):
                     f'The username "{data["username"]}" already exists.',
                     errno.EEXIST
                 )
-            if 'smb' in data:
+            if data.get('smb'):
                 smb_users = await self.middleware.call('datastore.query',
                                                        'account.bsdusers',
                                                        [('smb', '=', True)] + exclude_filter,
@@ -1114,7 +1114,7 @@ class GroupService(CRUDService):
         exclude_filter = [('id', '!=', pk)] if pk else []
 
         if 'name' in data:
-            if 'smb' in data:
+            if data.get('smb'):
                 if data['name'].upper() in [x.name for x in SMBBuiltin]:
                     verrors.add(
                         f'{schema}.name',

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -385,10 +385,11 @@ class SMBService(SystemServiceService):
         await self.middleware.call('smb.set_sid', data['cifs_SID'])
 
         if await self.middleware.call("smb.getparm", "passdb backend", "global") == "tdbsam":
-            job.set_progress(40, 'Synchronizing passdb.')
-            await self.middleware.call("smb.synchronize_passdb")
-            job.set_progress(50, 'Synchronizing group mappings.')
-            await self.middleware.call("smb.synchronize_group_mappings")
+            job.set_progress(40, 'Synchronizing passdb and groupmap.')
+            pdb_job = await self.middleware.call("smb.synchronize_passdb")
+            grp_job = await self.middleware.call("smb.synchronize_group_mappings")
+            await pdb_job.wait()
+            await grp_job.wait()
             await self.middleware.call("admonitor.start")
             job.set_progress(60, 'generating SMB share configuration.')
             await self.middleware.call("etc.generate", "smb_share")

--- a/src/middlewared/middlewared/plugins/smb_/passdb.py
+++ b/src/middlewared/middlewared/plugins/smb_/passdb.py
@@ -1,4 +1,4 @@
-from middlewared.service import Service, private
+from middlewared.service import Service, job, private
 from middlewared.service_exception import CallError
 from middlewared.utils import Popen, run
 from middlewared.plugins.smb import SMBCmd
@@ -133,7 +133,8 @@ class SMBService(Service):
             raise CallError(f'Failed to delete user [{username}]: {deluser.stderr.decode()}')
 
     @private
-    async def synchronize_passdb(self):
+    @job(lock="passdb_sync")
+    async def synchronize_passdb(self, job):
         """
         Create any missing entries in the passdb.tdb.
         Replace NT hashes of users if they do not match what is the the config file.

--- a/src/middlewared/middlewared/plugins/smb_/passdb.py
+++ b/src/middlewared/middlewared/plugins/smb_/passdb.py
@@ -24,7 +24,7 @@ class SMBService(Service):
         if not os.path.exists(f'{private_dir}/passdb.tdb'):
             return pdbentries
 
-        if await self.middleware.call('smb.getparm', 'passdb backend', 'global') == 'ldapsam':
+        if await self.middleware.call('smb.getparm', 'passdb backend', 'global') != 'tdbsam':
             return pdbentries
 
         if not verbose:
@@ -63,13 +63,18 @@ class SMBService(Service):
         return pdbentries
 
     @private
-    async def update_passdb_user(self, username):
+    async def update_passdb_user(self, username, passdb_backend=None):
         """
         Updates a user's passdb entry to reflect the current server configuration.
         Accounts that are 'locked' in the UI will have their corresponding passdb entry
         disabled.
         """
-        if await self.middleware.call('smb.getparm', 'passdb backend', 'global') == 'ldapsam':
+        if passdb_backend is None:
+            passdb_backend = await self.middleware.call('smb.getparm',
+                                                        'passdb backend',
+                                                        'global')
+
+        if passdb_backend != 'tdbsam':
             return
 
         bsduser = await self.middleware.call('user.query', [
@@ -135,7 +140,11 @@ class SMBService(Service):
         Synchronize the "disabled" state of users
         Delete any entries in the passdb_tdb file that don't exist in the config file.
         """
-        if await self.middleware.call('smb.getparm', 'passdb backend', 'global') == 'ldapsam':
+        passdb_backend = await self.middleware.call('smb.getparm',
+                                                    'passdb backend',
+                                                    'global')
+
+        if passdb_backend != 'tdbsam':
             return
 
         conf_users = await self.middleware.call('user.query', [
@@ -145,7 +154,7 @@ class SMBService(Service):
             ]]
         ])
         for u in conf_users:
-            await self.middleware.call('smb.update_passdb_user', u['username'])
+            await self.middleware.call('smb.update_passdb_user', u['username'], passdb_backend)
 
         pdb_users = await self.passdb_list()
         if len(pdb_users) > len(conf_users):


### PR DESCRIPTION
Improve validation for usernames and groupnames when "smb" is selected. Convert groupmap and passdb synchronization to jobs as these can potentially take a significant amount of time to complete in environments with large numbers of SMB users.