### PR TITLE
NAS-106601 / 12.0 / Don't alert on non-fatal rsync return codes (by blkeller)

### DIFF
--- a/src/middlewared/middlewared/plugins/rsync.py
+++ b/src/middlewared/middlewared/plugins/rsync.py
@@ -669,7 +669,7 @@ class RsyncTaskService(CRUDService):
         """
         Job to run rsync task of `id`.
 
-        Output is saved to job log excerpt as well as syslog.
+        Output is saved to job log excerpt (not syslog).
         """
         rsync = self.middleware.call_sync('rsynctask._get_instance', id)
         commandline = self.middleware.call_sync('rsynctask.commandline', id)


### PR DESCRIPTION
This is a fix for JIRA issue NAS-106601:
https://jira.ixsystems.com/browse/NAS-106601

Would it be OK if I also backported this to the 11.3 stable branch?
