### PR TITLE
NAS-106167 / 11.3 / Fix SMB share generation on boot

### DIFF
--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -169,6 +169,7 @@ class EtcService(Service):
         ],
         'smb_configure': [
             {'type': 'py', 'path': 'smb_configure'},
+            {'type': 'mako', 'path': 'local/smb4_share.conf'},
         ],
         'snmpd': [
             {'type': 'mako', 'path': 'local/snmpd.conf'},


### PR DESCRIPTION
Work on optimizing / removing timeouts in environments with
large numbers of local users caused a regression in smb share
config generation. Explicitly add SMB share generation to
the SMB setup routine on system dataset setup. At this point
all the SMB coniguration details should be ready and properly
initialized.