### PR TITLE
Do not permit users to set root as a guest account

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -511,6 +511,9 @@ class SMBService(SystemServiceService):
         if new['netbiosname'] and new['netbiosname'].lower() == new['workgroup'].lower():
             verrors.add('smb_update.netbiosname', 'NetBIOS and Workgroup must be unique')
 
+        if new['guest'] == 'root':
+            verrors.add('smb_update.guest', '"root" is not a permitted guest account')
+
         if data.get('bindip'):
             bindip_choices = list((await self.bindip_choices()).keys())
             for idx, item in enumerate(data['bindip']):


### PR DESCRIPTION
This one should not need explanation.