### PR TITLE
Fix groupmap deletion for stale SMB builtin groups

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/groupmap.py
+++ b/src/middlewared/middlewared/plugins/smb_/groupmap.py
@@ -134,7 +134,7 @@ class SMBService(Service):
                 stale_entry = list(filter(lambda x: b.name.lower().capitalize() == x['ntgroup'], groupmap.values()))
                 if stale_entry:
                     must_remove_cache = True
-                    await self.groupmap_delete(b.name.lower().capitalize())
+                    await self.groupmap_delete({"ntgroup": b.name.lower().capitalize()})
 
                 await self.groupmap_add(b.value[0], passdb_backend)
 


### PR DESCRIPTION
smb.groupmap_delete now accepts a dictionary for its argument
so that we can delete either by SID or NT name. Update usage in
builtin groupmap cleanup code in smb.synchronize_group_mappings.