### PR TITLE
NAS-107074 / 12.0 / Permissions are incorrect on home directory move (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -18,6 +18,7 @@ import random
 import shlex
 import shutil
 import string
+import stat
 import subprocess
 import time
 
@@ -368,6 +369,12 @@ class UserService(CRUDService):
 
         await self.__common_validation(verrors, data, 'user_update', pk=pk)
 
+        try:
+            st = os.stat(user.get("home", "/nonexistent")).st_mode
+            old_mode = f'{stat.S_IMODE(st):03o}'
+        except FileNotFoundError:
+            old_mode = None
+
         home = data.get('home') or user['home']
         has_home = home != '/nonexistent'
         # root user (uid 0) is an exception to the rule
@@ -414,11 +421,18 @@ class UserService(CRUDService):
         if home_copy and not os.path.isdir(user['home']):
             try:
                 os.makedirs(user['home'])
-                await self.middleware.call('filesystem.chown', {
+                mode_to_set = user.get('home_mode')
+                if not mode_to_set:
+                    mode_to_set = '700' if old_mode is None else old_mode
+
+                perm_job = await self.middleware.call('filesystem.setperm', {
                     'path': user['home'],
                     'uid': user['uid'],
                     'gid': group['bsdgrp_gid'],
+                    'mode': mode_to_set,
+                    'options': {'stripacl': True},
                 })
+                await perm_job.wait()
             except OSError:
                 self.logger.warn('Failed to chown homedir', exc_info=True)
             if not os.path.isdir(user['home']):


### PR DESCRIPTION
In case of moving location of home directory from path a to path b, if path b
does not exist, we need to explicitly set permissions as well strip any ACL
on the path in order to ensure that premissions from original path are preserved.

Preference for new mode is as follows:
1. user-supplied mode in 'user.update' call
2. existing mode on old path
3. default mode. Since this is most likely an error condition, default is 0700.