### PR TITLE
NAS-107067 / 11.3 / Fix chown of skel directory contents for new local users

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -294,7 +294,6 @@ class UserService(CRUDService):
                         'path': dest_file,
                         'uid': data['uid'],
                         'gid': group['gid'],
-                        'options': {'recursive': True}
                     })
 
             data['sshpubkey'] = sshpubkey


### PR DESCRIPTION
```
  File "/usr/local/lib/python3.7/site-packages/middlewared/plugins/filesystem.py", line 463, in chown
    self._winacl(data['path'], 'chown', uid, gid, options)
middlewared.service_exception.CallError: [EFAULT] Winacl chown on path /mnt/ADTest/test_home/testuser/.profile failed with error: [winacl: /mnt/ADTest/test_home/testuser/.profile: chdir() failed.: Not a directory]
````

Before plumbing in middleware permissions api, we were recursively changing owner on each item in the newly copied skel separately. This was preserved in filesystem.chown call, but subsequent changes to ensure that recursive filesystem permissions changes will only occur in the given path caused regression in this account behavior. For now, simply remove the recursive flag because the contents of '/usr/share/skel/' are only files.