### PR TITLE
Use systemd as native cgroup driver

### DIFF
--- a/src/middlewared/middlewared/etc_files/docker.py
+++ b/src/middlewared/middlewared/etc_files/docker.py
@@ -9,4 +9,7 @@ def render(service, middleware):
 
     os.makedirs('/etc/docker', exist_ok=True)
     with open('/etc/docker/daemon.json', 'w') as f:
-        f.write(json.dumps({'data-root': os.path.join(sys_config['path'], 'services/docker')}))
+        f.write(json.dumps({
+            'data-root': os.path.join(sys_config['path'], 'services/docker'),
+            'exec-opts': ['native.cgroupdriver=systemd'],
+        }))


### PR DESCRIPTION
Default to using systemd as native cgroup driver for docker. ( clarification - https://github.com/kubernetes/kubeadm/issues/1394#issuecomment-462878219 )