### PR TITLE
NAS-106586 / 12.1 / Refresh failover status before starting services after becoming master

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/event.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/event.py
@@ -476,6 +476,7 @@ class FailoverService(Service):
 
                 self.logger.warn('Volume imports complete.')
                 self.logger.warn('Restarting services.')
+                self.run_call('failover.status_refresh')
                 FREENAS_DB = '/data/freenas-v1.db'
                 conn = sqlite3.connect(FREENAS_DB)
                 c = conn.cursor()


### PR DESCRIPTION
If we don't refresh failover status prior to restarting services, then we
may end up passing a stale cached status to etc scripts and cause
services to come up misconfigured.