### PR TITLE
NAS-107144 / 11.3 / Fix random serial generation for extents

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi.py
+++ b/src/middlewared/middlewared/plugins/iscsi.py
@@ -827,7 +827,7 @@ class iSCSITargetExtentService(CRUDService):
                        )[0]
                 mac = nic['state']['link_address'].replace(':', '').strip()
 
-                ltg = await self.query([], {'order_by': ['id']})
+                ltg = await self.middleware.call('datastore.query', self._config.datastore, [], {'order_by': ['id']})
                 if len(ltg) > 0:
                     lid = ltg[-1]['id']
                 else:


### PR DESCRIPTION
This commit fixes an issue in 11.3 where datastore query prefixes all fields with service supplied prefix. This does not work well with id field as it's simple id and prefixing it with service prefix results in column not being found. In 12, the design is different where we search for the column before adding prefix and then later default to adding prefix if present.
The right fix would be to fix the datastore behaviour but to keep the changes minimal, I am fixing the effect. I ensured that we have no other usage of a service using order by with id and being affected in 11.3