### PR TITLE
NAS-107069 / 11.3 / Symlink /usr/share/skel to /etc/skel in FreeBSD

### DIFF
--- a/src/middlewared/middlewared/etc_files/pam.d/pam.skel_freebsd
+++ b/src/middlewared/middlewared/etc_files/pam.d/pam.skel_freebsd
@@ -1,0 +1,15 @@
+<%
+    import os
+
+    def setup_skel():
+        if not os.path.islink('/etc/skel'):
+            try:
+                os.rmdir('/etc/skel')
+                os.symlink('/usr/share/skel', '/etc/skel')
+            except Exception:
+                middleware.logger.warning("Failed to set up skel directory "
+                                          "automatically generated home directories "
+                                          "for SSH users may be impacted.", exc_info=True)
+%>
+${setup_skel()}
+

--- a/src/middlewared/middlewared/etc_files/pam.d/pam.skel_freebsd
+++ b/src/middlewared/middlewared/etc_files/pam.d/pam.skel_freebsd
@@ -4,7 +4,8 @@
     def setup_skel():
         if not os.path.islink('/etc/skel'):
             try:
-                os.rmdir('/etc/skel')
+                if os.path.isdir('/etc/skel'):
+                    os.rmdir('/etc/skel')
                 os.symlink('/usr/share/skel', '/etc/skel')
             except Exception:
                 middleware.logger.warning("Failed to set up skel directory "


### PR DESCRIPTION
pam_mkhomedir appears to default to trying to get files from "/etc/skel".
This possibly indicates a regression in the port, but since it can
be hard to predict behavior of applications that use pam libraries
and hardcode skel path to Linux default location, make this path a
symlink to the FreeBSD path.