### PR TITLE
NAS-105270 / 12.1 / Platform dependent ShellApplication

### DIFF
--- a/src/middlewared/middlewared/utils/osc/freebsd/os.py
+++ b/src/middlewared/middlewared/utils/osc/freebsd/os.py
@@ -1,5 +1,6 @@
 # -*- coding=utf-8 -*-
 import logging
+import select
 
 from bsd import closefrom
 
@@ -7,7 +8,7 @@ from middlewared.utils.osc.common.os import close_fds as common_close_fds
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["close_fds"]
+__all__ = ["close_fds", "PidWaiter"]
 
 
 def close_fds(low_fd, max_fd=None):
@@ -15,3 +16,15 @@ def close_fds(low_fd, max_fd=None):
         closefrom(low_fd)
     else:
         common_close_fds(low_fd, max_fd)
+
+
+class PidWaiter:
+    def __init__(self, middleware, pid):
+        self.middleware = middleware
+
+        self.kqueue = select.kqueue()
+        kevent = select.kevent(pid, select.KQ_FILTER_PROC, select.KQ_EV_ADD | select.KQ_EV_ENABLE, select.KQ_NOTE_EXIT)
+        self.kqueue.control([kevent], 0)
+
+    async def wait(self, timeout):
+        return bool(await self.middleware.run_in_thread(self.kqueue.control, None, 1, timeout))

--- a/src/middlewared/middlewared/utils/osc/linux/os.py
+++ b/src/middlewared/middlewared/utils/osc/linux/os.py
@@ -1,8 +1,31 @@
 # -*- coding=utf-8 -*-
+import asyncio
 import logging
+import os
 
 from middlewared.utils.osc.common.os import close_fds
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["close_fds"]
+__all__ = ["close_fds", "PidWaiter"]
+
+
+class PidWaiter:
+    def __init__(self, middleware, pid):
+        self.middleware = middleware
+        self.pid = pid
+
+    async def wait(self, timeout):
+        granularity = 0.1
+        count = int(timeout / granularity)
+        for i in range(count):
+            try:
+                if os.waitpid(self.pid, os.WNOHANG) != (0, 0):
+                    return True
+            except ChildProcessError:
+                return True
+
+            if i != count - 1:
+                await asyncio.sleep(granularity)
+
+        return False


### PR DESCRIPTION
There are no corresponding `epoll` resources, the proper way in Linux is to handle `SIGCHLD` which seems to be an overengineering for this case.