### PR TITLE
NAS-107140 / 12.0 / Expand api tests for user

### DIFF
--- a/tests/api2/user.py
+++ b/tests/api2/user.py
@@ -32,6 +32,7 @@ home_files = {
     "~/.ssh/authorized_keys": "0o100600",
 }
 
+
 def test_01_get_next_uid():
     results = GET('/user/get_next_uid/')
     assert results.status_code == 200, results.text
@@ -40,6 +41,12 @@ def test_01_get_next_uid():
 
 
 def test_02_creating_user_testuser():
+    """
+    Test for basic user creation. In this case 'smb' is disabled to bypass
+    passdb-related code. This is because the passdb add relies on users existing
+    in passwd database, and errors during error creation will get masked as
+    passdb errors.
+    """
     global user_id
     payload = {
         "username": "testuser",
@@ -47,6 +54,7 @@ def test_02_creating_user_testuser():
         "group_create": True,
         "password": "test",
         "uid": next_uid,
+        "smb": False,
         "shell": shell
     }
     results = POST("/user/", payload)
@@ -58,28 +66,44 @@ def test_03_look_user_is_created():
     assert len(GET('/user?username=testuser').json()) == 1
 
 
-def test_04_get_user_info():
+def test_04_check_user_exists():
+    """
+    get_user_obj is a wrapper around the pwd module.
+    This check verifies that the user is _actually_ created.
+    """
+    payload = {
+        "username": "testuser"
+    }
+    results = POST("/user/get_user_obj/", payload)
+    assert results.status_code == 200, results.text
+    if results.status_code == 200:
+        pw = results.json()
+        assert pw['pw_uid'] == next_uid, results.text
+        assert pw['pw_shell'] == shell, results.text
+
+
+def test_05_get_user_info():
     global userinfo
     userinfo = GET(f'/user/id/{user_id}').json()
 
 
-def test_05_look_user_name():
+def test_06_look_user_name():
     assert userinfo["username"] == "testuser"
 
 
-def test_06_look_user_full_name():
+def test_07_look_user_full_name():
     assert userinfo["full_name"] == "Test User"
 
 
-def test_07_look_user_uid():
+def test_08_look_user_uid():
     assert userinfo["uid"] == next_uid
 
 
-def test_08_look_user_shell():
+def test_09_look_user_shell():
     assert userinfo["shell"] == shell
 
 
-def test_09_add_employee_id_and_team_special_attributes():
+def test_10_add_employee_id_and_team_special_attributes():
     payload = {
         'key': 'Employee ID',
         'value': 'TU1234',
@@ -90,18 +114,18 @@ def test_09_add_employee_id_and_team_special_attributes():
     assert results.status_code == 200, results.text
 
 
-def test_10_get_new_next_uid():
+def test_11_get_new_next_uid():
     results = GET('/user/get_next_uid/')
     assert results.status_code == 200, results.text
     global new_next_uid
     new_next_uid = results.json()
 
 
-def test_11_next_and_new_next_uid_not_equal():
+def test_12_next_and_new_next_uid_not_equal():
     assert new_next_uid != next_uid
 
 
-def test_12_setting_user_groups():
+def test_13_setting_user_groups():
     payload = {'groups': [group_id]}
     GET('/user?username=testuser').json()[0]['id']
     results = PUT(f"/user/id/{user_id}/", payload)
@@ -110,7 +134,7 @@ def test_12_setting_user_groups():
 
 # Update tests
 # Update the testuser
-def test_13_updating_user_testuser_info():
+def test_14_updating_user_testuser_info():
     payload = {"full_name": "Test Renamed",
                "password": "testing123",
                "uid": new_next_uid}
@@ -118,57 +142,57 @@ def test_13_updating_user_testuser_info():
     assert results.status_code == 200, results.text
 
 
-def test_14_get_user_new_info():
+def test_15_get_user_new_info():
     global userinfo
     userinfo = GET('/user?username=testuser').json()[0]
 
 
-def test_15_look_user_full_name():
+def test_16_look_user_full_name():
     assert userinfo["full_name"] == "Test Renamed"
 
 
-def test_16_look_user_new_uid():
+def test_17_look_user_new_uid():
     assert userinfo["uid"] == new_next_uid
 
 
-def test_17_look_user_groups():
+def test_18_look_user_groups():
     assert userinfo["groups"] == [group_id]
 
 
-def test_18_remove_old_team_special_atribute():
+def test_19_remove_old_team_special_atribute():
     payload = 'Team'
     results = POST(f"/user/id/{user_id}/pop_attribute/", payload)
     assert results.status_code == 200, results.text
 
 
-def test_19_add_new_team_to_special_atribute():
+def test_20_add_new_team_to_special_atribute():
     payload = {'key': 'Team', 'value': 'QA'}
     results = POST(f"/user/id/{user_id}/set_attribute/", payload)
     assert results.status_code == 200, results.text
 
 
 # Delete the testuser
-def test_20_deleting_user_testuser():
+def test_21_deleting_user_testuser():
     results = DELETE(f"/user/id/{user_id}/", {"delete_group": True})
     assert results.status_code == 200, results.text
 
 
-def test_21_look_user_is_delete():
+def test_22_look_user_is_delete():
     assert len(GET('/user?username=testuser').json()) == 0
 
 
-def test_22_has_root_password():
+def test_23_has_root_password():
     assert GET('/user/has_root_password/', anonymous=True).json() is True
 
 
-def test_23_get_next_uid_for_shareuser():
+def test_24_get_next_uid_for_shareuser():
     results = GET('/user/get_next_uid/')
     assert results.status_code == 200, results.text
     global next_uid
     next_uid = results.json()
 
 
-def test_24_creating_shareuser_to_test_sharing():
+def test_25_creating_shareuser_to_test_sharing():
     payload = {
         "username": "shareuser",
         "full_name": "Share User",
@@ -182,7 +206,7 @@ def test_24_creating_shareuser_to_test_sharing():
     assert results.status_code == 200, results.text
 
 
-def test_25_get_next_uid_for_homes_check():
+def test_26_get_next_uid_for_homes_check():
     results = GET('/user/get_next_uid/')
     assert results.status_code == 200, results.text
     global next_uid
@@ -190,7 +214,7 @@ def test_25_get_next_uid_for_homes_check():
 
 
 @pytest.mark.dependency(name="HOME_DS_CREATED")
-def test_26_creating_home_dataset():
+def test_27_creating_home_dataset():
     """
     SMB share_type is selected for this test so that
     we verify that ACL is being stripped properly from
@@ -205,7 +229,7 @@ def test_26_creating_home_dataset():
 
 
 @pytest.mark.dependency(name="USER_CREATED")
-def test_27_creating_user_with_homedir(request):
+def test_28_creating_user_with_homedir(request):
     depends(request, ["HOME_DS_CREATED"])
     global user_id
     payload = {
@@ -224,7 +248,7 @@ def test_27_creating_user_with_homedir(request):
     user_id = results.json()
 
 
-def test_28_smb_user_passb_entry_exists(request):
+def test_29_smb_user_passb_entry_exists(request):
     depends(request, ["USER_CREATED"])
     cmd = "midclt call smb.passdb_list true"
     results = SSH_TEST(cmd, user, password, ip)
@@ -242,24 +266,24 @@ def test_28_smb_user_passb_entry_exists(request):
 
 
 @pytest.mark.dependency(name="HOMEDIR_EXISTS")
-def test_29_homedir_exists(request):
+def test_30_homedir_exists(request):
     depends(request, ["USER_CREATED"])
     results = POST('/filesystem/stat/', f'/mnt/{dataset}/testuser2')
     assert results.status_code == 200, results.text
 
 
-def test_30_homedir_acl_stripped(request):
+def test_31_homedir_acl_stripped(request):
     depends(request, ["HOMEDIR_EXISTS"])
     # Homedir permissions changes are backgrounded.
     # one second sleep should be sufficient for them to complete.
     time.sleep(1)
     results = POST('/filesystem/stat/', f'/mnt/{dataset}/testuser2')
     assert results.status_code == 200, results.text
-    assert results.json()['acl'] == False, results.text
+    assert results.json()['acl'] is False, results.text
 
 
 @pytest.mark.parametrize('to_test', home_files.keys())
-def test_31_homedir_check_perm(to_test, request):
+def test_32_homedir_check_perm(to_test, request):
     depends(request, ["HOMEDIR_EXISTS"])
     results = POST('/filesystem/stat/', f'/mnt/{dataset}/testuser2/{to_test[2:]}')
     assert results.status_code == 200, results.text
@@ -267,7 +291,7 @@ def test_31_homedir_check_perm(to_test, request):
     assert results.json()['uid'] == next_uid, results.text
 
 
-def test_32_homedir_testfile_create(request):
+def test_33_homedir_testfile_create(request):
     depends(request, ["HOMEDIR_EXISTS"])
     testfile = f'/mnt/{dataset}/testuser2/testfile.txt'
 
@@ -280,7 +304,7 @@ def test_32_homedir_testfile_create(request):
 
 
 @pytest.mark.dependency(name="HOMEDIR2_EXISTS")
-def test_33_homedir_move_new_directory(request):
+def test_34_homedir_move_new_directory(request):
     payload = {
         "home": f'/mnt/{dataset}/new_home',
     }
@@ -292,7 +316,7 @@ def test_33_homedir_move_new_directory(request):
 
 
 @pytest.mark.parametrize('to_test', home_files.keys())
-def test_34_after_move_check_perm(to_test, request):
+def test_35_after_move_check_perm(to_test, request):
     depends(request, ["HOMEDIR2_EXISTS"])
     results = POST('/filesystem/stat/', f'/mnt/{dataset}/new_home/{to_test[2:]}')
     assert results.status_code == 200, results.text
@@ -300,13 +324,13 @@ def test_34_after_move_check_perm(to_test, request):
     assert results.json()['uid'] == next_uid, results.text
 
 
-def test_35_testfile_successfully_moved(request):
+def test_36_testfile_successfully_moved(request):
     depends(request, ["HOMEDIR2_EXISTS"])
     results = POST('/filesystem/stat/', f'/mnt/{dataset}/new_home/testfile.txt')
     assert results.status_code == 200, results.text
 
 
-def test_36_lock_smb_user(request):
+def test_37_lock_smb_user(request):
     depends(request, ["USER_CREATED"])
     payload = {
         "locked": True,
@@ -315,7 +339,11 @@ def test_36_lock_smb_user(request):
     assert results.status_code == 200, results.text
 
 
-def test_37_verify_locked_smb_user_is_disabled(request):
+def test_38_verify_locked_smb_user_is_disabled(request):
+    """
+    This test verifies that the passdb user is disabled
+    when "locked" is set to True.
+    """
     depends(request, ["USER_CREATED"])
     cmd = "midclt call smb.passdb_list true"
     results = SSH_TEST(cmd, user, password, ip)
@@ -332,14 +360,42 @@ def test_37_verify_locked_smb_user_is_disabled(request):
         assert my_entry["Account Flags"] == "[DU         ]", str(my_entry)
 
 
-def test_38_deleting_homedir_user(request):
+def test_39_convert_to_non_smb_user(request):
+    depends(request, ["USER_CREATED"])
+    payload = {
+        "smb": False,
+    }
+    results = PUT(f"/user/id/{user_id}", payload)
+    assert results.status_code == 200, results.text
+
+
+def test_40_verify_absent_from_passdb(request):
+    """
+    This test verifies that the user no longer appears
+    in Samba's passdb after "smb" is set to False.
+    """
+    depends(request, ["USER_CREATED"])
+    cmd = "midclt call smb.passdb_list true"
+    results = SSH_TEST(cmd, user, password, ip)
+    assert results['result'] is True, results['output']
+    pdb_list = json.loads(results['output'])
+    my_entry = None
+    for entry in pdb_list:
+        if entry['Unix username'] == "testuser2":
+            my_entry = entry
+            break
+
+    assert my_entry is None, results['output']
+
+
+def test_41_deleting_homedir_user(request):
     depends(request, ["USER_CREATED"])
     results = DELETE(f"/user/id/{user_id}/", {"delete_group": True})
     assert results.status_code == 200, results.text
 
 
 @pytest.mark.dependency(name="NON_SMB_USER_CREATED")
-def test_39_creating_non_smb_user(request):
+def test_42_creating_non_smb_user(request):
     depends(request, ["HOME_DS_CREATED"])
     global user_id
     payload = {
@@ -355,7 +411,11 @@ def test_39_creating_non_smb_user(request):
     user_id = results.json()
 
 
-def test_40_verify_non_smb_user_absent_from_passdb(request):
+def test_43_verify_non_smb_user_absent_from_passdb(request):
+    """
+    Creating new user with "smb" = False must not
+    result in a passdb entry being generated.
+    """
     depends(request, ["NON_SMB_USER_CREATED"])
     cmd = "midclt call smb.passdb_list true"
     results = SSH_TEST(cmd, user, password, ip)
@@ -363,20 +423,66 @@ def test_40_verify_non_smb_user_absent_from_passdb(request):
     pdb_list = json.loads(results['output'])
     my_entry = None
     for entry in pdb_list:
-        if entry['Unix username'] == "testuser2":
+        if entry['Unix username'] == "testuser3":
             my_entry = entry
             break
 
     assert my_entry is None, results['output']
 
 
-def test_41_deleting_non_smb_user(request):
+def test_44_convert_to_smb_knownfail(request):
+    """
+    SMB auth for local users relies stored NT hash. We only generate this hash
+    for SMB users. This means that converting from non-SMB to SMB requires
+    re-submitting password so that we can generate the required hash. If
+    payload submitted without password, then validation error _must_ be raised.
+    """
+    depends(request, ["NON_SMB_USER_CREATED"])
+    payload = {
+        "smb": True,
+    }
+    results = PUT(f"/user/id/{user_id}", payload)
+    assert results.status_code == 422, results.text
+
+
+def test_45_convert_to_smb_user(request):
+    depends(request, ["NON_SMB_USER_CREATED"])
+    payload = {
+        "smb": True,
+        "password": "test",
+    }
+    results = PUT(f"/user/id/{user_id}", payload)
+    assert results.status_code == 200, results.text
+
+
+def test_46_converted_smb_user_passb_entry_exists(request):
+    """
+    At this point the non-SMB user has been converted to an SMB user. Verify
+    that a passdb entry was appropriately generated.
+    """
+    depends(request, ["NON_SMB_USER_CREATED"])
+    cmd = "midclt call smb.passdb_list true"
+    results = SSH_TEST(cmd, user, password, ip)
+    assert results['result'] is True, results['output']
+    pdb_list = json.loads(results['output'])
+    my_entry = None
+    for entry in pdb_list:
+        if entry['Unix username'] == "testuser3":
+            my_entry = entry
+            break
+
+    assert my_entry is not None, results['output']
+    if my_entry is not None:
+        assert my_entry["Account Flags"] == "[U          ]", str(my_entry)
+
+
+def test_47_deleting_non_smb_user(request):
     depends(request, ["NON_SMB_USER_CREATED"])
     results = DELETE(f"/user/id/{user_id}/", {"delete_group": True})
     assert results.status_code == 200, results.text
 
 
-def test_42_destroying_home_dataset(request):
+def test_48_destroying_home_dataset(request):
     depends(request, ["HOME_DS_CREATED"])
     results = DELETE(f"/pool/dataset/id/{dataset_url}/")
     assert results.status_code == 200, results.text


### PR DESCRIPTION
Expand tests to explicitly verify the following:
- Users are actually being created
- changing "smb" from True to False results in passdb removal
- changing "smb" from False to True results in passdb addition

Related to NAS-107135