### PR TITLE
NAS-106683 / 12.1 / Use correct rsync path for SCALE

### DIFF
--- a/src/middlewared/middlewared/plugins/rsync.py
+++ b/src/middlewared/middlewared/plugins/rsync.py
@@ -626,9 +626,7 @@ class RsyncTaskService(TaskPathService):
         rsync = await self._get_instance(id)
         path = shlex.quote(rsync['path'])
 
-        line = [
-            '/usr/local/bin/rsync'
-        ]
+        line = ['rsync']
         for name, flag in (
             ('archive', '-a'),
             ('compress', '-z'),


### PR DESCRIPTION
closes truenas/truenas-build\#28