### PR TITLE
NAS-107076 / 12.1 / Expand regression tests for user api (by anodos325)

### DIFF
--- a/tests/api2/test_011_user.py
+++ b/tests/api2/test_011_user.py
@@ -6,12 +6,14 @@
 
 import pytest
 import sys
+import json
 import os
+import time
 from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from functions import POST, GET, DELETE, PUT
-from auto_config import scale, ha
+from functions import POST, GET, DELETE, PUT, SSH_TEST
+from auto_config import scale, ha, password, user, ip
 if scale is True:
     shell = '/bin/bash'
 else:
@@ -20,6 +22,15 @@ else:
 group = 'root' if scale else 'wheel'
 group_id = GET(f'/group/?group={group}', controller_a=ha).json()[0]['id']
 
+dataset = f"{pool_name}/test_homes"
+dataset_url = dataset.replace('/', '%2F')
+
+home_files = {
+    "~/": "0o40750",
+    "~/.profile": "0o100644",
+    "~/.ssh": "0o40700",
+    "~/.ssh/authorized_keys": "0o100600",
+}
 
 @pytest.mark.dependency(name="user_01")
 def test_01_get_next_uid():
@@ -194,4 +205,205 @@ def test_24_creating_shareuser_to_test_sharing(request):
         "shell": shell
     }
     results = POST("/user/", payload)
+    assert results.status_code == 200, results.text
+
+
+def test_25_get_next_uid_for_homes_check():
+    results = GET('/user/get_next_uid/')
+    assert results.status_code == 200, results.text
+    global next_uid
+    next_uid = results.json()
+
+
+@pytest.mark.dependency(name="HOME_DS_CREATED")
+def test_26_creating_home_dataset(request):
+    """
+    SMB share_type is selected for this test so that
+    we verify that ACL is being stripped properly from
+    the newly-created home directory.
+    """
+    depends(request, ["pool_04"], scope="session")
+    payload = {
+        "name": dataset,
+        "share_type": "SMB"
+    }
+    results = POST("/pool/dataset/", payload)
+    assert results.status_code == 200, results.text
+
+
+@pytest.mark.dependency(name="USER_CREATED")
+def test_27_creating_user_with_homedir(request):
+    depends(request, ["HOME_DS_CREATED"])
+    global user_id
+    payload = {
+        "username": "testuser2",
+        "full_name": "Test User2",
+        "group_create": True,
+        "password": "test",
+        "uid": next_uid,
+        "shell": shell,
+        "sshpubkey": "canary",
+        "home": f'/mnt/{dataset}/testuser2',
+        "home_mode": '750'
+    }
+    results = POST("/user/", payload)
+    assert results.status_code == 200, results.text
+    user_id = results.json()
+
+
+def test_28_smb_user_passb_entry_exists(request):
+    depends(request, ["USER_CREATED"])
+    cmd = "midclt call smb.passdb_list true"
+    results = SSH_TEST(cmd, user, password, ip)
+    assert results['result'] is True, results['output']
+    pdb_list = json.loads(results['output'])
+    my_entry = None
+    for entry in pdb_list:
+        if entry['Unix username'] == "testuser2":
+            my_entry = entry
+            break
+
+    assert my_entry is not None, results['output']
+    if my_entry is not None:
+        assert my_entry["Account Flags"] == "[U          ]", str(my_entry)
+
+
+@pytest.mark.dependency(name="HOMEDIR_EXISTS")
+def test_29_homedir_exists(request):
+    depends(request, ["USER_CREATED"])
+    results = POST('/filesystem/stat/', f'/mnt/{dataset}/testuser2')
+    assert results.status_code == 200, results.text
+
+
+def test_30_homedir_acl_stripped(request):
+    depends(request, ["HOMEDIR_EXISTS"])
+    # Homedir permissions changes are backgrounded.
+    # one second sleep should be sufficient for them to complete.
+    time.sleep(1)
+    results = POST('/filesystem/stat/', f'/mnt/{dataset}/testuser2')
+    assert results.status_code == 200, results.text
+    assert results.json()['acl'] == False, results.text
+
+
+@pytest.mark.parametrize('to_test', home_files.keys())
+def test_31_homedir_check_perm(to_test, request):
+    depends(request, ["HOMEDIR_EXISTS"])
+    results = POST('/filesystem/stat/', f'/mnt/{dataset}/testuser2/{to_test[2:]}')
+    assert results.status_code == 200, results.text
+    assert oct(results.json()['mode']) == home_files[to_test], f"{to_test}: {results.text}"
+    assert results.json()['uid'] == next_uid, results.text
+
+
+def test_32_homedir_testfile_create(request):
+    depends(request, ["HOMEDIR_EXISTS"])
+    testfile = f'/mnt/{dataset}/testuser2/testfile.txt'
+
+    cmd = f'touch {testfile}'
+    results = SSH_TEST(cmd, user, password, ip)
+    assert results['result'] is True, results['output']
+
+    results = POST('/filesystem/stat/', testfile)
+    assert results.status_code == 200, results.text
+
+
+@pytest.mark.dependency(name="HOMEDIR2_EXISTS")
+def test_33_homedir_move_new_directory(request):
+    payload = {
+        "home": f'/mnt/{dataset}/new_home',
+    }
+    results = PUT(f"/user/id/{user_id}", payload)
+    assert results.status_code == 200, results.text
+
+    results = POST('/filesystem/stat/', f'/mnt/{dataset}/new_home')
+    assert results.status_code == 200, results.text
+
+
+@pytest.mark.parametrize('to_test', home_files.keys())
+def test_34_after_move_check_perm(to_test, request):
+    depends(request, ["HOMEDIR2_EXISTS"])
+    results = POST('/filesystem/stat/', f'/mnt/{dataset}/new_home/{to_test[2:]}')
+    assert results.status_code == 200, results.text
+    assert oct(results.json()['mode']) == home_files[to_test], f"{to_test}: {results.text}"
+    assert results.json()['uid'] == next_uid, results.text
+
+
+def test_35_testfile_successfully_moved(request):
+    depends(request, ["HOMEDIR2_EXISTS"])
+    results = POST('/filesystem/stat/', f'/mnt/{dataset}/new_home/testfile.txt')
+    assert results.status_code == 200, results.text
+
+
+def test_36_lock_smb_user(request):
+    depends(request, ["USER_CREATED"])
+    payload = {
+        "locked": True,
+    }
+    results = PUT(f"/user/id/{user_id}", payload)
+    assert results.status_code == 200, results.text
+
+
+def test_37_verify_locked_smb_user_is_disabled(request):
+    depends(request, ["USER_CREATED"])
+    cmd = "midclt call smb.passdb_list true"
+    results = SSH_TEST(cmd, user, password, ip)
+    assert results['result'] is True, results['output']
+    pdb_list = json.loads(results['output'])
+    my_entry = None
+    for entry in pdb_list:
+        if entry['Unix username'] == "testuser2":
+            my_entry = entry
+            break
+
+    assert my_entry is not None, results['output']
+    if my_entry is not None:
+        assert my_entry["Account Flags"] == "[DU         ]", str(my_entry)
+
+
+def test_38_deleting_homedir_user(request):
+    depends(request, ["USER_CREATED"])
+    results = DELETE(f"/user/id/{user_id}/", {"delete_group": True})
+    assert results.status_code == 200, results.text
+
+
+@pytest.mark.dependency(name="NON_SMB_USER_CREATED")
+def test_39_creating_non_smb_user(request):
+    depends(request, ["HOME_DS_CREATED"])
+    global user_id
+    payload = {
+        "username": "testuser3",
+        "full_name": "Test User3",
+        "group_create": True,
+        "password": "test",
+        "uid": next_uid,
+        "smb": False
+    }
+    results = POST("/user/", payload)
+    assert results.status_code == 200, results.text
+    user_id = results.json()
+
+
+def test_40_verify_non_smb_user_absent_from_passdb(request):
+    depends(request, ["NON_SMB_USER_CREATED"])
+    cmd = "midclt call smb.passdb_list true"
+    results = SSH_TEST(cmd, user, password, ip)
+    assert results['result'] is True, results['output']
+    pdb_list = json.loads(results['output'])
+    my_entry = None
+    for entry in pdb_list:
+        if entry['Unix username'] == "testuser2":
+            my_entry = entry
+            break
+
+    assert my_entry is None, results['output']
+
+
+def test_41_deleting_non_smb_user(request):
+    depends(request, ["NON_SMB_USER_CREATED"])
+    results = DELETE(f"/user/id/{user_id}/", {"delete_group": True})
+    assert results.status_code == 200, results.text
+
+
+def test_42_destroying_home_dataset(request):
+    depends(request, ["HOME_DS_CREATED"])
+    results = DELETE(f"/pool/dataset/id/{dataset_url}/")
     assert results.status_code == 200, results.text


### PR DESCRIPTION
Add tests for following:
- permissions set correctly on home directory creation
- permissions set correctly on home directory move
- home directory move actually copies files to new path
- SMB users are added to passdb.tdb on creation
- SMB users are disabled when user is locked
- Non-SMB users are not added t o passdb


Related to: NAS-107074, NAS-107067, NAS-107051