### PR TITLE
NAS-107166 / 11.3 / Move NFS kerberos SPN setup into separate function

### DIFF
--- a/src/middlewared/middlewared/etc_files/rc.conf.py
+++ b/src/middlewared/middlewared/etc_files/rc.conf.py
@@ -153,6 +153,10 @@ def services_config(middleware, context):
 
 
 def nfs_config(middleware, context):
+    # nfs.extend() method checks contents of keytab for
+    # nfs service principal name entries. Ensure that
+    # system keytab is generated before this point.
+    middleware.call_sync('etc.generate', 'kerberos')
     nfs = middleware.call_sync('nfs.config')
 
     mountd_flags = ['-rS']

--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -856,6 +856,18 @@ class KerberosKeytabService(CRUDService):
         return sorted(kerberos_principals)
 
     @private
+    async def has_nfs_principal(self):
+        """
+        This method checks whether the kerberos keytab contains an nfs service principal
+        """
+        principals = await self.kerberos_principal_choices()
+        for p in principals:
+            if p.startswith("nfs/"):
+                return True
+
+        return False
+
+    @private
     async def store_samba_keytab(self):
         """
         Samba will automatically generate system keytab entries for the AD machine account

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -25,9 +25,8 @@ class NFSService(SystemServiceService):
 
     @private
     async def nfs_extend(self, nfs):
-        nfs["v4_krb_enabled"] = (
-            nfs["v4_krb"] or bool(await self.middleware.call("datastore.query", "directoryservice.kerberoskeytab"))
-        )
+        keytab_has_nfs = await self.middleware.call("kerberos.keytab.has_nfs_principal")
+        nfs["v4_krb_enabled"] = (nfs["v4_krb"] or keytab_has_nfs)
         nfs["userd_manage_gids"] = nfs.pop("16")
         return nfs
 
@@ -103,10 +102,8 @@ class NFSService(SystemServiceService):
         new.update(data)
 
         verrors = ValidationErrors()
-
-        new_v4_krb_enabled = (
-            new["v4_krb"] or bool(await self.middleware.call("datastore.query", "directoryservice.kerberoskeytab"))
-        )
+        keytab_has_nfs = await self.middleware.call("kerberos.keytab.has_nfs_principal")
+        new_v4_krb_enabled = new["v4_krb"] or keytab_has_nfs
 
         if new["v4"] and new_v4_krb_enabled and not await self.middleware.call("system.is_freenas"):
             if await self.middleware.call("failover.licensed"):


### PR DESCRIPTION
This is to provide support a mechanism to add these entries after
the fact, and is a prep step for providing APIs for the webui team
to prompt users to add kerberos SPNs to AD in the NFS form (if AD
is enabled).

Regression test added in NAS-107169