### PR TITLE
NAS-107438 / 20.10 / Reintroduce special behavior for HOMES path (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1032,17 +1032,27 @@ class SharingSMBService(SharingService):
 
     @private
     async def validate(self, data, schema_name, verrors, old=None):
+        """
+        Path is a required key in almost all cases. There is a special edge case for LDAP
+        [homes] shares. In this case we allow an empty path. Samba interprets this to mean
+        that the path should be dynamically set to the user's home directory on the LDAP server.
+        Local user auth to SMB shares is prohibited when LDAP is enabled with a samba schema.
+        """
         home_result = await self.home_exists(
             data['home'], schema_name, verrors, old)
 
         if home_result:
             verrors.add(f'{schema_name}.home',
                         'Only one share is allowed to be a home share.')
-        elif not home_result and not data['path']:
-            verrors.add(f'{schema_name}.path', 'This field is required.')
 
         if data['path']:
             await self.validate_path_field(data, schema_name, verrors)
+        elif not data['home']:
+            verrors.add(f'{schema_name}.path', 'This field is required.')
+        else:
+            ldap = await self.middleware.call('ldap.config')
+            if not ldap['enable'] or not ldap['has_samba_schema']:
+                verrors.add(f'{schema_name}.path', 'This field is required.')
 
         if data['auxsmbconf']:
             try:

--- a/src/middlewared/middlewared/plugins/smb_/registry.py
+++ b/src/middlewared/middlewared/plugins/smb_/registry.py
@@ -227,6 +227,40 @@ class SharingSMBService(Service):
         return await self.apply_conf_registry(share, confdiff)
 
     @private
+    async def add_multiprotocol_conf(self, conf, gl, data):
+        nfs_path_list = []
+        for export in gl['nfs_exports']:
+            nfs_path_list.extend(export['paths'])
+
+        if any(filter(lambda x: f"{conf['path']}/" in f"{x}/", nfs_path_list)):
+            self.logger.debug("SMB share [%s] is also an NFS export. "
+                              "Applying parameters for mixed-protocol share.", data['name'])
+            conf.update({
+                "strict locking": "yes",
+                "posix locking": "yes",
+                "level2 oplocks": "no",
+                "oplocks": "no"
+            })
+            if data['durablehandle']:
+                self.logger.warn("Disabling durable handle support on SMB share [%s] "
+                                 "due to NFS export of same path.", data['name'])
+                await self.middleware.call('datastore.update', 'sharing.cifs_share',
+                                           data['id'], {'cifs_durablehandle': False})
+                data['durablehandle'] = False
+
+        if any(filter(lambda x: f"{x['path']}/" in f"{conf['path']}/" or f"{conf['path']}/" in f"{x['path']}/", gl['afp_shares'])):
+            self.logger.debug("SMB share [%s] is also an AFP share. "
+                              "Applying parameters for mixed-protocol share.", data['name'])
+            conf.update({
+                "fruit:locking": "netatalk",
+                "fruit:metadata": "netatalk",
+                "fruit:resource": "file",
+                "strict locking": "auto",
+                "streams_xattr:prefix": "user.",
+                "streams_xattr:store_stream_type": "no"
+            })
+
+    @private
     async def share_to_smbconf(self, conf_in, globalconf=None):
         data = conf_in.copy()
         gl = await self.get_global_params(globalconf)
@@ -235,10 +269,14 @@ class SharingSMBService(Service):
 
         if data['home'] and gl['ad_enabled']:
             data['path_suffix'] = '%D/%U'
-        elif data['home']:
+        elif data['home'] and data['path']:
             data['path_suffix'] = '%U'
 
-        conf['path'] = '/'.join([data['path'], data['path_suffix']]) if data['path_suffix'] else data['path']
+        if data['path']:
+            conf['path'] = '/'.join([data['path'], data['path_suffix']]) if data['path_suffix'] else data['path']
+        else:
+            conf['path'] = ''
+
         if osc.IS_FREEBSD:
             data['vfsobjects'] = ['aio_fbsd']
         else:
@@ -256,25 +294,6 @@ class SharingSMBService(Service):
             conf["hosts deny"] = data['hostsdeny']
         conf["read only"] = "yes" if data['ro'] else "no"
         conf["guest ok"] = "yes" if data['guestok'] else "no"
-
-        nfs_path_list = []
-        for export in gl['nfs_exports']:
-            nfs_path_list.extend(export['paths'])
-
-        if any(filter(lambda x: f"{conf['path']}/" in f"{x}/", nfs_path_list)):
-            self.logger.debug("SMB share [%s] is also an NFS export. "
-                              "Applying parameters for mixed-protocol share.", data['name'])
-            conf.update({
-                "strict locking": "yes",
-                "level2 oplocks": "no",
-                "oplocks": "no"
-            })
-            if data['durablehandle']:
-                self.logger.warn("Disabling durable handle support on SMB share [%s] "
-                                 "due to NFS export of same path.", data['name'])
-                await self.middleware.call('datastore.update', 'sharing.cifs_share',
-                                           data['id'], {'cifs_durablehandle': False})
-                data['durablehandle'] = False
 
         if gl['fruit_enabled']:
             data['vfsobjects'].append('fruit')
@@ -343,23 +362,12 @@ class SharingSMBService(Service):
             conf["fruit:metadata"] = "stream"
             conf["fruit:resource"] = "stream"
 
-        if any(filter(lambda x: f"{x['path']}/" in f"{conf['path']}/" or f"{conf['path']}/" in f"{x['path']}/", gl['afp_shares'])):
-            self.logger.debug("SMB share [%s] is also an AFP share. "
-                              "Applying parameters for mixed-protocol share.", data['name'])
-            conf.update({
-                "fruit:locking": "netatalk",
-                "fruit:metadata": "netatalk",
-                "fruit:resource": "file",
-                "strict locking": "auto",
-                "streams_xattr:prefix": "user.",
-                "streams_xattr:store_stream_type": "no"
-            })
+        if conf["path"]:
+            await self.add_multiprotocol_conf(conf, gl, data['name'])
 
         if data['timemachine']:
             conf["fruit:time machine"] = "yes"
             conf["fruit:locking"] = "none"
-
-        nfs_path_list = []
 
         if data['recyclebin']:
             conf.update({


### PR DESCRIPTION
The SMB plugin had undocumented behavior prior to 11.3 whereby in non-AD
enviorments, administrators could leave the SMB path empty for HOMES
shares and thereby allow samba to auto-generate the path based on the
user's home directory path configured in the GUI.

Original PR: https://github.com/freenas/freenas/pull/5591