### PR TITLE
NAS-106902 / 12.1 / VM libvirt connection improvements

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/connection.py
+++ b/src/middlewared/middlewared/plugins/vm/connection.py
@@ -36,3 +36,8 @@ class LibvirtConnectionMixin:
     def _check_connection_alive(self):
         if not self._is_connection_alive():
             raise CallError('Failed to connect to libvirt')
+
+    def _check_setup_connection(self):
+        if not self._is_connection_alive():
+            self.middleware.call_sync('vm.setup_libvirt_connection', 10)
+        self._check_connection_alive()

--- a/src/middlewared/middlewared/plugins/vm/events.py
+++ b/src/middlewared/middlewared/plugins/vm/events.py
@@ -10,7 +10,7 @@ class VMService(Service, LibvirtConnectionMixin):
 
     @private
     def setup_libvirt_events(self):
-        self._check_connection_alive()
+        self._check_setup_connection()
 
         def callback(conn, dom, event, detail, opaque):
             """

--- a/src/middlewared/middlewared/plugins/vm/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/vm/lifecycle.py
@@ -44,10 +44,14 @@ class VMService(Service, VMSupervisorMixin):
             self.middleware.logger.error('Failed to connect to libvirtd')
 
     @private
+    def setup_libvirt_connection(self, timeout=30):
+        self.middleware.call_sync(f'vm.initialize_{osc.SYSTEM.lower()}')
+        self.middleware.call_sync('vm.wait_for_libvirtd', timeout)
+
+    @private
     def initialize_vms(self, timeout=30):
         if self.middleware.call_sync('vm.query'):
-            self.middleware.call_sync(f'vm.initialize_{osc.SYSTEM.lower()}')
-            self.middleware.call_sync('vm.wait_for_libvirtd', timeout)
+            self.setup_libvirt_connection(timeout)
         else:
             return
 

--- a/src/middlewared/middlewared/plugins/vm/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/vm/lifecycle.py
@@ -44,7 +44,7 @@ class VMService(Service, VMSupervisorMixin):
             self.middleware.logger.error('Failed to connect to libvirtd')
 
     @private
-    def initialize_vms(self, timeout=10):
+    def initialize_vms(self, timeout=30):
         if self.middleware.call_sync('vm.query'):
             self.middleware.call_sync(f'vm.initialize_{osc.SYSTEM.lower()}')
             self.middleware.call_sync('vm.wait_for_libvirtd', timeout)
@@ -159,5 +159,5 @@ async def __event_system_ready(middleware, event_type, args):
 async def setup(middleware):
     await middleware.call('vm.update_zfs_arc_max_initial')
     if await middleware.call('system.ready'):
-        asyncio.ensure_future(middleware.call('vm.initialize_vms', 2))  # We use a short timeout here deliberately
+        asyncio.ensure_future(middleware.call('vm.initialize_vms', 5))  # We use a short timeout here deliberately
     middleware.event_subscribe('system', __event_system_ready)

--- a/src/middlewared/middlewared/plugins/vm/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/vm/lifecycle.py
@@ -114,6 +114,14 @@ class VMService(Service, VMSupervisorMixin):
                 self._close()
 
     @private
+    def setup_details(self):
+        return {
+            'connected': self._is_connection_alive(),
+            'connection_initialised': bool(self.LIBVIRT_CONNECTION),
+            'domains': list(self.vms.keys()),
+        }
+
+    @private
     async def terminate(self):
         async with SHUTDOWN_LOCK:
             await self.middleware.call('vm.deinitialize_vms', {'stop_libvirt': False})

--- a/src/middlewared/middlewared/plugins/vm/supervisor/supervisor_base.py
+++ b/src/middlewared/middlewared/plugins/vm/supervisor/supervisor_base.py
@@ -36,7 +36,7 @@ class VMSupervisorBase(LibvirtConnectionMixin):
         self.middleware = middleware
         self.devices = []
 
-        self._check_connection_alive()
+        self._check_setup_connection()
 
         self.libvirt_domain_name = f'{self.vm_data["id"]}_{self.vm_data["name"]}'
         self.domain = self.stop_devices_thread = None

--- a/src/middlewared/middlewared/plugins/vm/vm_lifecycle.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_lifecycle.py
@@ -21,7 +21,7 @@ class VMService(Service, VMSupervisorMixin):
 
             ENOMEM(12): not enough free memory to run the VM without overcommit
         """
-        self._check_setup_connection()
+        await self.middleware.run_in_thread(self._check_setup_connection)
 
         vm = await self.middleware.call('vm.get_instance', id)
         if vm['status']['state'] == 'RUNNING':

--- a/src/middlewared/middlewared/plugins/vm/vm_lifecycle.py
+++ b/src/middlewared/middlewared/plugins/vm/vm_lifecycle.py
@@ -21,7 +21,7 @@ class VMService(Service, VMSupervisorMixin):
 
             ENOMEM(12): not enough free memory to run the VM without overcommit
         """
-        self._check_connection_alive()
+        self._check_setup_connection()
 
         vm = await self.middleware.call('vm.get_instance', id)
         if vm['status']['state'] == 'RUNNING':
@@ -70,7 +70,7 @@ class VMService(Service, VMSupervisorMixin):
         `force_after_timeout` when supplied, it will initiate poweroff for the VM forcing it to exit if it has
         not already stopped within the specified `shutdown_timeout`.
         """
-        self._check_connection_alive()
+        self._check_setup_connection()
         vm_data = self.middleware.call_sync('vm.get_instance', id)
 
         if options['force']:
@@ -89,7 +89,7 @@ class VMService(Service, VMSupervisorMixin):
         """
         Poweroff a VM.
         """
-        self._check_connection_alive()
+        self._check_setup_connection()
 
         vm_data = self.middleware.call_sync('vm.get_instance', id)
         self._poweroff(vm_data['name'])
@@ -102,7 +102,6 @@ class VMService(Service, VMSupervisorMixin):
         """
         Restart a VM.
         """
-        self._check_connection_alive()
+        self._check_setup_connection()
         vm = self.middleware.call_sync('vm.get_instance', id)
-        self._check_connection_alive()
         self._restart(vm['name'])

--- a/src/middlewared/middlewared/plugins/vm/vms.py
+++ b/src/middlewared/middlewared/plugins/vm/vms.py
@@ -102,7 +102,7 @@ class VMService(CRUDService, VMSupervisorMixin):
         `shutdown_timeout` seconds, system initiates poweroff for the VM to stop it.
         """
         async with LIBVIRT_LOCK:
-            self._check_setup_connection()
+            await self.middleware.run_in_thread(self._check_setup_connection)
 
         verrors = ValidationErrors()
         await self.__common_validation(verrors, 'vm_create', data)
@@ -293,7 +293,7 @@ class VMService(CRUDService, VMSupervisorMixin):
         new.update(data)
 
         if new['name'] != old['name']:
-            self._check_setup_connection()
+            await self.middleware.run_in_thread(self._check_setup_connection)
             if old['status']['state'] == 'RUNNING':
                 raise CallError('VM name can only be changed when VM is inactive')
 
@@ -333,7 +333,7 @@ class VMService(CRUDService, VMSupervisorMixin):
         """
         async with LIBVIRT_LOCK:
             vm = await self.get_instance(id)
-            self._check_setup_connection()
+            await self.middleware.run_in_thread(self._check_setup_connection)
             status = await self.middleware.call('vm.status', id)
             if status.get('state') == 'RUNNING':
                 await self.middleware.call('vm.poweroff', id)

--- a/src/middlewared/middlewared/plugins/vm/vms.py
+++ b/src/middlewared/middlewared/plugins/vm/vms.py
@@ -102,9 +102,7 @@ class VMService(CRUDService, VMSupervisorMixin):
         `shutdown_timeout` seconds, system initiates poweroff for the VM to stop it.
         """
         async with LIBVIRT_LOCK:
-            if not self._is_connection_alive():
-                await self.middleware.call('vm.wait_for_libvirtd', 10)
-        self._check_connection_alive()
+            self._check_setup_connection()
 
         verrors = ValidationErrors()
         await self.__common_validation(verrors, 'vm_create', data)
@@ -295,7 +293,7 @@ class VMService(CRUDService, VMSupervisorMixin):
         new.update(data)
 
         if new['name'] != old['name']:
-            self._check_connection_alive()
+            self._check_setup_connection()
             if old['status']['state'] == 'RUNNING':
                 raise CallError('VM name can only be changed when VM is inactive')
 
@@ -335,7 +333,7 @@ class VMService(CRUDService, VMSupervisorMixin):
         """
         async with LIBVIRT_LOCK:
             vm = await self.get_instance(id)
-            self._check_connection_alive()
+            self._check_setup_connection()
             status = await self.middleware.call('vm.status', id)
             if status.get('state') == 'RUNNING':
                 await self.middleware.call('vm.poweroff', id)


### PR DESCRIPTION
This PR introduces following changes:
1) Increase libvirtd start timeout as in some cases it can take more time to initiate.
2) If for any reason we lost the connection to libvirt, try to re-open it before any VM action. If this happens, user is basically left with no other option except to restart middleware ( or in some cases libvirt and middleware both ).
3) Add a helper method to retrieve libvirt setup details.