### PR TITLE
NAS-106685 / 12.0 / Double-check the return value of disk.identifier_to_device in disk.sync_all (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/sync.py
+++ b/src/middlewared/middlewared/plugins/disk_/sync.py
@@ -97,7 +97,11 @@ class DiskService(Service, ServiceChangeMixin):
             original_disk = disk.copy()
 
             name = await self.middleware.call('disk.identifier_to_device', disk['disk_identifier'], sys_disks)
-            if not name or name in seen_disks:
+            if (
+                    not name or
+                    name in seen_disks or
+                    await self.middleware.call('disk.device_to_identifier', name) != disk['disk_identifier']
+            ):
                 # If we cant translate the identifier to a device, give up
                 # If name has already been seen once then we are probably
                 # dealing with with multipath here


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x dd4f3fe111b7fd0b0b65ca7c79c21dac11e2fa72

