### PR TITLE
NAS-106768 / 12.1 / fix HA API tests

### DIFF
--- a/tests/api2/test_004_disable_failover.py
+++ b/tests/api2/test_004_disable_failover.py
@@ -13,7 +13,8 @@ pytestmark = pytest.mark.skipif(not ha, reason="Skipping test for Core and Scale
 
 def test_01_disable_failover():
     payload = {
-        "disabled": True
+        "disabled": True,
+        "master": True,
     }
     results = PUT('/failover/', payload, controller_a=ha)
     assert results.status_code == 200, results.text

--- a/tests/api2/test_005_interface.py
+++ b/tests/api2/test_005_interface.py
@@ -228,7 +228,7 @@ def test_16_get_interface_has_pending_changes():
     assert results.json() is True, results.text
 
 
-def test_17_commite_interface():
+def test_17_commit_interface():
     payload = {
         "rollback": True,
         "checkin_timeout": 10

--- a/tests/api2/test_010_enable_failover.py
+++ b/tests/api2/test_010_enable_failover.py
@@ -13,7 +13,8 @@ pytestmark = pytest.mark.skipif(not ha, reason="Skipping test for Core and Scale
 
 def test_01_enable_failover():
     payload = {
-        "disabled": False
+        "disabled": False,
+        "master": True,
     }
     results = PUT('/failover/', payload)
     assert results.status_code == 200, results.text


### PR DESCRIPTION
We need to pass the master boolean option when disabling/enabling failover. If we don't, there is a chance the standby controller will run fenced --force which reserves the disks preventing the zpools from being created.