### PR TITLE
NAS-106705 / 11.3 / Reset SMB HA mode prior to starting AD join job

### DIFF
--- a/src/middlewared/middlewared/etc_files/smb_configure.py
+++ b/src/middlewared/middlewared/etc_files/smb_configure.py
@@ -277,6 +277,7 @@ def validate_group_mappings(middleware, conf):
 
 
 def render(service, middleware):
+    middleware.call_sync('smb.reset_smb_ha_mode')
     conf = {}
     conf = get_config(middleware)
     if conf['systemdataset']['path'] is None:

--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -925,7 +925,7 @@ class ActiveDirectoryService(ConfigService):
         """
         ad = await self.config()
         smb = await self.middleware.call('smb.config')
-        smb_ha_mode = await self.middleware.call('smb.get_smb_ha_mode')
+        smb_ha_mode = await self.middleware.call('smb.reset_smb_ha_mode')
         if smb_ha_mode == 'UNIFIED':
             if await self.middleware.call('failover.status') != 'MASTER':
                 return


### PR DESCRIPTION
This addresses a possible situation where the cached SMB_HA_MODE
may be incorrect if user changes system dataset location immediately
prior to joining AD.

Also add SMB_HA_MODE reset in smb_configure. This gets called on
system dataset move.