### PR TITLE
NAS-106558 / 12.0 / fix ALUA on TN HA (by yocalebo)

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/event.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/event.py
@@ -522,7 +522,6 @@ class FailoverService(Service):
                         pass
                     self.run_call('service.restart', 'cifs', {'ha_propagate': False})
 
-                # iscsi should be running on standby but we make sure its started anyway
                 c.execute('SELECT srv_enable FROM services_services WHERE srv_service = "iscsitarget"')
                 ret = c.fetchone()
                 if ret and ret[0] == 1:

--- a/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
+++ b/src/middlewared/middlewared/plugins/service_/services/iscsitarget.py
@@ -14,14 +14,6 @@ class ISCSITargetService(SimpleService):
 
     systemd_unit = "scst"
 
-    async def before_stop(self):
-        if osc.IS_FREEBSD:
-            cp = await run(["sysctl", "kern.cam.ctl.ha_peer=''"], check=False)
-            if cp.returncode and "unknown oid" not in cp.stderr.decode().lower():
-                self.middleware.logger.error(
-                    "Failed to set sysctl kern.cam.ctl.ha_peer : %s", cp.stderr.decode()
-                )
-
     async def reload(self):
         if osc.IS_LINUX:
             return (await run(


### PR DESCRIPTION
This one is tricky. On boot, etc.generate will set the `ha_peer` entry for ALUA appropriately. However, on backup event we restarted the iscsitarget service which removed that entry.

There is no reason to remove that entry in the service. etc.generate takes care of that by itself.