### PR TITLE
NAS-107099 / 12.1 / Do not display previous replication task status after deleting it and…

### DIFF
--- a/src/middlewared/middlewared/plugins/zettarepl.py
+++ b/src/middlewared/middlewared/plugins/zettarepl.py
@@ -281,7 +281,7 @@ class ZettareplService(Service):
                 if self.observer_queue_reader is None:
                     self.observer_queue_reader = start_daemon_thread(target=self._observer_queue_reader)
 
-                self.middleware.call_sync("zettarepl.set_hold_tasks", hold_tasks)
+                self.middleware.call_sync("zettarepl.notify_definition", definition, hold_tasks)
 
     def stop(self):
         with self.lock:
@@ -319,7 +319,7 @@ class ZettareplService(Service):
             self.middleware.call_sync("zettarepl.start")
             self.queue.put(("tasks", definition))
 
-        self.middleware.call_sync("zettarepl.set_hold_tasks", hold_tasks)
+        self.middleware.call_sync("zettarepl.notify_definition", definition, hold_tasks)
 
     async def run_periodic_snapshot_task(self, id):
         try:


### PR DESCRIPTION
… creating new replication task.

This happens because SQLite IDs can duplicate deleted rows.