### PR TITLE
QE-365 / 11.3 / Change the activedirectory API test to supports the new ad server

### DIFF
--- a/tests/api2/activedirectory.py
+++ b/tests/api2/activedirectory.py
@@ -3,12 +3,32 @@
 import os
 import sys
 import pytest
+from pytest_dependency import depends
 from time import sleep
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from auto_config import pool_name, user, password, ip
-from config import *
-from functions import GET, POST, PUT, DELETE, SSH_TEST, ping_host, wait_on_job
+from auto_config import pool_name, ip, hostname
+from functions import GET, POST, PUT, DELETE, SSH_TEST, wait_on_job
+
+try:
+    from config import AD_DOMAIN, ADPASSWORD, ADUSERNAME, ADNameServer
+except ImportError:
+    Reason = 'ADNameServer AD_DOMAIN, ADPASSWORD, or/and ADUSERNAME are missing in config.py"'
+    pytestmark = pytest.mark.skip(reason=Reason)
+
+BSDReason = 'BSD host configuration is missing in ixautomation.conf'
+try:
+    from config import BSD_HOST, BSD_USERNAME, BSD_PASSWORD
+    bsd_host_cfg = pytest.mark.skipif(False, reason=BSDReason)
+except ImportError:
+    bsd_host_cfg = pytest.mark.skipif(True, reason=BSDReason)
+
+OSXReason = 'OSX host configuration is missing in ixautomation.conf'
+try:
+    from config import OSX_HOST, OSX_USERNAME, OSX_PASSWORD
+    osx_host_cfg = pytest.mark.skipif(False, reason=OSXReason)
+except ImportError:
+    osx_host_cfg = pytest.mark.skipif(True, reason=OSXReason)
 
 ad_data_type = {
     'id': int,
@@ -44,45 +64,16 @@ ad_object_list = [
     "enable"
 ]
 
-MOUNTPOINT = f"/tmp/ad-test"
+MOUNTPOINT = "/tmp/ad-test"
 dataset = f"{pool_name}/ad-bsd"
 dataset_url = dataset.replace('/', '%2F')
 SMB_NAME = "TestShare"
 SMB_PATH = f"/mnt/{dataset}"
 VOL_GROUP = "wheel"
 
-BSDReason = 'BSD host configuration is missing in ixautomation.conf'
-OSXReason = 'OSX host configuration is missing in ixautomation.conf'
-Reason = "AD_DOMAIN, ADPASSWORD, and ADUSERNAME are missing in config.py"
 
-ad_host_up = False
-if 'AD_DOMAIN' in locals():
-    ad_host_up = ping_host(AD_DOMAIN, 5)
-    print(ad_host_up)
-    if ad_host_up is False:
-        print(ad_host_up)
-        Reason = f'{AD_DOMAIN} is down'
-
-skip_ad_test = pytest.mark.skipif(all(["AD_DOMAIN" in locals(),
-                                       "ADPASSWORD" in locals(),
-                                       "ADUSERNAME" in locals(),
-                                       ad_host_up is True
-                                       ]) is False, reason=Reason)
-
-
-bsd_host_cfg = pytest.mark.skipif(all(["BSD_HOST" in locals(),
-                                       "BSD_USERNAME" in locals(),
-                                       "BSD_PASSWORD" in locals()
-                                       ]) is False, reason=BSDReason)
-
-osx_host_cfg = pytest.mark.skipif(all(["OSX_HOST" in locals(),
-                                       "OSX_USERNAME" in locals(),
-                                       "OSX_PASSWORD" in locals()
-                                       ]) is False, reason=OSXReason)
-
-
-@skip_ad_test
-def test_01_get_nameserver1_and_nameserver2():
+@pytest.mark.dependency(name="ad_01")
+def test_01_get_nameserver1_and_nameserver2(request):
     global nameserver1, nameserver2
     results = GET("/network/configuration/")
     assert results.status_code == 200, results.text
@@ -90,18 +81,9 @@ def test_01_get_nameserver1_and_nameserver2():
     nameserver2 = results.json()['nameserver2']
 
 
-@skip_ad_test
-def test_02_store_AD_credentials_in_a_file_for_mount_smbfs():
-    global ad_dns
-    cmd = f'ping -c 5 {AD_DOMAIN}'
-    results = SSH_TEST(cmd, user, password, ip)
-    ad_dns = results['result']
-
-
-@skip_ad_test
-def test_03_set_nameserver_for_ad():
-    if ad_dns is True:
-        pytest.skip('DNS is fine')
+@pytest.mark.dependency(name="ad_02")
+def test_02_set_nameserver_for_ad(request):
+    depends(request, ["ad_01"])
     global payload
     payload = {
         "nameserver1": ADNameServer,
@@ -114,41 +96,42 @@ def test_03_set_nameserver_for_ad():
     assert isinstance(results.json(), dict), results.text
 
 
-@skip_ad_test
-def test_04_get_activedirectory_data():
+def test_03_get_activedirectory_data(request):
+    depends(request, ["ad_01", "ad_02"])
     global results
     results = GET('/activedirectory/')
     assert results.status_code == 200, results.text
 
 
-@skip_ad_test
 @pytest.mark.parametrize('data', list(ad_data_type.keys()))
-def test_05_verify_activedirectory_data_type_of_the_object_value_of_(data):
+def test_04_verify_activedirectory_data_type_of_the_object_value_of_(request, data):
+    depends(request, ["ad_01", "ad_02"])
     assert isinstance(results.json()[data], ad_data_type[data]), results.text
 
 
-@skip_ad_test
-def test_06_get_activedirectory_state():
+def test_05_get_activedirectory_state(request):
+    depends(request, ["ad_01", "ad_02"])
     results = GET('/activedirectory/get_state/')
     assert results.status_code == 200, results.text
     assert results.json() == 'DISABLED', results.text
 
 
-@skip_ad_test
-def test_07_get_activedirectory_started_before_starting_activedirectory():
+def test_06_get_activedirectory_started_before_starting_activedirectory(request):
+    depends(request, ["ad_01", "ad_02"])
     results = GET('/activedirectory/started/')
     assert results.status_code == 200, results.text
     assert results.json() is False, results.text
 
 
-@skip_ad_test
-def test_08_creating_ad_dataset_for_smb():
+@pytest.mark.dependency(name="ad_07")
+def test_07_creating_ad_dataset_for_smb(request):
+    depends(request, ["ad_01", "ad_02"])
     results = POST("/pool/dataset/", {"name": dataset})
     assert results.status_code == 200, results.text
 
 
-@skip_ad_test
-def test_09_Changing_permissions_on_dataset():
+def test_08_Changing_permissions_on_dataset(request):
+    depends(request, ["ad_01", "ad_02", "ad_07"])
     global job_id_09
     results = POST(f'/pool/dataset/id/{dataset_url}/permission/', {
         'acl': [],
@@ -160,20 +143,21 @@ def test_09_Changing_permissions_on_dataset():
     job_id_09 = results.json()
 
 
-@skip_ad_test
-def test_10_verify_the_job_id_is_successfull():
+def test_09_verify_the_job_id_is_successfull(request):
+    depends(request, ["ad_01", "ad_02", "ad_07"])
     job_status = wait_on_job(job_id_09, 180)
     assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
 
-@skip_ad_test
-def test_11_enabling_activedirectory():
+@pytest.mark.dependency(name="ad_10")
+def test_10_enabling_activedirectory(request):
+    depends(request, ["ad_01", "ad_02", "ad_07"])
     global payload, results, job_id_11
     payload = {
         "bindpw": ADPASSWORD,
         "bindname": ADUSERNAME,
         "domainname": AD_DOMAIN,
-        "netbiosname": BRIDGEHOST,
+        "netbiosname": hostname,
         "idmap_backend": "RID",
         "dns_timeout": 15,
         "verbose_logging": True,
@@ -184,45 +168,45 @@ def test_11_enabling_activedirectory():
     job_id_11 = results.json()['job_id']
 
 
-@skip_ad_test
-def test_12_verify_job_id_is_successfull():
+def test_11_verify_job_id_is_successfull(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     job_status = wait_on_job(job_id_11, 180)
     assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
 
-@skip_ad_test
-def test_13_get_activedirectory_state():
+def test_12_get_activedirectory_state(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     global results
     results = GET('/activedirectory/get_state/')
     assert results.status_code == 200, results.text
     assert results.json() == 'HEALTHY', results.text
 
 
-@skip_ad_test
-def test_14_get_activedirectory_started():
+def test_13_get_activedirectory_started(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     results = GET('/activedirectory/started/')
     assert results.status_code == 200, results.text
     assert results.json() is True, results.text
 
 
-@skip_ad_test
-def test_15_get_activedirectory_data():
+def test_14_get_activedirectory_data(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     global results
     results = GET('/activedirectory/')
     assert results.status_code == 200, results.text
 
 
-@skip_ad_test
 @pytest.mark.parametrize('data', ad_object_list)
-def test_16_verify_activedirectory_data_of_(data):
+def test_15_verify_activedirectory_data_of_(request, data):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     if data == 'domainname':
         assert results.json()[data].lower() == payload[data], results.text
     else:
         assert results.json()[data] == payload[data], results.text
 
 
-@skip_ad_test
-def test_17_setting_up_smb():
+def test_16_setting_up_smb(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     global payload, results
     payload = {
         "description": "Test FreeNAS Server",
@@ -232,27 +216,27 @@ def test_17_setting_up_smb():
     assert results.status_code == 200, results.text
 
 
-@skip_ad_test
 @pytest.mark.parametrize('data', ["description", "guest"])
-def test_18_verify_the_value_of_put_smb_object_value_of_(data):
+def test_17_verify_the_value_of_put_smb_object_value_of_(request, data):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     assert results.json()[data] == payload[data], results.text
 
 
-@skip_ad_test
-def test_19_get_smb_data():
+def test_18_get_smb_data(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     global results
     results = GET("/smb/")
     assert results.status_code == 200, results.text
 
 
-@skip_ad_test
 @pytest.mark.parametrize('data', ["description", "guest"])
-def test_20_verify_the_value_of_get_smb_object_(data):
+def test_19_verify_the_value_of_get_smb_object_(request, data):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     assert results.json()[data] == payload[data], results.text
 
 
-@skip_ad_test
-def test_21_creating_a_smb_share_on_smb_path():
+def test_20_creating_a_smb_share_on_smb_path(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     global payload, results, smb_id
     payload = {
         "comment": "My Test SMB Share",
@@ -266,62 +250,62 @@ def test_21_creating_a_smb_share_on_smb_path():
     smb_id = results.json()['id']
 
 
-@skip_ad_test
 @pytest.mark.parametrize('data', ["comment", "path", "name", "guestok", "vfsobjects"])
-def test_22_verify_the_value_of_the_created_sharing_smb_object_(data):
+def test_21_verify_the_value_of_the_created_sharing_smb_object_(request, data):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     assert results.json()[data] == payload[data], results.text
 
 
-@skip_ad_test
-def test_23_get_sharing_smb_from_id():
+def test_22_get_sharing_smb_from_id(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     global results
     results = GET(f"/sharing/smb/id/{smb_id}/")
     assert results.status_code == 200, results.text
 
 
-@skip_ad_test
 @pytest.mark.parametrize('data', ["comment", "path", "name", "guestok", "vfsobjects"])
-def test_24_verify_the_value_of_get_sharing_smb_object_(data):
+def test_23_verify_the_value_of_get_sharing_smb_object_(request, data):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     assert results.json()[data] == payload[data], results.text
 
 
-@skip_ad_test
-def test_25_enable_cifs_service():
+def test_24_enable_cifs_service(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     results = PUT("/service/id/cifs/", {"enable": True})
     assert results.status_code == 200, results.text
 
 
-@skip_ad_test
-def test_26_checking_to_see_if_clif_service_is_enabled():
+def test_25_checking_to_see_if_clif_service_is_enabled(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     results = GET("/service?service=cifs")
     assert results.json()[0]["enable"] is True, results.text
 
 
-@skip_ad_test
-def test_27_starting_cifs_service():
+def test_26_starting_cifs_service(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     payload = {"service": "cifs", "service-control": {"onetime": True}}
     results = POST("/service/restart/", payload)
     assert results.status_code == 200, results.text
     sleep(1)
 
 
-@skip_ad_test
-def test_28_checking_to_see_if_nfs_service_is_running():
+def test_27_checking_to_see_if_nfs_service_is_running(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     results = GET("/service?service=cifs")
     assert results.json()[0]["state"] == "RUNNING", results.text
 
 
 @bsd_host_cfg
-@skip_ad_test
-def test_29_creating_smb_mountpoint():
+def test_28_creating_smb_mountpoint(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     results = SSH_TEST('mkdir -p "%s" && sync' % MOUNTPOINT,
                        BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
     assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
-@skip_ad_test
-def test_30_store_AD_credentials_in_a_file_for_mount_smbfs():
+def test_29_store_AD_credentials_in_a_file_for_mount_smbfs(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     cmd = 'echo "[TESTNAS:ADUSER]" > ~/.nsmbrc && '
     cmd += 'echo "password=12345678" >> ~/.nsmbrc'
     results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
@@ -329,8 +313,8 @@ def test_30_store_AD_credentials_in_a_file_for_mount_smbfs():
 
 
 @bsd_host_cfg
-@skip_ad_test
-def test_31_mounting_SMB():
+def test_30_mounting_SMB(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     cmd = 'mount_smbfs -N -I %s -W AD03 ' % ip
     cmd += '"//guest@testnas/%s" "%s"' % (SMB_NAME, MOUNTPOINT)
     results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
@@ -338,48 +322,48 @@ def test_31_mounting_SMB():
 
 
 @bsd_host_cfg
-@skip_ad_test
-def test_32_creating_SMB_file():
+def test_31_creating_SMB_file(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     results = SSH_TEST('touch "%s/testfile"' % MOUNTPOINT,
                        BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
     assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
-@skip_ad_test
-def test_33_moving_SMB_file():
+def test_32_moving_SMB_file(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     cmd = 'mv "%s/testfile" "%s/testfile2"' % (MOUNTPOINT, MOUNTPOINT)
     results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
     assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
-@skip_ad_test
-def test_34_copying_SMB_file():
+def test_33_copying_SMB_file(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     cmd = 'cp "%s/testfile2" "%s/testfile"' % (MOUNTPOINT, MOUNTPOINT)
     results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
     assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
-@skip_ad_test
-def test_35_deleting_SMB_file_1_2():
+def test_34_deleting_SMB_file_1_2(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     results = SSH_TEST('rm "%s/testfile"' % MOUNTPOINT,
                        BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
     assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
-@skip_ad_test
-def test_36_deleting_SMB_file_2_2():
+def test_35_deleting_SMB_file_2_2(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     results = SSH_TEST('rm "%s/testfile2"' % MOUNTPOINT,
                        BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
     assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
-@skip_ad_test
-def test_37_unmounting_SMB():
+def test_36_unmounting_SMB(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     results = SSH_TEST('umount "%s"' % MOUNTPOINT,
                        BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
     assert results['result'] is True, results['output']
@@ -387,15 +371,15 @@ def test_37_unmounting_SMB():
 
 # Delete tests
 @bsd_host_cfg
-@skip_ad_test
-def test_38_removing_SMB_mountpoint():
+def test_37_removing_SMB_mountpoint(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     cmd = 'test -d "%s" && rmdir "%s" || exit 0' % (MOUNTPOINT, MOUNTPOINT)
     results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
     assert results['result'] is True, results['output']
 
 
-@skip_ad_test
-def test_39_leave_activedirectory():
+def test_38_leave_activedirectory(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     global payload, results
     payload = {
         "username": ADUSERNAME,
@@ -405,28 +389,28 @@ def test_39_leave_activedirectory():
     assert results.status_code == 200, results.text
 
 
-@skip_ad_test
-def test_40_get_activedirectory_state():
+def test_39_get_activedirectory_state(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     results = GET('/activedirectory/get_state/')
     assert results.status_code == 200, results.text
     assert results.json() == 'DISABLED', results.text
 
 
-@skip_ad_test
-def test_41_get_activedirectory_started_after_leaving_AD():
+def test_40_get_activedirectory_started_after_leaving_AD(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     results = GET('/activedirectory/started/')
     assert results.status_code == 200, results.text
     assert results.json() is False, results.text
 
 
-@skip_ad_test
-def test_42_re_enable_activedirectory():
+def test_41_re_enable_activedirectory(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     global payload, results, job_id_42
     payload = {
         "bindpw": ADPASSWORD,
         "bindname": ADUSERNAME,
         "domainname": AD_DOMAIN,
-        "netbiosname": BRIDGEHOST,
+        "netbiosname": hostname,
         "idmap_backend": "RID",
         "enable": True
     }
@@ -435,37 +419,37 @@ def test_42_re_enable_activedirectory():
     job_id_42 = results.json()['job_id']
 
 
-@skip_ad_test
-def test_43_verify_job_id_is_successfull():
+def test_42_verify_job_id_is_successfull(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     job_status = wait_on_job(job_id_42, 180)
     assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
 
-@skip_ad_test
-def test_44_get_activedirectory_state():
+def test_43_get_activedirectory_state(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     global results
     results = GET('/activedirectory/get_state/')
     assert results.status_code == 200, results.text
     assert results.json() == 'HEALTHY', results.text
 
 
-@skip_ad_test
-def test_45_get_activedirectory_started():
+def test_44_get_activedirectory_started(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     results = GET('/activedirectory/started/')
     assert results.status_code == 200, results.text
     assert results.json() is True, results.text
 
 
-@skip_ad_test
-def test_46_get_activedirectory_data():
+def test_45_get_activedirectory_data(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     global results
     results = GET('/activedirectory/')
     assert results.status_code == 200, results.text
 
 
-@skip_ad_test
 @pytest.mark.parametrize('data', ad_object_list)
-def test_47_verify_activedirectory_data_of_(data):
+def test_46_verify_activedirectory_data_of_(request, data):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     if data == 'domainname':
         assert results.json()[data].lower() == payload[data], results.text
     else:
@@ -475,16 +459,16 @@ def test_47_verify_activedirectory_data_of_(data):
 # Testing OSX
 # Mount share on OSX system and create a test file
 @osx_host_cfg
-@skip_ad_test
-def test_48_Create_mount_point_for_SMB_on_OSX_system():
+def test_47_Create_mount_point_for_SMB_on_OSX_system(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     results = SSH_TEST('mkdir -p "%s"' % MOUNTPOINT,
                        OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
     assert results['result'] is True, results['output']
 
 
 @osx_host_cfg
-@skip_ad_test
-def test_49_Mount_SMB_share_on_OSX_system():
+def test_48_Mount_SMB_share_on_OSX_system(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     cmd = 'mount -t smbfs "smb://%s:' % ADUSERNAME
     cmd += '%s@%s/%s" "%s"' % (ADPASSWORD, ip, SMB_NAME, MOUNTPOINT)
     results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
@@ -492,8 +476,8 @@ def test_49_Mount_SMB_share_on_OSX_system():
 
 
 @osx_host_cfg
-@skip_ad_test
-def test_50_Create_file_on_SMB_share_via_OSX_to_test_permissions():
+def test_49_Create_file_on_SMB_share_via_OSX_to_test_permissions(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     results = SSH_TEST('touch "%s/testfile.txt"' % MOUNTPOINT,
                        OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
     assert results['result'] is True, results['output']
@@ -501,8 +485,8 @@ def test_50_Create_file_on_SMB_share_via_OSX_to_test_permissions():
 
 # Move test file to a new location on the SMB share
 @osx_host_cfg
-@skip_ad_test
-def test_51_Moving_SMB_test_file_into_a_new_directory():
+def test_50_Moving_SMB_test_file_into_a_new_directory(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     cmd = 'mkdir -p "%s/tmp" && ' % MOUNTPOINT
     cmd += 'mv "%s/testfile.txt" ' % MOUNTPOINT
     cmd += '"%s/tmp/testfile.txt"' % MOUNTPOINT
@@ -512,8 +496,8 @@ def test_51_Moving_SMB_test_file_into_a_new_directory():
 
 # Delete test file and test directory from SMB share
 @osx_host_cfg
-@skip_ad_test
-def test_52_Deleting_test_file_and_directory_from_SMB_share():
+def test_51_Deleting_test_file_and_directory_from_SMB_share(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     cmd = 'rm -f "%s/tmp/testfile.txt" && ' % MOUNTPOINT
     cmd += 'rmdir "%s/tmp"' % MOUNTPOINT
     results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
@@ -521,8 +505,8 @@ def test_52_Deleting_test_file_and_directory_from_SMB_share():
 
 
 @osx_host_cfg
-@skip_ad_test
-def test_53_Verifying_that_test_file_directory_successfully_removed():
+def test_52_Verifying_that_test_file_directory_successfully_removed(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     cmd = 'find -- "%s/" -prune -type d -empty | grep -q .' % MOUNTPOINT
     results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
     assert results['result'] is True, results['output']
@@ -530,8 +514,8 @@ def test_53_Verifying_that_test_file_directory_successfully_removed():
 
 # Clean up mounted SMB share
 @osx_host_cfg
-@skip_ad_test
-def test_54_Unmount_SMB_share():
+def test_53_Unmount_SMB_share(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     results = SSH_TEST('umount -f "%s"' % MOUNTPOINT,
                        OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
     assert results['result'] is True, results['output']
@@ -539,16 +523,16 @@ def test_54_Unmount_SMB_share():
 
 # Delete tests
 @osx_host_cfg
-@skip_ad_test
-def test_55_Removing_SMB_mountpoint():
+def test_54_Removing_SMB_mountpoint(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     cmd = 'test -d "%s" && rmdir "%s" || exit 0' % (MOUNTPOINT, MOUNTPOINT)
     results = SSH_TEST(cmd, OSX_USERNAME, OSX_PASSWORD, OSX_HOST)
     assert results['result'] is True, results['output']
 
 
 # put all code to disable and delete under here
-@skip_ad_test
-def test_56_disable_activedirectory():
+def test_55_disable_activedirectory(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     global payload, results, job_id_56
     payload = {
         "enable": False
@@ -558,22 +542,22 @@ def test_56_disable_activedirectory():
     job_id_56 = results.json()['job_id']
 
 
-@skip_ad_test
-def test_58_get_activedirectory_state():
+def test_56_get_activedirectory_state(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     results = GET('/activedirectory/get_state/')
     assert results.status_code == 200, results.text
     assert results.json() == 'DISABLED', results.text
 
 
-@skip_ad_test
-def test_59_get_activedirectory_started_after_disabling_AD():
+def test_57_get_activedirectory_started_after_disabling_AD(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     results = GET('/activedirectory/started/')
     assert results.status_code == 200, results.text
     assert results.json() is False, results.text
 
 
-@skip_ad_test
-def test_60_re_enable_activedirectory():
+def test_58_re_enable_activedirectory(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     global payload, results, job_id_60
     payload = {
         "enable": True
@@ -583,29 +567,29 @@ def test_60_re_enable_activedirectory():
     job_id_60 = results.json()['job_id']
 
 
-@skip_ad_test
-def test_61_verify_job_id_is_successfull():
+def test_59_verify_job_id_is_successfull(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     job_status = wait_on_job(job_id_60, 180)
     assert job_status['state'] == 'SUCCESS', str(job_status['results'])
 
 
-@skip_ad_test
-def test_62_get_activedirectory_state():
+def test_60_get_activedirectory_state(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     global results
     results = GET('/activedirectory/get_state/')
     assert results.status_code == 200, results.text
     assert results.json() == 'HEALTHY', results.text
 
 
-@skip_ad_test
-def test_63_get_activedirectory_started():
+def test_61_get_activedirectory_started(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     results = GET('/activedirectory/started/')
     assert results.status_code == 200, results.text
     assert results.json() is True, results.text
 
 
-@skip_ad_test
-def test_64_leave_activedirectory():
+def test_62_leave_activedirectory(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     global payload, results
     payload = {
         "username": ADUSERNAME,
@@ -615,56 +599,54 @@ def test_64_leave_activedirectory():
     assert results.status_code == 200, results.text
 
 
-@skip_ad_test
-def test_65_get_activedirectory_state():
+def test_63_get_activedirectory_state(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     results = GET('/activedirectory/get_state/')
     assert results.status_code == 200, results.text
     assert results.json() == 'DISABLED', results.text
 
 
-@skip_ad_test
-def test_66_get_activedirectory_started_after_living():
+def test_64_get_activedirectory_started_after_living(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     results = GET('/activedirectory/started/')
     assert results.status_code == 200, results.text
     assert results.json() is False, results.text
 
 
-@skip_ad_test
-def test_67_disable_cifs_service_at_boot():
+def test_65_disable_cifs_service_at_boot(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     results = PUT("/service/id/cifs/", {"enable": False})
     assert results.status_code == 200, results.text
 
 
-@skip_ad_test
-def test_68_checking_to_see_if_clif_service_is_enabled_at_boot():
+def test_66_checking_to_see_if_clif_service_is_enabled_at_boot(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     results = GET("/service?service=cifs")
     assert results.json()[0]["enable"] is False, results.text
 
 
-@skip_ad_test
-def test_69_stoping_clif_service():
+def test_67_stoping_clif_service(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     payload = {"service": "cifs", "service-control": {"onetime": True}}
     results = POST("/service/stop/", payload)
     assert results.status_code == 200, results.text
     sleep(1)
 
 
-@skip_ad_test
-def test_70_checking_if_cifs_is_stop():
+def test_68_checking_if_cifs_is_stop(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     results = GET("/service?service=cifs")
     assert results.json()[0]['state'] == "STOPPED", results.text
 
 
-@skip_ad_test
-def test_71_destroying_ad_dataset_for_smb():
+def test_69_destroying_ad_dataset_for_smb(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     results = DELETE(f"/pool/dataset/id/{dataset_url}/")
     assert results.status_code == 200, results.text
 
 
-@skip_ad_test
-def test_72_configure_setting_domain_hostname_and_dns():
-    if ad_dns is True:
-        pytest.skip('DSN is fine')
+def test_70_configure_setting_domain_hostname_and_dns(request):
+    depends(request, ["ad_01", "ad_02", "ad_07", "ad_10"])
     global payload
     payload = {
         "nameserver1": nameserver1,


### PR DESCRIPTION
Marked the activedirectory test 01, 02, 07 10 dependency
added depends list with the ad dependency in activedirectory test
remove the ping test in activedirectory test
remove the ping for the host of the activedirectory test
replace skip ad test by pytestmark
update ad api v1 test to set ad nameserver  