### PR TITLE
Create docker directory if it does not exist

### DIFF
--- a/src/middlewared/middlewared/etc_files/docker.py
+++ b/src/middlewared/middlewared/etc_files/docker.py
@@ -7,5 +7,6 @@ def render(service, middleware):
     if not sys_config['path']:
         return
 
+    os.makedirs('/etc/docker', exist_ok=True)
     with open('/etc/docker/daemon.json', 'w') as f:
         f.write(json.dumps({'data-root': os.path.join(sys_config['path'], 'services/docker')}))


### PR DESCRIPTION
On first boot, we don't have docker directory, so we should create it if it does not exist.