### PR TITLE
Fixes NAS-106760 - crash in updating SMB shares

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/registry.py
+++ b/src/middlewared/middlewared/plugins/smb_/registry.py
@@ -176,15 +176,19 @@ class SharingSMBService(Service):
         try:
             reg_conf = await self.reg_showshare(share if not data['home'] else 'homes')
         except Exception:
-            return None
-
+            return {
+                'added': {},
+                'removed': {},
+                'modified': {}
+            }
+                  
         s_keys = set(share_conf.keys())
         r_keys = set(reg_conf.keys())
         intersect = s_keys.intersection(r_keys)
         return {
             'added': {x: share_conf[x] for x in s_keys - r_keys},
             'removed': {x: reg_conf[x] for x in r_keys - s_keys},
-            'modified': {x: (share_conf[x], reg_conf[x]) for x in intersect if share_conf[x] != reg_conf[x]},
+            'modified': {x: (share_conf[x], reg_conf[x]) for x in intersect if share_conf[x] != reg_conf[x]}
         }
 
     @private

--- a/src/middlewared/middlewared/plugins/smb_/registry.py
+++ b/src/middlewared/middlewared/plugins/smb_/registry.py
@@ -179,7 +179,7 @@ class SharingSMBService(Service):
             return {
                 'added': {},
                 'removed': {},
-                'modified': {}
+                'modified': {},
             }
 
         s_keys = set(share_conf.keys())
@@ -188,7 +188,7 @@ class SharingSMBService(Service):
         return {
             'added': {x: share_conf[x] for x in s_keys - r_keys},
             'removed': {x: reg_conf[x] for x in r_keys - s_keys},
-            'modified': {x: (share_conf[x], reg_conf[x]) for x in intersect if share_conf[x] != reg_conf[x]}
+            'modified': {x: (share_conf[x], reg_conf[x]) for x in intersect if share_conf[x] != reg_conf[x]},
         }
 
     @private

--- a/src/middlewared/middlewared/plugins/smb_/registry.py
+++ b/src/middlewared/middlewared/plugins/smb_/registry.py
@@ -181,7 +181,7 @@ class SharingSMBService(Service):
                 'removed': {},
                 'modified': {}
             }
-                  
+
         s_keys = set(share_conf.keys())
         r_keys = set(reg_conf.keys())
         intersect = s_keys.intersection(r_keys)


### PR DESCRIPTION
Fixes a crash/exception when SMB shares updated.

In diff_middleware_and_registry() line 175 should return a dict object compatible with the expected return value:   {'added': {}, 'removed': {}, 'modified' : {}}, not just a "None" object.

The crash/exception itself, stems from do_update() in smb.py lines 743-749:

            diff = await self.middleware.call(
                'sharing.smb.diff_middleware_and_registry', new['name'], new
            )
            share_name = new['name'] if not new['home'] else 'homes'
            await self.middleware.call('sharing.smb.apply_conf_diff',
                                       'REGISTRY', share_name, diff)

- As part of updating SMB shares, do_update() calls diff_middleware_and_registry(). 
- Line 175 of diff_middleware_and_registry()  returns None rather than a dict with no differences, as the value of diff
- 3 lines later diff=None is passed as a parameter to apply_conf_diff().
- apply_conf_diff() passes that value intact to apply_conf_registry(), which raises the exception seen, because diff['added/removed/modified'] don't exist, so the for... loops in that function are over invalid objects.  

If the expected objects exist but are empty, the bug is fixed.

Tested, now works for me.
