### PR TITLE
NAS-106705 / 12.1 / Reset SMB HA mode prior to starting AD join job (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -633,7 +633,7 @@ class ActiveDirectoryService(ConfigService):
         """
         ad = await self.config()
         smb = await self.middleware.call('smb.config')
-        smb_ha_mode = await self.middleware.call('smb.get_smb_ha_mode')
+        smb_ha_mode = await self.middleware.call('smb.reset_smb_ha_mode')
         if smb_ha_mode == 'UNIFIED':
             if await self.middleware.call('failover.status') != 'MASTER':
                 return

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -401,6 +401,7 @@ class SMBService(SystemServiceService):
     @private
     @job(lock="smb_configure")
     async def configure(self, job):
+        await self.reset_smb_ha_mode()
         job.set_progress(0, 'Preparing to configure SMB.')
         data = await self.config()
         job.set_progress(10, 'Generating SMB config.')


### PR DESCRIPTION
This addresses a possible situation where the cached SMB_HA_MODE
may be incorrect if user changes system dataset location immediately
prior to joining AD.

Also add SMB_HA_MODE reset in smb.configure. This gets called on
system dataset move.