### PR TITLE
NAS-107315 / 20.10 / fix rsync mem leak when snapdir = visible

### DIFF
--- a/src/middlewared/middlewared/utils/osc/freebsd/user_context.py
+++ b/src/middlewared/middlewared/utils/osc/freebsd/user_context.py
@@ -69,7 +69,7 @@ def _run_command(user, commandline, q, rv):
 
 
 def run_command_with_user_context(commandline, user, callback):
-    q = Queue()
+    q = Queue(maxsize=100)
     rv = Value('i')
     stdout = b''
     p = Process(
@@ -86,6 +86,11 @@ def run_command_with_user_context(commandline, user, callback):
             callback(get)
         except queue.Empty:
             pass
+        except Exception:
+            logger.error('Unhandled exception', exc_info=True)
+            p.kill()
+            raise
+
     p.join()
 
     return subprocess.CompletedProcess(


### PR DESCRIPTION
- `queue.Full` exception in the producer was a no-op because the consumer didn't initiate the Queue() object with the `maxsize` keyword
- make sure we catch any other exception in the consumer and kill off the dangling process

Without these changes, there is a memory leak in a certain scenario with rsync tasks.
- if the `snapdir` zfs property is set to `visible` then rsync will try to delete/update contents in the `.zfs` directory
- this will fail, obviously, since that's a read-only area in the filesystem
- since the shared buffer could grow without bounds and because we're not catching any other exception in the consumer, there is a possibility of the buffer never getting freed