### PR TITLE
NAS-106306 / 11.3 / Allow syncing of interfaces in case of setting mtu failure (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -1708,7 +1708,12 @@ class InterfaceService(CRUDService):
                     continue
 
                 if member_iface.mtu != mtu:
-                    member_iface.mtu = mtu
+                    try:
+                        member_iface.mtu = mtu
+                    except Exception:
+                        self.logger.error(
+                            'Unable to set MTU of %r bridge member %r to %d', name, member, mtu, exc_info=True
+                        )
                 sync_interface_opts[member]['skip_mtu'] = True
 
             for member in members_database - members:
@@ -1724,7 +1729,12 @@ class InterfaceService(CRUDService):
                 iface.delete_member(member)
 
             if iface.mtu != mtu:
-                iface.mtu = mtu
+                try:
+                    iface.mtu = mtu
+                except Exception:
+                    self.logger.error(
+                        'Unable to set MTU of %r bridge to %d', name, mtu, exc_info=True
+                    )
 
         self.logger.info('Interfaces in database: {}'.format(', '.join(interfaces) or 'NONE'))
         # Configure VLAN before BRIDGE so MTU is configured in correct order


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 7c3dcc308aaca43471b42141ae0b6f6127de06c6

This commit introduces changes where if we have a network config with a chain `physical iface -> vlan -> bridge` ( all having say MTU of 9000 ), we won't be able to set a custom MTU for the ifaces if specified because interfaces are synced after bridges have been setup.
Why this is an issue is because when we add the members to the bridge we configure their MTU and if up in the chain we have lower MTU values, we can't change the MTU.