### PR TITLE
NAS-107385 / 20.10 / Use AES-256-CCM as default zfs cipher

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -493,7 +493,7 @@ class PoolService(CRUDService):
             'encryption_options',
             Bool('generate_key', default=False),
             Int('pbkdf2iters', default=350000, validators=[Range(min=100000)]),
-            Str('algorithm', default='AES-256-GCM', enum=ZFS_ENCRYPTION_ALGORITHM_CHOICES),
+            Str('algorithm', default='AES-256-CCM', enum=ZFS_ENCRYPTION_ALGORITHM_CHOICES),
             Str('passphrase', default=None, null=True, empty=False, private=True),
             Str('key', default=None, null=True, validators=[Range(min=64, max=64)], private=True),
             register=True


### PR DESCRIPTION
This commit adds changes to use AES-256-CCM as default cipher as it's faster then AES-256-GCM and is the default used by zfs(8)