### PR TITLE
NAS-106946 / 12.0 / Multiple idmap generation and validation fixes (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf
@@ -7,6 +7,7 @@
         import sys
         import logging
         from middlewared.utils import osc
+        from middlewared.plugins.idmap import IdmapBackend
 
         logger = logging.getLogger(__name__)
 
@@ -267,6 +268,19 @@
 
             return pc
 
+        def check_required_options(idmap, options, domain):
+            required_keys = idmap.required_keys()
+            missing_keys = []
+            for key in required_keys:
+                if not options.get(key):
+                    missing_keys.append(key)
+
+            if missing_keys:
+                self.logger.warning("Idmap backend for domain [%s] lacks "
+                                    "required configuration option(s): %s. User "
+                                    "authentication and apects of domain integration "
+                                    "may be negatively impacted.", domain, missing_keys)
+
         def add_idmap_domain(pc, db, idmap, autorid_enabled=False):
             """
             Generate idmap settings. DS_TYPE_LDAP, DS_TYPE_ACTIVEDIRECTORY, and DS_TYPE_DEFAULT_DOMAIN
@@ -292,7 +306,9 @@
 
             low_range = idmap['range_low']
             high_range = idmap['range_high']
-            backend = idmap['idmap_backend'].lower()
+            backend = IdmapBackend[idmap['idmap_backend']]
+
+            check_required_options(backend, idmap['options'], idmap['name'])
 
             if idmap['name'] in ['DS_TYPE_ACTIVEDIRECTORY', 'DS_TYPE_LDAP']:
                 domain = db['cifs']['workgroup']
@@ -301,67 +317,68 @@
             else:
                 domain = idmap['name']
 
-            if backend != "autorid":
-                pc.update({f'idmap config {domain}: backend': backend})
-                pc.update({f'idmap config {domain}: range': f'{low_range}-{high_range}'})
+            if backend != IdmapBackend.AUTORID:
+                pc.update({
+                    f'idmap config {domain}: backend': backend.name.lower(),
+                    f'idmap config {domain}: range': f'{low_range}-{high_range}'
+                })
 
-            if backend == "autorid":
-                pc.update({'idmap config * : backend': backend})
-                pc.update({'idmap config * : range': f'{low_range}-{high_range}'})
-                pc.update({'idmap config * : rangesize': idmap['options']['rangesize']})
-                if idmap['options']['readonly']:
+            if backend == IdmapBackend.AUTORID:
+                pc.update({
+                    f'idmap config * : backend': backend.name.lower(),
+                    f'idmap config * : range': f'{low_range}-{high_range}'
+                })
+                if 'rangesize' in idmap['options']:
+                    pc.update({'idmap config * : rangesize': idmap['options']['rangesize']})
+                if idmap['options'].get('readonly'):
                     pc.update({'idmap config * : readonly': 'Yes'})
-                if idmap['options']['ignore_builtin']:
+                if idmap['options'].get('ignore_builtin'):
                     pc.update({'idmap config * : ignore_builtin': 'Yes'})
 
-            elif backend == "ad":
+            elif backend == IdmapBackend.AD:
                 pc.update({f'idmap config {domain}: schema_mode': idmap['options']['schema_mode'].lower()})
-                if idmap['options']['unix_nss_info']:
-                    pc.update({f'idmap config {domain}: unix_nss_info': 'yes'})
-                if idmap['options']['unix_primary_group']:
-                    pc.update({f'idmap config {domain}: unix_primary_group': idmap['options']['unix_primary_group']})
+                if idmap['options'].get('unix_nss_info'):
+                    pc.update({f'idmap config {domain}: unix_nss_info': 'Yes'})
+                if idmap['options'].get('unix_primary_group'):
+                    pc.update({f'idmap config {domain}: unix_primary_group': 'Yes'})
 
-            elif backend == "ldap":
-                if idmap['options']['ldap_base_dn']:
+            elif backend == IdmapBackend.LDAP:
+                if idmap['options'].get('ldap_base_dn'):
                     pc.update({f'idmap config {domain}: ldap_base_dn': idmap['options']['ldap_base_dn']})
                 elif db['role'] == 'ldap_member':
                     pc.update({f'idmap config {domain}: ldap_base_dn': db['ldap']['basedn']})
 
-                if idmap['options']['ldap_user_dn']:
+                if idmap['options'].get('ldap_user_dn'):
                     pc.update({f'idmap config {domain}: ldap_user_dn': idmap['options']['ldap_user_dn']})
 
-                if idmap['options']['ldap_url']:
+                if idmap['options'].get('ldap_url'):
                     pc.update({f'idmap config {domain}: ldap_url': idmap['options']['ldap_url']})
                 elif db['role'] == 'ldap_member':
                     ldap_uri = generate_ldap_backend(db['ldap']).lstrip('ldapsam: ')
                     pc.update({f'idmap config {domain}: ldap_url': ldap_uri})
 
-                pc.update({f'idmap config {domain}: read only': 'yes'})
+                pc.update({f'idmap config {domain}: read only': 'Yes'})
                 
-            elif backend == "rfc2307":
+            elif backend == IdmapBackend.RFC2307:
                 pc.update({f'idmap config {domain}: ldap_server': idmap['options']['ldap_server']})
-                if idmap['options']['ldap_server_url']:
+                if idmap['options'].get('ldap_url'):
                     pc.update({f'idmap config {domain}: ldap_url': idmap['options']['ldap_url']})
-                if idmap['options']['bind_path_user']:
+                if idmap['options'].get('bind_path_user'):
                     pc.update({f'idmap config {domain}: bind_path_user': idmap['options']['bind_path_user']})
-                if idmap['options']['bind_path_group']:
+                if idmap['options'].get('bind_path_group'):
                     pc.update({f'idmap config {domain}: bind_path_group': idmap['options']['bind_path_group']})
-                if idmap['options']['user_cn']:
+                if idmap['options'].get('user_cn'):
                     pc.update({f'idmap config {domain}: user_cn': "Yes"})
-                if idmap['options']['ldap_realm']:
+                if idmap['options'].get('ldap_realm'):
                     pc.update({f'idmap config {domain}: realm': "Yes"})
-                if idmap['options']['ldap_domain']:
+                if idmap['options'].get('ldap_domain'):
                     pc.update({f'idmap config {domain}: ldap_domain': idmap['options']['ldap_domain']})
-                if idmap['options']['ldap_user_dn']:
+                if idmap['options'].get('ldap_user_dn'):
                     pc.update({f'idmap config {domain}: ldap_user_dn': idmap['options']['ldap_user_dn']})
-                if idmap['options']['ssl']:
+                if idmap['options'].get('ssl'):
                     pc.update({'ldap ssl': 'start tls'})
                     if idmap['options']['ldap_server'].lower() == "ads":
                         pc.update({'ldap ssl ads': 'Yes'})
-
-            elif backend == "script":
-                if idmap['options']['script']:
-                    pc.update({f'idmap config {domain}: script': idmap['options']['script']})
 
             return pc
 


### PR DESCRIPTION
During course of writing regression tests for idmap plugin, I discovered multiple issues.

- Make smb.conf generation more forgiving about default / missing keys in backend['options'].
- Wait for idmap cache clear to complete before returning idmap updates
- Add new methods to write idmap secrets to secrets.tdb. "net idmap set secret" performs an smb.conf check, which we want 
   to avoid during idmap setup.
- Force a directory services secrets backup after idmap change if it resulted in new secrets being written to secrets.tdb.
- Fix / improve validation for some edge-cases.

See NAS-107011 for regression tests.