### PR TITLE
NAS-106639 / 12.1 / Fix traceback in ldap.conf generation script when AD enabled

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/openldap/ldap.conf
+++ b/src/middlewared/middlewared/etc_files/local/openldap/ldap.conf
@@ -22,11 +22,13 @@
 
         ad = middleware.call_sync('activedirectory.config')
         ad_enabled = ad['enable']
+        idmap = middleware.call_sync('idmap.query',
+                                     [('name', '=', 'DS_TYPE_ACTIVEDIRECTORY')],
+                                     {'get': True})
 
-        if ad['enable'] and ad['idmap_backend'] in ["rfc2307", "ldap"]:
+        if ad['enable'] and idmap['idmap_backend'] in ["rfc2307", "ldap"]:
             is_kerberized = True
             krb_realm = ad['kerberos_realm']
-            idmap = middleware.call_sync('idmap.get_or_create_idmap_by_domain', 'DS_TYPE_ACTIVEDIRECTORY')
             base = idmap['ldap_base_dn']
             idmap_url = idmap['ldap_url']
             idmap_url = re.sub('^(ldaps?://)', '', idmap_url)
@@ -64,12 +66,16 @@
 % if (ldap_enabled and ldap) or (ad_enabled and ad):
 # This file is used by Samba. If NETWORK_TIMEOUT is too high, then ldap failover
 # in Samba's ldapsam passdb backend may not occur.
+    %if uri:
 URI ${uri}
+    %endif
+    %if base:
 BASE ${base}
+    %endif
 NETWORK_TIMEOUT ${network_timeout}
 TIMEOUT ${timeout}
-    % if ssl:
 TLS_CACERT /etc/ssl/truenas_cacerts.pem
+    % if ssl:
         % if tls_certfile:
 TLS_CERT ${tls_certfile}
 TLS_KEY ${tls_keyfile}
@@ -80,7 +86,7 @@ TLS_REQCERT ${'demand' if tls_reqcert else 'allow'}
     % if is_kerberized:
 SASL_MECH GSSAPI
 SASL_REALM ${krb_realm}
-    % else:
+    % elif binddn:
 BINDDN ${binddn}
     % endif
 % endif


### PR DESCRIPTION
Ensure that our CACERT file is always populated, but remove any
parameters that are None. This will allow libads to use our GUI
cacerts if for some reason the idmap backend requires it, which
may be a requirement if environment has a trusted domain with an
external LDAP server providing IDs via idmap_rfc2307.