### PR TITLE
Disable IX-specific VFS modules in samba in scale

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -925,6 +925,19 @@ class SharingSMBService(SharingService):
                 f'{schema_name}.name',
                 f'{data["name"]} is a reserved section name, please select another one'
             )
+
+        if osc.IS_LINUX:
+            if data['shadowcopy']:
+                verrors.add(
+                    f'{schema_name}.shadowcopy',
+                    'ZFS shadow copy support is not yet implemented in TrueNAS scale'
+                )
+            if data['fsrvp']:
+                verrors.add(
+                    f'{schema_name}.fsrvp',
+                    'ZFS fsrvp support is not yet implemented in TrueNAS scale'
+                )
+
         if data.get('path_suffix') and len(data['path_suffix'].split('/')) > 2:
             verrors.add(f'{schema_name}.name',
                         'Path suffix may not contain more than two components.')

--- a/src/middlewared/middlewared/plugins/smb_/registry.py
+++ b/src/middlewared/middlewared/plugins/smb_/registry.py
@@ -274,7 +274,8 @@ class SharingSMBService(Service):
             data['vfsobjects'].extend(['recycle', 'crossrename'])
 
         if data['shadowcopy'] or data['fsrvp']:
-            data['vfsobjects'].append('shadow_copy_zfs')
+            if osc.IS_FREEBSD:
+                data['vfsobjects'].append('shadow_copy_zfs')
 
         if data['durablehandle']:
             conf.update({
@@ -283,7 +284,7 @@ class SharingSMBService(Service):
                 "posix locking": "no",
             })
 
-        if data['fsrvp']:
+        if data['fsrvp'] and osc.IS_FREEBSD:
             data['vfsobjects'].append('zfs_fsrvp')
             conf.update({
                 "shadow:ignore_empty_snaps": "false",


### PR DESCRIPTION
Users shouldn't be able to enable these until they're ported to Linux.