### PR TITLE
NAS-107367 / 20.10 / Correctly handle ACME certs using SAN

### DIFF
--- a/src/middlewared/middlewared/plugins/crypto.py
+++ b/src/middlewared/middlewared/plugins/crypto.py
@@ -1390,7 +1390,7 @@ class CertificateService(CRUDService):
 
         max_progress = (progress * 4) - progress - (progress * 4 / 5)
 
-        dns_mapping = {d.replace('*.', ''): v for d, v in domain_names_dns_mapping.items()}
+        dns_mapping = {d.replace('*.', '').split('DNS:', 1)[-1]: v for d, v in domain_names_dns_mapping.items()}
         for authorization_resource in order.authorizations:
             try:
                 status = False


### PR DESCRIPTION
When domain names are specified for SAN, we prefix them with 'DNS:' following with the cert standards, during acme authorisation, ACME server strips them and sends the authorisation for the domain name. We should handle this gracefully and strip out the prefix on our end as well confirming authorisation for the ACME order.