### PR TITLE
NAS-107166 / 12.0 / Move NFS kerberos SPN setup into separate function (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/nfsd.py
+++ b/src/middlewared/middlewared/etc_files/nfsd.py
@@ -5,10 +5,10 @@ from middlewared.utils import run
 logger = logging.getLogger(__name__)
 
 
-async def get_exports(middleware, config, shares, kerberos_keytabs):
+async def get_exports(middleware, config, shares, has_nfs_principal):
     result = []
 
-    sec = await middleware.call("nfs.sec", config, kerberos_keytabs)
+    sec = await middleware.call("nfs.sec", config, has_nfs_principal)
     if sec:
         result.append(f"V4: / -sec={':'.join(sec)}")
 
@@ -80,9 +80,9 @@ async def render(service, middleware):
 
     shares = await middleware.call("sharing.nfs.query", [["enabled", "=", True]])
 
-    kerberos_keytabs = await middleware.call("kerberos.keytab.query")
+    has_nfs_principal = await middleware.call('kerberos.keytab.has_nfs_principal')
 
     with open("/etc/exports", "w") as f:
-        f.write(await get_exports(middleware, config, shares, kerberos_keytabs))
+        f.write(await get_exports(middleware, config, shares, has_nfs_principal))
 
     await run("service", "mountd", "quietreload", check=False)

--- a/src/middlewared/middlewared/etc_files/rc.conf.py
+++ b/src/middlewared/middlewared/etc_files/rc.conf.py
@@ -153,6 +153,10 @@ def services_config(middleware, context):
 
 
 def nfs_config(middleware, context):
+    # nfs.extend() method checks contents of keytab for
+    # nfs service principal name entries. Ensure that
+    # system keytab is generated before this point.
+    middleware.call_sync('etc.generate', 'kerberos')
     nfs = middleware.call_sync('nfs.config')
 
     mountd_flags = ['-rS']

--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -671,18 +671,12 @@ class ActiveDirectoryService(ConfigService):
                 keytab so that the NFS principal will be available for gssd.
                 """
                 job.set_progress(60, 'Adding NFS Principal entries.')
-                must_update_trust_pw = await self._net_ads_setspn([
-                    f'nfs/{ad["netbiosname"].upper()}.{ad["domainname"]}',
-                    f'nfs/{ad["netbiosname"].upper()}'
-                ])
-                if must_update_trust_pw:
-                    try:
-                        await self.change_trust_account_pw()
-                    except Exception as e:
-                        self.logger.debug(
-                            "Failed to change trust password after setting NFS SPN: [%s]."
-                            "This may impact kerberized NFS sessions until the next scheduled trust account password change", e
-                        )
+
+                try:
+                    await self.add_nfs_spn(ad)
+                except Exception:
+                    self.logger.warning("Failed to add NFS spn to active directory "
+                                        "computer object.", exc_info=True)
 
                 job.set_progress(70, 'Storing computer account keytab.')
                 kt_id = await self.middleware.call('kerberos.keytab.store_samba_keytab')
@@ -944,7 +938,7 @@ class ActiveDirectoryService(ConfigService):
         Only automatically add NFS SPN entries on domain join
         if kerberized nfsv4 is enabled.
         """
-        if not (await self.middleware.call('nfs.config'))['v4_krb_enabled']:
+        if not (await self.middleware.call('nfs.config'))['v4_krb']:
             return False
 
         for spn in spn_list:
@@ -953,9 +947,8 @@ class ActiveDirectoryService(ConfigService):
                 'add', spn
             ], check=False)
             if netads.returncode != 0:
-                self.logger.debug('Failed to set spn entry [%s]: %s',
-                                  spn, netads.stderr.decode().strip())
-                return False
+                raise CallError('failed to set spn entry '
+                                f'[{spn}]: {netads.stderr.decode().strip()}')
 
         return True
 
@@ -993,6 +986,22 @@ class ActiveDirectoryService(ConfigService):
                 f"Failed to update trust password: [{netads.stderr.decode().strip()}] "
                 f"stdout: [{netads.stdout.decode().strip()}] "
             )
+
+    @private
+    async def add_nfs_spn(self, ad=None):
+        if ad is None:
+            ad = await self.config()
+
+        ok = await self._net_ads_setspn([
+            f'nfs/{ad["netbiosname"].upper()}.{ad["domainname"]}',
+            f'nfs/{ad["netbiosname"].upper()}'
+        ])
+        if not ok:
+            return False
+
+        await self.change_trust_account_pw()
+
+        return True
 
     @accepts()
     async def domain_info(self):

--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -1042,6 +1042,18 @@ class KerberosKeytabService(CRUDService):
         return sorted(kerberos_principals)
 
     @private
+    async def has_nfs_principal(self):
+        """
+        This method checks whether the kerberos keytab contains an nfs service principal
+        """
+        principals = await self.kerberos_principal_choices()
+        for p in principals:
+            if p.startswith("nfs/"):
+                return True
+
+        return False
+
+    @private
     async def store_samba_keytab(self):
         """
         Samba will automatically generate system keytab entries for the AD machine account

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -44,9 +44,8 @@ class NFSService(SystemServiceService):
 
     @private
     async def nfs_extend(self, nfs):
-        nfs["v4_krb_enabled"] = (
-            nfs["v4_krb"] or bool(await self.middleware.call("kerberos.keytab.query"))
-        )
+        keytab_has_nfs = await self.middleware.call("kerberos.keytab.has_nfs_principal")
+        nfs["v4_krb_enabled"] = (nfs["v4_krb"] or keytab_has_nfs)
         nfs["userd_manage_gids"] = nfs.pop("16")
         return nfs
 
@@ -162,9 +161,8 @@ class NFSService(SystemServiceService):
 
         verrors = ValidationErrors()
 
-        new_v4_krb_enabled = (
-            new["v4_krb"] or bool(await self.middleware.call("kerberos.keytab.query"))
-        )
+        keytab_has_nfs = await self.middleware.call("kerberos.keytab.has_nfs_principal")
+        new_v4_krb_enabled = new["v4_krb"] or keytab_has_nfs
 
         if new["v4"] and new_v4_krb_enabled and not await self.middleware.call("system.is_freenas"):
             if await self.middleware.call("failover.licensed"):

--- a/src/middlewared/middlewared/plugins/nfs_/sec.py
+++ b/src/middlewared/middlewared/plugins/nfs_/sec.py
@@ -10,11 +10,11 @@ class NFSService(Service):
         datastore_extend = 'nfs.nfs_extend'
 
     @private
-    async def sec(self, config, kerberos_keytabs):
+    async def sec(self, config, has_nfs_principal):
         if config["v4"]:
             if config["v4_krb"]:
                 return ["krb5", "krb5i", "krb5p"]
-            elif kerberos_keytabs:
+            elif has_nfs_principal:
                 return ["sys", "krb5", "krb5i", "krb5p"]
             else:
                 return ["sys"]


### PR DESCRIPTION
This is to provide support a mechanism to add these entries after
the fact, and is a prep step for providing APIs for the webui team
to prompt users to add kerberos SPNs to AD in the NFS form (if AD
is enabled).

Regression test added in NAS-107169

Original PR: https://github.com/freenas/freenas/pull/5453