### PR TITLE
NAS-107154 / 12.1 / Fix issue with smb share generation

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4_share.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4_share.conf
@@ -71,7 +71,7 @@
 
         try:
             if middleware.call_sync('cache.get', 'SMB_REG_INITIALIZED') is True:
-                return
+                return middleware.call_sync('sharing.smb.sync_registry')
         except KeyError:
             pass
 

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1147,6 +1147,10 @@ class SharingSMBService(SharingService):
             return
 
         active_shares = await self.query([('locked', '=', False), ('enabled', '=', True)])
+        for share in active_shares:
+            if share['home']:
+                share['name'] = 'homes'
+
         registry_shares = await self.middleware.call('sharing.smb.reg_listshares')
         cf_active = set([x['name'].casefold() for x in active_shares])
         cf_reg = set([x.casefold() for x in registry_shares])


### PR DESCRIPTION
In some edge cases it appears that the registry can become out of sync with our
configuration. There are two different ways this is handled.

1) unitialized registry - write share config to /usr/local/etc/smb4_share.conf
   This occurs during system dataset moves, and is imported into regsitry in its
   entirety later on.

2) initialized registry - re-sync registry using sharing.smb.sync_registry

This PR makes etc.generate smb_share a wrapper around registry synchronization so
that we're more careful to add / remove shares as needed. A bug in parsing share
names for [HOMES] shares is also fixed.