### PR TITLE
NAS-107148 / 12.1 / Generate a random default serial extent

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi.py
+++ b/src/middlewared/middlewared/plugins/iscsi.py
@@ -14,6 +14,7 @@ import errno
 import hashlib
 import re
 import os
+import secrets
 try:
     import sysctl
 except ImportError:
@@ -855,8 +856,8 @@ class iSCSITargetExtentService(SharingService):
                 else:
                     return f'{mac[:15-max(3, len(str(lid)))]}{lid:03}'[:15]
             except Exception:
-                self.logger.error('Failed to generate serial, using a default', exc_info=True)
-                return '10000001'
+                self.logger.error('Failed to generate serial, generating a random default', exc_info=True)
+                return secrets.token_hex()[:15]
         else:
             return serial
 


### PR DESCRIPTION
If we fail setting up extent for some reason, this commit ensures we still generate a radom default which the extent can consume