### PR TITLE
NAS-106717 / 12.0 / Disable auto-rollback for vfs_tmprotect

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -115,7 +115,6 @@ class SMBSharePreset(enum.Enum):
     ENHANCED_TIMEMACHINE = {"verbose_name": "Multi-user time machine", "params": {
         'path_suffix': '%U',
         'auxsmbconf': '\n'.join([
-            'tmprotect:auto_rollback=powerloss',
             'ixnas:zfs_auto_homedir=true',
             'ixnas:default_user_quota=1T',
         ])


### PR DESCRIPTION
This particular feature should probably only be exposed in master until it can be properly tested with multiple
clients and usage patterns.