### PR TITLE
NAS-107432 / 12.1 / disable offload capabilitie in interface test for core only

### DIFF
--- a/tests/api2/test_005_interface.py
+++ b/tests/api2/test_005_interface.py
@@ -10,7 +10,7 @@ import random
 
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from auto_config import ip, ha
+from auto_config import ip, ha, scale
 from functions import GET, PUT, POST
 
 if ha and "virtual_ip" in os.environ:
@@ -117,6 +117,9 @@ def test_08_set_main_interface_ipv4_to_false():
             }
         ]
     }
+
+    if any([ha, scale]) is False:
+        payload['disable_offload_capabilities'] = True
     results = PUT(f'/interface/id/{interface}/', payload)
     assert results.status_code == 200, results.text
     assert isinstance(results.json(), dict) is True, results.text


### PR DESCRIPTION
this will prevent jail, plugins and vm to affect NAS network