### PR TITLE
NAS-107019 / 11.3 / Fix issue with AD machine account keytab storage on HA platform

### DIFF
--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -788,10 +788,10 @@ class KerberosKeytabService(CRUDService):
         """
         Generate list of Kerberos principals that are not the AD machine account.
         """
-        smb = await self.middleware.call('smb.config')
+        ad = await self.middleware.call('activedirectory.config')
         pruned_list = []
         for i in keytab_list:
-            if smb['netbiosname'].upper() not in i['principal'].upper():
+            if ad['netbiosname'].upper() not in i['principal'].upper():
                 pruned_list.append(i)
 
         return pruned_list


### PR DESCRIPTION
netbiosname key in activedirectory config is HA configuration
aware and what is used for domain join. Use that rather than
the SMB netbiosname to ensure that we remove the correct keys
when creating the AD machine account keytab in our config file.

Regression test coverage provided in NAS-106978