### PR TITLE
NAS-107432 / 11.3 / disable offload capabilitie in interface test for core only (by ericbsd)

### DIFF
--- a/tests/api2/interfaces.py
+++ b/tests/api2/interfaces.py
@@ -10,8 +10,8 @@ import random
 
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from auto_config import interface, ip
-from functions import GET, PUT, POST, DELETE
+from auto_config import interface, ip, ha
+from functions import GET, PUT, POST
 
 aliases = {'address': ip}
 
@@ -45,7 +45,6 @@ def test_02_get_interface_aliases_ip():
         if ip in aliases_list['address']:
             interface_ip = aliases_list['address']
     assert interface_ip == ip, results.text
-
 
 
 def test_03_get_interface_aliases_broadcast_ip():
@@ -106,6 +105,9 @@ def test_08_set_main_interface_ipv4_to_false():
             }
         ]
     }
+
+    if ha is False:
+        payload['disable_offload_capabilities'] = True
     results = PUT(f'/interface/id/{interface}/', payload)
     assert results.status_code == 200, results.text
     assert isinstance(results.json(), dict) is True, results.text


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 4cf22a1f8120af4446914f99d9416edf94c7035a

this will prevent jail, plugins and vm to affect NAS network

Original PR: https://github.com/freenas/freenas/pull/5590