### PR TITLE
NAS-106601 / 11.3 / Don't alert on non-fatal rsync return codes (by blkeller)

### DIFF
--- a/src/middlewared/middlewared/plugins/rsync.py
+++ b/src/middlewared/middlewared/plugins/rsync.py
@@ -27,6 +27,7 @@
 import asyncio
 import asyncssh
 import contextlib
+import enum
 import glob
 import os
 import shlex
@@ -42,6 +43,40 @@ from middlewared.utils import run_command_with_user_context
 
 
 RSYNC_PATH_LIMIT = 1023
+
+
+class RsyncReturnCode(enum.Enum):
+    # from rsync's "errcode.h"
+    OK = 0
+    SYNTAX = 1         # syntax or usage error
+    PROTOCOL = 2       # protocol incompatibility
+    FILESELECT = 3     # errors selecting input/output files, dirs
+    UNSUPPORTED = 4    # requested action not supported
+    STARTCLIENT = 5    # error starting client-server protocol
+    SOCKETIO = 10      # error in socket IO
+    FILEIO = 11        # error in file IO
+    STREAMIO = 12      # error in rsync protocol data stream
+    MESSAGEIO = 13     # errors with program diagnostics
+    IPC = 14           # error in IPC code
+    CRASHED = 15       # sibling crashed
+    TERMINATED = 16    # sibling terminated abnormally
+    SIGNAL1 = 19       # status returned when sent SIGUSR1
+    SIGNAL = 20        # status returned when sent SIGINT, SIGTERM, SIGHUP
+    WAITCHILD = 21     # some error returned by waitpid()
+    MALLOC = 22        # error allocating core memory buffers
+    PARTIAL = 23       # partial transfer
+    VANISHED = 24      # file(s) vanished on sender side
+    DEL_LIMIT = 25     # skipped some deletes due to --max-delete
+    TIMEOUT = 30       # timeout in data send/receive
+    CONTIMEOUT = 35    # timeout waiting for daemon connection
+
+    @classmethod
+    def nonfatals(cls):
+        return tuple([rc.value for rc in [
+            cls.OK,
+            cls.VANISHED,
+            cls.DEL_LIMIT
+        ]])
 
 
 class RsyncdService(SystemServiceService):
@@ -593,7 +628,7 @@ class RsyncTaskService(CRUDService):
         for klass in ('RsyncSuccess', 'RsyncFailed') if not rsync['quiet'] else ():
             self.middleware.call_sync('alert.oneshot_delete', klass, rsync['id'])
 
-        if cp.returncode != 0:
+        if cp.returncode not in RsyncReturnCode.nonfatals():
             if not rsync['quiet']:
                 self.middleware.call_sync('alert.oneshot_create', 'RsyncFailed', {
                     'id': rsync['id'],

--- a/src/middlewared/middlewared/plugins/rsync.py
+++ b/src/middlewared/middlewared/plugins/rsync.py
@@ -616,7 +616,7 @@ class RsyncTaskService(CRUDService):
         """
         Job to run rsync task of `id`.
 
-        Output is saved to job log excerpt as well as syslog.
+        Output is saved to job log excerpt (not syslog).
         """
         rsync = self.middleware.call_sync('rsynctask._get_instance', id)
         commandline = self.middleware.call_sync('rsynctask.commandline', id)


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 59d70ca0721ebd8bf156f8921cd99f1691948fe8
    git cherry-pick -x 3fa3dec3fc96c88d5bbdcb54bf007d37db70bf81

This is a fix for JIRA issue NAS-106601:
https://jira.ixsystems.com/browse/NAS-106601

Would it be OK if I also backported this to the 11.3 stable branch?
