### PR TITLE
NAS-106703 / 12.0 / Ensure that permissions for tmp are correct during smb.configure (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -78,6 +78,7 @@ class SMBPath(enum.Enum):
     RUNDIR = ('/var/run/samba4', '/var/run/samba', 0o755, True)
     LOCKDIR = ('/var/lock', '/var/lock', 0o755, True)
     LOGDIR = ('/var/log/samba4', '/var/log/samba', 0o755, True)
+    IPCSHARE = ('/var/tmp', '/tmp', 0o1777, True)
 
     def platform(self):
         return self.value[1] if osc.IS_LINUX else self.value[0]


### PR DESCRIPTION
Samba uses /tmp for its IPC share path and incorrect permissions will break RPC preventing Windows clients from connecting.