### PR TITLE
NAS-106288 / 12.0 / Correctly validate certificate chain

### DIFF
--- a/src/middlewared/middlewared/plugins/crypto.py
+++ b/src/middlewared/middlewared/plugins/crypto.py
@@ -3,6 +3,7 @@ import dateutil
 import dateutil.parser
 import inspect
 import ipaddress
+import itertools
 import josepy as jose
 import json
 import os
@@ -297,7 +298,7 @@ class CryptoKeyService(Service):
     def validate_cert_with_chain(self, cert, chain):
         check_cert = crypto.load_certificate(crypto.FILETYPE_PEM, cert)
         store = crypto.X509Store()
-        for chain_cert in chain:
+        for chain_cert in itertools.chain.from_iterable(map(lambda c: RE_CERTIFICATE.findall(c), chain)):
             store.add_cert(
                 crypto.load_certificate(crypto.FILETYPE_PEM, chain_cert)
             )

--- a/src/middlewared/middlewared/plugins/kmip/connection.py
+++ b/src/middlewared/middlewared/plugins/kmip/connection.py
@@ -1,5 +1,6 @@
 import contextlib
 import socket
+import uuid
 
 from kmip.core import enums
 from kmip.pie.client import ProxyKmipClient
@@ -71,9 +72,9 @@ class KMIPServerMixin:
                 raise CallError('Retrieved managed object is not secret data')
             return obj.value.decode()
 
-    def _register_secret_data(self, key, conn):
+    def _register_secret_data(self, name, key, conn):
         # Create key on the KMIP Server
-        secret_data = SecretData(key.encode(), enums.SecretDataType.PASSWORD)
+        secret_data = SecretData(key.encode(), enums.SecretDataType.PASSWORD, name=f'{name}-{str(uuid.uuid4())[:7]}')
         try:
             uid = conn.register(secret_data)
         except KmipOperationFailure as e:

--- a/src/middlewared/middlewared/plugins/kmip/sed_keys.py
+++ b/src/middlewared/middlewared/plugins/kmip/sed_keys.py
@@ -143,7 +143,7 @@ class KMIPService(Service, KMIPServerMixin):
                         disk['kmip_uid'], conn, self.middleware.logger, disk['identifier']
                     )
                 try:
-                    uid = self._register_secret_data(self.disks_keys[disk['identifier']], conn)
+                    uid = self._register_secret_data(disk['identifier'], self.disks_keys[disk['identifier']], conn)
                 except Exception:
                     failed.append(disk['identifier'])
                     update_data = {'kmip_uid': None} if destroy_successful else {}
@@ -170,7 +170,7 @@ class KMIPService(Service, KMIPServerMixin):
                     )
                 self.global_sed_key = adv_config['sed_passwd']
                 try:
-                    uid = self._register_secret_data(self.global_sed_key, conn)
+                    uid = self._register_secret_data('global_sed_key', self.global_sed_key, conn)
                 except Exception:
                     failed.append('Global SED Key')
                 else:

--- a/src/middlewared/middlewared/plugins/kmip/zfs_keys.py
+++ b/src/middlewared/middlewared/plugins/kmip/zfs_keys.py
@@ -53,7 +53,7 @@ class KMIPService(Service, KMIPServerMixin):
                     if not destroy_successful:
                         self.middleware.logger.debug(f'Failed to destroy key from KMIP Server for {ds["name"]}')
                 try:
-                    uid = self._register_secret_data(self.zfs_keys[ds['name']], conn)
+                    uid = self._register_secret_data(ds['name'], self.zfs_keys[ds['name']], conn)
                 except Exception:
                     failed.append(ds['name'])
                     update_data = {'kmip_uid': None} if destroy_successful else {}


### PR DESCRIPTION
This commit introduces changes to ensure we factor in the scenario where the certificate field might actually contain the complete CA chain and we should add that to the store accordingly while validating.