### PR TITLE
NAS-107142 / 12.0 / Add tests for SMB groupmaps

### DIFF
--- a/tests/api2/group.py
+++ b/tests/api2/group.py
@@ -6,11 +6,14 @@
 
 import sys
 import os
+import json
+import pytest
 
 apifolder = os.getcwd()
 sys.path.append(apifolder)
 from functions import GET, POST, PUT, DELETE, SSH_TEST
 from auto_config import user, password, ip
+from pytest_dependency import depends
 
 GroupIdFile = "/tmp/.ixbuild_test_groupid"
 
@@ -23,11 +26,12 @@ def test_01_get_next_gid():
 
 
 # Create tests
-def test_02_greating_group_testgroup():
+def test_02_creating_group_testgroup():
     global groupid
     payload = {
         "gid": next_gid,
-        "name": "testgroup"
+        "name": "testgroup",
+        "smb": False,
     }
     results = POST("/group/", payload)
     assert results.status_code == 200, results.text
@@ -38,38 +42,53 @@ def test_03_look_group_is_created():
     assert len(GET('/group?group=testgroup').json()) == 1
 
 
-def test_04_get_group_info():
+def test_04_check_group_exists():
+    """
+    get_group_obj is a wrapper around the grp module.
+    This check verifies that the group is _actually_ created.
+    """
+    payload = {
+        "groupname": "testgroup"
+    }
+    results = POST("/group/get_group_obj/", payload)
+    assert results.status_code == 200, results.text
+    if results.status_code == 200:
+        gr = results.json()
+        assert gr['gr_gid'] == next_gid, results.text
+
+
+def test_05_get_group_info():
     global groupinfo
     groupinfo = GET('/group?group=testgroup').json()[0]
 
 
-def test_05_look_group_name():
+def test_06_look_group_name():
     assert groupinfo["group"] == "testgroup"
 
 
-def test_06_look_group_full_name():
+def test_07_look_group_full_name():
     assert groupinfo["gid"] == next_gid
 
 
-def test_07_look_for_testgroup_is_in_freenas_group():
+def test_08_look_for_testgroup_is_in_freenas_group():
     cmd = 'getent group | grep -q testgroup'
-    results = SSH_TEST(cmd, 'root', 'testing', ip)
+    results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is True, results['output']
 
 
-def test_08_get_new_next_gid():
+def test_09_get_new_next_gid():
     results = GET('/group/get_next_gid/')
     assert results.status_code == 200, results.text
     global new_next_gid
     new_next_gid = results.json()
 
 
-def test_09_next_gid_and_new_next_gid_not_equal():
+def test_10_next_gid_and_new_next_gid_not_equal():
     assert new_next_gid != next_gid
 
 
 # Update the testgroup
-def test_10_udating_group_testgroup():
+def test_11_updating_group_testgroup():
     payload = {
         "gid": new_next_gid,
         "name": "newgroup"
@@ -93,27 +112,161 @@ def test_14_look_user_new_uid():
 
 def test_15_look_for_testgroup_is_not_in_freenas_group():
     cmd = 'getent group | grep -q testgroup'
-    results = SSH_TEST(cmd, 'root', 'testing', ip)
+    results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is False, results['output']
 
 
 def test_16_look_for_newgroup_is_in_freenas_group():
     cmd = 'getent group | grep -q newgroup'
-    results = SSH_TEST(cmd, 'root', 'testing', ip)
+    results = SSH_TEST(cmd, user, password, ip)
     assert results['result'] is True, results['output']
 
 
+def test_17_convert_to_smb_group():
+    payload = {
+        "smb": True,
+    }
+    results = PUT("/group/id/%s" % groupid, payload)
+    assert results.status_code == 200, results.text
+
+
+def test_18_check_groupmap_added():
+    """
+    Changing "smb" from False to True should result in
+    insertion into group_mapping.tdb.
+    """
+    cmd = 'midclt call smb.groupmap_list'
+    results = SSH_TEST(cmd, user, password, ip)
+    assert results['result'] is True, results['output']
+    if results['result'] is True:
+        groupmap = (json.loads(results['output'])).get('newgroup')
+        assert groupmap is not None, results['output']
+
+
 # Delete the group
-def test_17_delete_group_testgroup_newgroup():
+def test_19_delete_group_testgroup_newgroup():
     results = DELETE(f"/group/id/{groupid}/", {"delete_users": True})
     assert results.status_code == 200, results.text
 
 
-def test_18_look_group_is_delete():
+def test_20_look_group_is_delete():
     assert len(GET('/group?group=newuser').json()) == 0
 
 
-def test_19_look_for_newgroup_is_not_in_freenas_group():
+def test_21_look_for_newgroup_is_not_in_freenas_group():
     cmd = 'getent group | grep -q newgroup'
     results = SSH_TEST(cmd, 'root', 'testing', ip)
     assert results['result'] is False, results['output']
+
+
+# Test new SMB groupmap
+def test_22_get_next_gid():
+    results = GET('/group/get_next_gid/')
+    assert results.status_code == 200, results.text
+    global next_gid
+    next_gid = results.json()
+
+
+# Create tests
+@pytest.mark.dependency(name="SMB_GROUP_CREATED")
+def test_23_creating_smb_group():
+    global groupid
+    payload = {
+        "gid": next_gid,
+        "name": "smbgroup",
+        "smb": True,
+    }
+    results = POST("/group/", payload)
+    assert results.status_code == 200, results.text
+    groupid = results.json()
+
+
+def test_24_check_groupmap_added(request):
+    """
+    Creating new group with "smb" = True should result in insertion into
+    group_mapping.tdb.
+    """
+    depends(request, ["SMB_GROUP_CREATED"])
+    cmd = 'midclt call smb.groupmap_list'
+    results = SSH_TEST(cmd, user, password, ip)
+    assert results['result'] is True, results['output']
+    global groupmap
+    if results['result'] is True:
+        groupmap = (json.loads(results['output'])).get('smbgroup')
+        assert groupmap is not None, results['output']
+
+
+def test_25_test_name_change_smb_group(request):
+    depends(request, ["SMB_GROUP_CREATED"])
+    payload = {
+        "name": "newsmbgroup"
+    }
+    results = PUT("/group/id/%s" % groupid, payload)
+    assert results.status_code == 200, results.text
+
+
+def test_26_old_groupmap_removed_after_name_change(request):
+    """
+    "net groupmap list" does not show group mappings for unix groups that no
+    longer exist. For this reason, we must use tdbdump to verify that the old
+    SID entry has been properly removed. Stale groupmap entries may cause
+    difficult-to-diagnose group mapping issues.
+    """
+    depends(request, ["SMB_GROUP_CREATED"])
+    cmd = 'tdbdump /var/db/system/samba4/group_mapping.tdb'
+    results = SSH_TEST(cmd, user, password, ip)
+    assert results['result'] is True, results['output']
+    if results['result'] is True:
+        for entry in results['output'].splitlines():
+            assert groupmap['SID'] not in entry, entry
+
+
+def test_27_new_groupmap_added_after_name_change(request):
+    """
+    Verify that new groupmap entry was inserted with correct
+    group name.
+    """
+    depends(request, ["SMB_GROUP_CREATED"])
+    cmd = 'midclt call smb.groupmap_list'
+    results = SSH_TEST(cmd, user, password, ip)
+    assert results['result'] is True, results['output']
+    if results['result'] is True:
+        groupmap = (json.loads(results['output'])).get('newsmbgroup')
+        assert groupmap is not None, results['output']
+
+
+def test_28_convert_smb_group_to_non_smb(request):
+    depends(request, ["SMB_GROUP_CREATED"])
+    payload = {
+        "smb": False
+    }
+    results = PUT("/group/id/%s" % groupid, payload)
+    assert results.status_code == 200, results.text
+
+
+def test_29_groupmap_deleted_after_smb_change(request):
+    """
+    Verify that new groupmap entry was deleted after change to "smb" = False.
+    """
+    depends(request, ["SMB_GROUP_CREATED"])
+    cmd = 'midclt call smb.groupmap_list'
+    results = SSH_TEST(cmd, user, password, ip)
+    assert results['result'] is True, results['output']
+    if results['result'] is True:
+        groupmap = (json.loads(results['output'])).get('newsmbgroup')
+        assert groupmap is None, results['output']
+
+
+def test_30_delete_group_smb_newgroup(request):
+    depends(request, ["SMB_GROUP_CREATED"])
+    results = DELETE(f"/group/id/{groupid}/", {"delete_users": True})
+    assert results.status_code == 200, results.text
+
+
+def test_31_verify_group_deleted(request):
+    depends(request, ["SMB_GROUP_CREATED"])
+    payload = {
+        "groupname": "newsmbgroup"
+    }
+    results = POST("/group/get_group_obj/", payload)
+    assert results.status_code == 500, results.text


### PR DESCRIPTION
Same procedure as for user passdb entries. Verify that groupmaps are
added and deleted as necessary. Initial group creation test performed
with "smb" = False to isolate group generation issues from groupmap
issues.

related to NAS-107135