### PR TITLE
NAS-106349 / 12.0 / Add initial POSIX1e ACL support to middleware

### DIFF
--- a/debian/debian/control
+++ b/debian/debian/control
@@ -8,7 +8,9 @@ Homepage: http://www.truenas.com
 
 Package: truenas
 Architecture: all
-Depends: collectd,
+Depends: acl,
+         cifs-utils,
+         collectd,
          cpuid,
          docker-ce,
          gdb,

--- a/src/middlewared/middlewared/plugins/filesystem.py
+++ b/src/middlewared/middlewared/plugins/filesystem.py
@@ -842,14 +842,13 @@ class FilesystemService(Service):
                                   check=False, capture_output=True)
         if stripacl.returncode != 0:
             raise CallError(f"Failed to remove POSIX1e ACL from [{path}]: "
-                                f"{stripacl.stderr.decode()}")
+                            f"{stripacl.stderr.decode()}")
 
         if options['stripacl']:
             job.set_progress(100, "Finished removing POSIX1e ACL")
             return
 
         job.set_progress(50, 'Reticulating splines.')
-
 
         for idx, ace in enumerate(dacl):
             if idx == 0:


### PR DESCRIPTION
Initial work to read and theoretically set a POSIX1e ACL on
filesystems that support that acl type rather than NFSv4 (glusterfs).

More work is needed to add support for maintining Samba ACLs on
POSIX1e filesystems since these ACLs may be written to xattrs in
the security namespace on Linux.