### PR TITLE
Send error message if 'method' message lacks a method

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -308,6 +308,11 @@ class Application(object):
             return
 
         if message['msg'] == 'method':
+            if 'method' not in message:
+                self.send_error(message, errno.EINVAL,
+                                "Message is malformed: 'method' is absent.")
+                return
+
             try:
                 serviceobj, methodobj = self.middleware._method_lookup(message['method'])
             except CallError as e:


### PR DESCRIPTION
Handle this particular type of malformed payload slightly more
gracefully.