### PR TITLE
NAS-107035 / 12.0 / Properly calculate swap partition size on 4k sector disks (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/format.py
+++ b/src/middlewared/middlewared/plugins/disk_/format.py
@@ -25,7 +25,7 @@ class DiskService(Service):
             raise CallError(f'Failed to wipe disk {disk}: {job.error}')
 
         # Calculate swap size.
-        swapsize = swapgb * 1024 * 1024 * 2
+        swapsize = swapgb * 1024 * 1024 * 1024 / (disk_details["sectorsize"] or 512)
         # Round up to nearest whole integral multiple of 128
         # so next partition starts at mutiple of 128.
         swapsize = (int((swapsize + 127) / 128)) * 128


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 9eafdf906e8dbeb21e1e9144753343028f073a36

@william-gr I'll backport from 12.0 to 12.1

Original PR: https://github.com/freenas/freenas/pull/5373