### PR TITLE
smb4.conf lines beginning #; are not errors, they're ignorable comments and should be silently ignored

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/registry.py
+++ b/src/middlewared/middlewared/plugins/smb_/registry.py
@@ -345,7 +345,7 @@ class SharingSMBService(Service):
             data['auxsmbconf'] = (SMBSharePreset[data["purpose"]].value)["params"]["auxsmbconf"]
 
         for param in data['auxsmbconf'].splitlines():
-            if not param.strip():
+            if not param.strip() or param.strip()[0] in '#;':
                 continue
             try:
                 kv = param.split('=', 1)


### PR DESCRIPTION
Don't treat smb4.conf comments as errors. Just silently ignore them