### PR TITLE
NAS-106181 / 12.0 / avahi: set "allow-interfaces" to an empty list (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/avahi/avahi-daemon.conf
+++ b/src/middlewared/middlewared/etc_files/local/avahi/avahi-daemon.conf
@@ -27,6 +27,7 @@ use-ipv6=${"yes" if ipv6_enabled else "no"}
 ratelimit-interval-usec=1000000
 ratelimit-burst=1000
 enable-dbus=no
+allow-interfaces=
 
 [wide-area]
 enable-wide-area=yes


### PR DESCRIPTION
Per manpage, if this parameter is set to an empty list, then all local interfaces except loopback and point-to-point will be used.