### PR TITLE
NAS-106237 / 11.3 / Avoid race between zpool import completion and share config generation

### DIFF
--- a/src/middlewared/middlewared/plugins/afp.py
+++ b/src/middlewared/middlewared/plugins/afp.py
@@ -316,6 +316,10 @@ async def pool_post_import(middleware, pool):
     """
     Makes sure to reload AFP if a pool is imported and there are shares configured for it.
     """
+    if pool is None:
+        asyncio.ensure_future(middleware.call('etc.generate', 'afpd'))
+        return
+
     path = f'/mnt/{pool["name"]}'
     if await middleware.call('sharing.afp.query', [
         ('OR', [

--- a/src/middlewared/middlewared/plugins/ftp.py
+++ b/src/middlewared/middlewared/plugins/ftp.py
@@ -172,6 +172,14 @@ async def pool_post_import(middleware, pool):
     """
     We don't set up anonymous FTP if pool is not imported yet.
     """
+    if pool is None:
+        try:
+            await middleware.call("etc.generate", "ftp")
+        except Exception:
+            middleware.logger.debug("Failed to generate ftp configuration file.", exc_info=True)
+        finally:
+            return
+
     await middleware.call("service.reload", "ftp")
 
 

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -488,6 +488,10 @@ async def pool_post_import(middleware, pool):
     """
     Makes sure to reload NFS if a pool is imported and there are shares configured for it.
     """
+    if pool is None:
+        asyncio.ensure_future(middleware.call('etc.generate', 'nfsd'))
+        return
+
     path = f'/mnt/{pool["name"]}'
     for share in await middleware.call('sharing.nfs.query'):
         if any(filter(lambda x: x == path or x.startswith(f'{path}/'), share['paths'])):

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -2490,11 +2490,6 @@ class PoolService(CRUDService):
             self.logger.warn('Failed to configure collectd', exc_info=True)
 
         try:
-            self.middleware.call_sync('etc.generate', 'ftp')
-        except Exception:
-            self.logger.warn('Failed to configure ftp', exc_info=True)
-
-        try:
             self.middleware.call_sync('etc.generate', 'syslogd')
         except Exception:
             self.logger.warn('Failed to configure syslogd', exc_info=True)
@@ -2504,6 +2499,9 @@ class PoolService(CRUDService):
         # Configure swaps after importing pools. devd events are not yet ready at this
         # stage of the boot process.
         self.middleware.call_sync('disk.swaps_configure')
+
+        # Call post_import hook for sharing services now that pools are imported
+        self.middleware.call_hook_sync('pool.post_import', None)
 
         job.set_progress(100, 'Pools import completed')
 

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -967,6 +967,10 @@ async def pool_post_import(middleware, pool):
     """
     Makes sure to reload SMB if a pool is imported and there are shares configured for it.
     """
+    if pool is None:
+        asyncio.ensure_future(middleware.call('etc.generate', 'smb_share'))
+        return
+
     path = f'/mnt/{pool["name"]}'
     if await middleware.call('sharing.smb.query', [
         ('OR', [

--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -393,6 +393,9 @@ async def pool_post_import(middleware, pool):
     """
     On pool import we may need to reconfigure system dataset.
     """
+    if pool is None:
+        return
+
     await middleware.call('systemdataset.setup')
 
 

--- a/src/middlewared/middlewared/plugins/webdav.py
+++ b/src/middlewared/middlewared/plugins/webdav.py
@@ -237,6 +237,10 @@ async def pool_post_import(middleware, pool):
     """
     Makes sure to reload WebDAV if a pool is imported and there are shares configured for it.
     """
+    if pool is None:
+        asyncio.ensure_future(middleware.call('etc.generate', 'webdav'))
+        return
+
     path = f'/mnt/{pool["name"]}'
     if await middleware.call('sharing.webdav.query', [
         ('OR', [


### PR DESCRIPTION
11.3-U2 added a sanity check when generating share configuration to
avoid adding shares to non-existent paths. In some cases configuration
file generation may happen before zpool import completes. This causes
shares on the pool with slow import to not be visible.