### PR TITLE
NAS-106963 / 12.0 / Address race in unlocking SMB shares (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -948,10 +948,10 @@ class KerberosKeytabService(CRUDService):
         """
         Generate list of Kerberos principals that are not the AD machine account.
         """
-        smb = await self.middleware.call('smb.config')
+        ad = await self.middleware.call('activedirectory.config')
         pruned_list = []
         for i in keytab_list:
-            if smb['netbiosname'].upper() not in i['principal'].upper():
+            if ad['netbiosname'].upper() not in i['principal'].upper():
                 pruned_list.append(i)
 
         return pruned_list

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1122,6 +1122,11 @@ class SharingSMBService(SharingService):
         file. This method simply reconciles lists of shares, removing from and adding to
         the registry as-needed.
         """
+        if not os.path.exists(SMBPath.GLOBALCONF.platform()):
+            self.logger.warning("smb.conf does not exist. Skipping registry synchronization."
+                                "This may indicate that SMB service has not completed initialization.")
+            return
+
         active_shares = await self.query([('locked', '=', False), ('enabled', '=', True)])
         registry_shares = await self.middleware.call('sharing.smb.reg_listshares')
         cf_active = set([x['name'].casefold() for x in active_shares])


### PR DESCRIPTION
If smb.conf does not exist at this point, it means that the SMB
service has not initialized. Generate a log message so that we can
track the race condition, but don't fail. Ensure that directory service
initialization always starts kerberos and generates nsswitch.conf.