### PR TITLE
NAS-106496 / 11.3 / don't try to unset ha_peer when stopping ctld

### DIFF
--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -5,7 +5,6 @@ import inspect
 import os
 import psutil
 import signal
-import sysctl
 import threading
 import time
 import subprocess
@@ -260,7 +259,7 @@ class ServiceService(CRUDService):
         await self.middleware.call_hook('service.pre_action', service, 'reload', options)
         try:
             await self._simplecmd("reload", service, options)
-        except Exception as e:
+        except Exception:
             await self.restart(service, options)
         return await self.started(service)
 
@@ -424,9 +423,6 @@ class ServiceService(CRUDService):
         await self._service("ctld", "start", **kwargs)
 
     async def _stop_iscsitarget(self, **kwargs):
-        with contextlib.suppress(IndexError):
-            sysctl.filter("kern.cam.ctl.ha_peer")[0].value = ""
-
         await self._service("ctld", "stop", force=True, **kwargs)
 
     async def _reload_iscsitarget(self, **kwargs):


### PR DESCRIPTION
There is no reason to unset the ha_peer ALUA sysctl when stopping ctld. This is the equivalent change that went into 12.1 (0c5141b097fad69a972d707c2fd742a3ac933fa0) and 12.0 (5f97d9644910fe36b89e99a69347893045cc9df9) respectively.