### PR TITLE
NAS-106875 / 12.1 / Add directory services stats to usage plugin

### DIFF
--- a/src/middlewared/middlewared/plugins/usage.py
+++ b/src/middlewared/middlewared/plugins/usage.py
@@ -137,6 +137,18 @@ class UsageService(Service):
             'ha_licensed': await self.middleware.call('failover.licensed'),
         }
 
+    async def gather_directory_service_stats(self, context):
+        config = await self.middleware.call('ldap.config')
+        return {
+            'directory_services': {
+                'state': await self.middleware.call('directoryservices.get_state'),
+                'ldap': {
+                    'kerberos_realm_populated': bool(config['kerberos_realm']),
+                    'has_samba_schema': config['has_samba_schema'],
+                },
+            },
+        }
+
     async def gather_cloud_services(self, context):
         return {
             'cloud_services': list({


### PR DESCRIPTION
We have the following stats gathered for directory services:
```
{
  "directory_services": {
    "state": {
      "activedirectory": "DISABLED",
      "ldap": "DISABLED",
      "nis": "DISABLED"
    },
    "kerberos_realm_populated": false,
    "has_samba_schema": false
  }
}
```