### PR TITLE
NAS-107438 / 11.3 / Reintroduce special behavior for HOMES path

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4_share.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4_share.conf
@@ -66,10 +66,42 @@
 
             return vfs_objects_ordered
 
+        def add_multiprocol_conf(db, share_conf, share_path, share_name):
+            """
+            If we detect that this share is also an AFP share, then enable cross-protocol
+            locking, and change the way alternate datastream naming syntax so that it matches
+            what netatalk does.
+
+            With NFS, turn off oplocks since FreeBSD doesn't currently support kernel oplocks
+            and force strict locking. In the case of detection of NFS/SMB shares, only look
+            at whether the SMB share's path is identical to or a parent of the NFS export. This
+            does not catch every possible edge case of the same data being shared, but it is an
+            acceptable compromise for now.
+            """
+            if any(filter(lambda x: f"{x['path']}/" in f"{share_path}/" or f"{share_path}/" in f"{x['path']}/", db['afp_shares'])):
+                logger.debug(f"SMB share ({share_name}) is also an AFP share. Applying parameters for mixed-protocol share.")
+                share_conf.update({
+                    "fruit:locking": "netatalk",
+                    "strict locking": "auto",
+                    "streams_xattr:prefix": "user.",
+                    "streams_xattr:store_stream_type": "no"
+                })
+                db['fruit_enabled'] = True
+
+            nfs_path_list = []
+            for export in db['nfs_exports']: nfs_path_list.extend(export['paths'])
+            if any(filter(lambda x: f"{share_path}/" in f"{x}/", nfs_path_list)):
+                logger.debug(f"SMB share ({share_name}) is also an NFS export. Applying parameters for mixed-protocol share.")
+                share_conf.update({
+                    "strict locking": "yes",
+                    "level2 oplocks": "no",
+                    "oplocks": "no"
+                })
+
         def parse_db_config(db):
             pc = {}
             for share in db['shares']:
-                if not os.path.exists(share['path']):
+                if not share['home'] and not os.path.exists(share['path']):
                     middleware.logger.warning('Path [%s] to share [%s] does not exist',
                                               share['path'], share['name'])
                     continue
@@ -111,36 +143,8 @@
                 if share['hostsdeny']:
                     pc[share["name"]].update({"hosts deny": share['hostsdeny']})
 
-                """
-                   If we detect that this share is also an AFP share, then enable cross-protocol
-                   locking, and change the way alternate datastream naming syntax so that it matches
-                   what netatalk does.
-
-                   With NFS, turn off oplocks since FreeBSD doesn't currently support kernel oplocks
-                   and force strict locking. In the case of detection of NFS/SMB shares, only look
-                   at whether the SMB share's path is identical to or a parent of the NFS export. This
-                   does not catch every possible edge case of the same data being shared, but it is an
-                   acceptable compromise for now.
-                """
-                if any(filter(lambda x: f"{x['path']}/" in f"{share['path']}/" or f"{share['path']}/" in f"{x['path']}/", db['afp_shares'])):
-                    logger.debug(f"SMB share ({share['name']}) is also an AFP share. Appling parameters for mixed-protocol share.")
-                    pc[share["name"]].update({
-                        "fruit:locking": "netatalk",
-                        "strict locking": "auto",
-                        "streams_xattr:prefix": "user.",
-                        "streams_xattr:store_stream_type": "no"
-                    })
-                    db['fruit_enabled'] = True
-
-                nfs_path_list = []
-                for export in db['nfs_exports']: nfs_path_list.extend(export['paths'])
-                if any(filter(lambda x: f"{share['path']}/" in f"{x}/", nfs_path_list)):
-                    logger.debug(f"SMB share ({share['name']}) is also an NFS export. Appling parameters for mixed-protocol share.")
-                    pc[share["name"]].update({
-                        "strict locking": "yes",
-                        "level2 oplocks": "no",
-                        "oplocks": "no"
-                    })
+                if share['path']:
+                    add_multiprocol_conf(db, pc[share["name"]], share["path"], share["name"])
 
                 if db['fruit_enabled']:
                     if "fruit" not in share['vfsobjects']:


### PR DESCRIPTION
The SMB plugin had undocumented behavior prior to 11.3 whereby in non-AD
enviorments, administrators could leave the SMB path empty for HOMES
shares and thereby allow samba to auto-generate the path based on the
user's home directory path configured in the GUI.