### PR TITLE
Improve wording of verbose name for WORM_DROPBOX preset

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -153,7 +153,7 @@ class SMBSharePreset(enum.Enum):
             'ixnas:zfs_auto_homedir=true'
         ])
     }}
-    WORM_DROPBOX = {"verbose_name": "Files become readonly of SMB after 5 minutes", "params": {
+    WORM_DROPBOX = {"verbose_name": "SMB WORM. Files become readonly via SMB after 5 minutes", "params": {
         'path_suffix': '',
         'auxsmbconf': '\n'.join([
             'worm:grace_period = 300',


### PR DESCRIPTION
Include term WORM, but make it clear that this only works via the
SMB protocol.