### PR TITLE
NAS-106901 / 12.1 / Use tmpfs for /tmp

### DIFF
--- a/src/freenas/etc/systemd/system/tmp.mount
+++ b/src/freenas/etc/systemd/system/tmp.mount
@@ -1,0 +1,29 @@
+# /etc/systemd/system/tmp.mount
+#  SPDX-License-Identifier: LGPL-2.1+
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+[Unit]
+Description=Temporary Directory (/tmp)
+Documentation=https://systemd.io/TEMPORARY_DIRECTORIES
+Documentation=man:file-hierarchy(7)
+Documentation=https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems
+ConditionPathIsSymbolicLink=!/tmp
+DefaultDependencies=no
+Conflicts=umount.target
+Before=local-fs.target umount.target middlewared.service
+After=swap.target
+
+[Mount]
+What=tmpfs
+Where=/tmp
+Type=tmpfs
+Options=mode=1777,strictatime,nosuid,nodev
+
+[Install]
+WantedBy=local-fs.target

--- a/src/freenas/usr/lib/systemd/system-preset/10-truenas.preset
+++ b/src/freenas/usr/lib/systemd/system-preset/10-truenas.preset
@@ -2,6 +2,9 @@
 enable middlewared.service
 enable ix-*
 
+# Enabled mounts
+enable tmp.mount
+
 # Enabled services
 enable collectd.service
 enable nginx.service


### PR DESCRIPTION
We should use tmpfs for /tmp as we would like to avoid hitting boot pool as much as we can. Systemd ships `tmp.mount` under `/usr/share`, we make sure to move that to our base image so that it can be used to have /tmp as tmpfs.