### PR TITLE
NAS-106505 / 12.0 / AD: split messages from wb_fifo on newline

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -1453,7 +1453,8 @@ class WBStatusThread(threading.Thread):
         while not self.finished.is_set():
             with open(f'{SMBPath.RUNDIR.platform()}/.wb_fifo') as f:
                 data = f.read()
-                self.parse_msg(data)
+                for msg in data.splitlines():
+                    self.parse_msg(msg)
 
         self.logger.debug('exiting winbind messaging thread')
 


### PR DESCRIPTION
In some situations winbindd may write multiple status change messages
before the middleware thread has an opportunity to read them. Because
of this, the winbindd behavior has been modified in a separate PR to
append a terminating newline to status messages. Accordingly, we
need to splitlines() in middleware to separate out the messages and
then parse each one separately to avoid JSON exceptions.