### PR TITLE
NAS-106795 / 12.0 / Modify migration to simplified SMB configuration setup

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/12.0/2020-01-23_10-22_simplify_smb_shares.py
+++ b/src/middlewared/middlewared/alembic/versions/12.0/2020-01-23_10-22_simplify_smb_shares.py
@@ -26,7 +26,7 @@ def upgrade():
     """
     standard_vfs_objects = ['ixnas', 'streams_xattr', 'fruit', 'catia']
     fruit_enabled = False
-    has_acl = False
+    has_acl = True
     has_streams =False
     has_catia = False
     set_durable = True
@@ -61,8 +61,8 @@ def upgrade():
                 fruit_enabled = True
             if v == 'streams_xattr':
                 has_streams = True
-            if v == 'ixnas':
-                has_acl = True
+            if v == 'noacl':
+                has_acl = False
             if v == 'catia':
                 has_catia = True
 


### PR DESCRIPTION
Originally in case of non-standard VFS objects we defaulted ACL
to False. This can cause user confusion post-migration if they were
using vfs_zfsacl instead of vfs_ixnas for some reason. Revised
migration strategy is to default to True and only change to False
if vfs_noacl is enabled on the share.