### PR TITLE
Move 2 hard-coded SMB globals from tail to head of [global] section

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf
@@ -418,6 +418,8 @@
 %>
 
 [global]
+        registry shares = yes
+        include = registry
     % for param, value in parsed_conf.items():
       % if type(value) == list:
         ${param} = ${' '.join(value)}
@@ -425,5 +427,3 @@
         ${param} = ${value}
       % endif
     % endfor
-        registry shares = yes
-        include = registry


### PR DESCRIPTION
This addresses an uncommon edge case that came to light in the forums, when migrating 11.3 -> 12

In some unusual cases under 11.3 and earlier, it *might* have been necessary or decided, to put some share info in the global auxiliary section. It shouldn't be, as a rule, and wouldn't be recommended, but it works fine.  For example, to set access for  IPC$, and a couple of other unusual cases. 

But in 12-BETA1, the present code builds the [global] section of smb4.conf differently, like this:

[global]
..... standard global stuff.....
.... user aux text, including a [section] piece...
**registry shares = yes**
**include = registry**

The last 2 lines appearing in a non-global section break smb4.conf, and thats new in 12-BETA1.

This fixes it by moving the 2 new lines added in 12-BETA1, to the start of [global]. Samba doesn't care where they are, as long as they are in [global]. Trivially solved.

Obviously as a rule people shouldn't put share info in the global aux section, but the fix is so trivial, it's worth simply putting it in and being done.