### PR TITLE
NAS-107432 / 12.0 / disable offload capabilitie in interface test for core only (by ericbsd)

### DIFF
--- a/tests/api2/interfaces.py
+++ b/tests/api2/interfaces.py
@@ -10,7 +10,8 @@ import random
 
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from auto_config import interface, ip
+
+from auto_config import interface, ip, ha, scale
 from functions import GET, PUT, POST
 
 aliases = {'address': ip}
@@ -103,6 +104,9 @@ def test_08_set_main_interface_ipv4_to_false():
             }
         ]
     }
+
+    if any([ha, scale]) is False:
+        payload['disable_offload_capabilities'] = True
     results = PUT(f'/interface/id/{interface}/', payload)
     assert results.status_code == 200, results.text
     assert isinstance(results.json(), dict) is True, results.text


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 4cf22a1f8120af4446914f99d9416edf94c7035a

this will prevent jail, plugins and vm to affect NAS network

Original PR: https://github.com/freenas/freenas/pull/5590