### PR TITLE
NAS-106171 / 11.3 / SMB: Add RID check after initial SMB configuration

### DIFF
--- a/src/middlewared/middlewared/etc_files/smb_configure.py
+++ b/src/middlewared/middlewared/etc_files/smb_configure.py
@@ -297,4 +297,5 @@ def render(service, middleware):
     if conf['passdb_backend'] == "tdbsam":
         middleware.call_sync('smb.synchronize_passdb')
         validate_group_mappings(middleware, conf)
+        middleware.call_sync('smb.check_rid_conflict')
         middleware.call_sync('admonitor.start')


### PR DESCRIPTION
Add check to see whether any duplicate RIDs appear in the group_mapping
and passdb databases. If duplicates exist, remove the group_mapping
database and re-create it.