### PR TITLE
NAS-107037 / 11.3 / Have ftp reload method reload proftpd rather than restart it

### DIFF
--- a/src/middlewared/middlewared/plugins/service.py
+++ b/src/middlewared/middlewared/plugins/service.py
@@ -726,7 +726,7 @@ class ServiceService(CRUDService):
 
     async def _reload_ftp(self, **kwargs):
         await self.middleware.call("etc.generate", "ftp")
-        await self._service("proftpd", "restart", **kwargs)
+        await self._service("proftpd", "reload", **kwargs)
 
     async def _restart_ftp(self, **kwargs):
         await self._stop_ftp()


### PR DESCRIPTION
proftpd supports sending SIGHUP to process to reload config.
Having the service restart in the reload method causes pool
import hook to start the FTP service.