### PR TITLE
NAS-107148 / 11.3 / Generate a random default serial extent (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/iscsi.py
+++ b/src/middlewared/middlewared/plugins/iscsi.py
@@ -17,6 +17,7 @@ import errno
 import hashlib
 import re
 import os
+import secrets
 import subprocess
 import sysctl
 import uuid
@@ -834,8 +835,8 @@ class iSCSITargetExtentService(CRUDService):
                     lid = 0
                 return f'{mac[:15-max(3, len(str(lid)))]}{lid:03}'[:15]
             except Exception:
-                self.logger.error('Failed to generate serial, using a default', exc_info=True)
-                return '10000001'
+                self.logger.error('Failed to generate serial, generating a random default', exc_info=True)
+                return secrets.token_hex()[:15]
         else:
             return serial
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 60bbd4090fb482f0b9bdc8a01ade8bbdc8d3961b

If we fail setting up extent for some reason, this commit ensures we still generate a radom default which the extent can consume