### PR TITLE
NAS-106693 / 12.1 / Only map partitions which have valid partition uuid

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs_/disks_linux.py
+++ b/src/middlewared/middlewared/plugins/zfs_/disks_linux.py
@@ -22,7 +22,7 @@ class ZFSPoolService(Service, PoolDiskServiceBase):
         ):
             if dev['DEVTYPE'] == 'disk':
                 mapping[dev.sys_name] = dev.sys_name
-            else:
+            elif dev.get('ID_PART_ENTRY_UUID'):
                 parent = dev.find_parent('block')
                 mapping[dev.sys_name] = parent.sys_name
                 mapping[os.path.join('disk/by-partuuid', dev['ID_PART_ENTRY_UUID'])] = parent.sys_name


### PR DESCRIPTION
We have cases where zvols being treated as block devices have partitions which do not have partition uuid, so we should skip these when trying to list disks of a given pool.