### PR TITLE
NAS-106567 / 11.3 / Default to adding server EKU extension in internal certificates

### DIFF
--- a/src/middlewared/middlewared/plugins/crypto.py
+++ b/src/middlewared/middlewared/plugins/crypto.py
@@ -1470,7 +1470,8 @@ class CertificateService(CRUDService):
         cert_info.update({
             'ca_privatekey': signing_cert['privatekey'],
             'ca_certificate': signing_cert['certificate'],
-            'serial': cert_serial
+            'serial': cert_serial,
+            'server_auth_eku': True,  # For 11.3, we assume each certificate is a server certificate
         })
 
         cert, key = await self.middleware.call(


### PR DESCRIPTION
We intend FN to be used as a server with the services we share/expose and with that context in mind, we default to adding server EKU extension while creating internal certificates