### PR TITLE
NAS-106991 / 12.0 / Reduce SMB-related log entries (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -927,6 +927,10 @@ class SharingSMBService(SharingService):
     async def close_share(self, share_name):
         c = await run([SMBCmd.SMBCONTROL.value, 'smbd', 'close-share', share_name], check=False)
         if c.returncode != 0:
+            if "Can't find pid" in c.stderr.decode():
+                # smbd is not running. Don't log error message.
+                return
+
             self.logger.warn('Failed to close smb share [%s]: [%s]',
                              share_name, c.stderr.decode().strip())
 

--- a/src/middlewared/middlewared/plugins/smb_/registry.py
+++ b/src/middlewared/middlewared/plugins/smb_/registry.py
@@ -42,7 +42,9 @@ class SharingSMBService(Service):
 
         netconf = await run(cmd, check=False)
         if netconf.returncode != 0:
-            self.logger.debug('netconf failure stdout: %s', netconf.stdout.decode())
+            if action != 'getparm':
+                self.logger.debug('netconf failure for command [%s] stdout: %s',
+                                  cmd, netconf.stdout.decode())
             raise CallError(
                 f'net conf {action} [{share}] failed with error: {netconf.stderr.decode()}'
             )


### PR DESCRIPTION
Don't log on failure to close share if smbd in not running.
Don't log stdout on "netconf getparm" failures. This often just
means the parameter queried wasn't in the registry.