### PR TITLE
NAS-107124 / 12.0 / Fix /etc/skel symlink

### DIFF
--- a/src/middlewared/middlewared/etc_files/pam.d/pam.skel_freebsd
+++ b/src/middlewared/middlewared/etc_files/pam.d/pam.skel_freebsd
@@ -4,7 +4,8 @@
     def setup_skel():
         if not os.path.islink('/etc/skel'):
             try:
-                os.rmdir('/etc/skel')
+                if os.path.isdir('/etc/skel'):
+                    os.rmdir('/etc/skel')
                 os.symlink('/usr/share/skel', '/etc/skel')
             except Exception:
                 middleware.logger.warning("Failed to set up skel directory "


### PR DESCRIPTION
Reference system on which I was initially troubleshooting auto home
directories for AD users had this dir in existence. Apparently, this
is not always the case. Add check before rmdir on /etc/skel.