### PR TITLE
NAS-106912 / 12.1 / Make sure ix-shutdown is not stopped after middlewared

### DIFF
--- a/debian/debian/ix-shutdown.service
+++ b/debian/debian/ix-shutdown.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Exec TrueNAS shutdown tasks
 
-After=network.target
+After=network.target middlewared.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
In a race condition sometimes, ix-shutdown is stopped by systemd after middlewared has already stopped resulting in the service never finishing.