### PR TITLE
NAS-106754 / 12.0 / Generate encrypt key path when importing geli encrypted pools (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -1318,6 +1318,7 @@ class PoolService(CRUDService):
                 'vol_name': pool_name,
                 'vol_encrypt': encrypt,
                 'vol_guid': data['guid'],
+                'vol_encryptkey': str(uuid.uuid4()) if encrypt else '',
             })
             pool = await self.middleware.call('pool.query', [('id', '=', pool_id)], {'get': True})
             if encrypt > 0:


### PR DESCRIPTION
This commit fixes an issue where we did not generate a path for the key provided by the user to import a geli encrypted pool.