### PR TITLE
NAS-106941 / 12.1 / Fix unlock parent check

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -2189,7 +2189,7 @@ class PoolDatasetService(CRUDService):
         datasets = self.query_encrypted_datasets(id.split('/', 1)[0], {'key_loaded': False})
         for name, ds in datasets.items():
             ds_key = keys_supplied.get(name) or ds['encryption_key']
-            if ds['locked'] and id != name and id.startswith(name):
+            if ds['locked'] and id.startswith(f'{name}/'):
                 # This ensures that `id` has locked parents and they should be unlocked first
                 locked_datasets.append(name)
             elif ZFSKeyFormat(ds['key_format']['value']) == ZFSKeyFormat.RAW and ds_key:


### PR DESCRIPTION
This commit fixes an issue where a dataset name being a subset of current dataset name but not necessarily it's parent ended up being marked as a locked parent whereas it is not really the parent.