### PR TITLE
NAS-107023 / 12.1 / Expand list of error strings that should trigger an AD rejoin

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -37,6 +37,18 @@ class neterr(enum.Enum):
     NOTJOINED = 2
     FAULT = 3
 
+    def to_status(errstr):
+        errors_to_rejoin = [
+            '0xfffffff6',
+            'The name provided is not a properly formed account name',
+            'The attempted logon is invalid.'
+        ]
+        for err in errors_to_rejoin:
+            if err in errstr:
+                return neterr.NOTJOINED
+
+        return neterr.FAULT
+
 
 class SRV(enum.Enum):
     DOMAINCONTROLLER = '_ldap._tcp.dc._msdcs.'
@@ -921,10 +933,7 @@ class ActiveDirectoryService(ConfigService):
             with open(f"{SMBPath.LOGDIR.platform()}/domain_testjoin_{int(datetime.datetime.now().timestamp())}.log", "w") as f:
                 f.write(errout)
 
-            if '0xfffffff6' in errout or 'The name provided is not a properly formed account name' in errout:
-                return neterr.NOTJOINED
-            else:
-                return neterr.FAULT
+            return neterr.to_status(errout)
 
         return neterr.JOINED
 


### PR DESCRIPTION
Issue discovered during abusive testing of domain joins / leaves.
In some cases samba will try to authenticate with stale AD secrets
in secrets.tdb rather than use the kerberos ticket specified in the
`net ads testjoin` command. This results in a pre-authentication
failure being returned by the underlying kerberos library. Expand
the list of "testjoin" error responses that trigger a domain rejoin
to include this particular one as well.