### PR TITLE
NAS-106316 / 11.3 / Make sure HOME env variable is set correctly when setting user context (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/utils/__init__.py
+++ b/src/middlewared/middlewared/utils/__init__.py
@@ -139,6 +139,8 @@ def setusercontext(user):
     except Exception:
         os.chdir('/')
 
+    os.environ['HOME'] = passwd.pw_dir
+
 
 def _run_command(user, commandline, q, rv):
     setusercontext(user)


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 3a12437284f6a1d64d1811918e4bdfbd0d475af5

