### PR TITLE
Handle case where pool is null on post import hook

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
@@ -1533,7 +1533,7 @@ async def hook_pool_export(middleware, pool=None, *args, **kwargs):
 
 
 async def hook_pool_post_import(middleware, pool):
-    if pool['encrypt'] == 2 and pool['passphrase']:
+    if pool and pool['encrypt'] == 2 and pool['passphrase']:
         await middleware.call(
             'failover.update_encryption_keys', {
                 'pools': [{'name': pool['name'], 'passphrase': pool['passphrase']}]


### PR DESCRIPTION
On boot, post_import hook sends None as arg, we should make sure that registered hooks respect that parameter.