### PR TITLE
NAS-107437 / 12.0 / Expand validation for user home directories (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/account.py
+++ b/src/middlewared/middlewared/plugins/account.py
@@ -21,6 +21,7 @@ import string
 import stat
 import subprocess
 import time
+from pathlib import Path
 
 SKEL_PATH = '/usr/share/skel/'
 
@@ -742,8 +743,18 @@ class UserService(CRUDService):
             )
 
         if 'home' in data:
+            p = Path(data['home'])
+            if not p.is_absolute():
+                verrors.add(f'{schema}.home', '"Home Directory" must be an absolute path.')
+                return
+
+            if p.is_file():
+                verrors.add(f'{schema}.home', '"Home Directory" cannot be a file.')
+                return
+
             if ':' in data['home']:
                 verrors.add(f'{schema}.home', '"Home Directory" cannot contain colons (:).')
+
             if data['home'] != '/nonexistent':
                 if not data['home'].startswith('/mnt/'):
                     verrors.add(
@@ -765,11 +776,26 @@ class UserService(CRUDService):
                         f'{schema}.home',
                         'Path component for "Home Directory" is currently encrypted and locked'
                     )
+                elif len(p.resolve().parents) == 2:
+                    verrors.add(
+                        f'{schema}.home',
+                        f'The specified path is a ZFS pool mountpoint "({data["home"]})" '
+                    )
 
         if 'home_mode' in data:
             try:
                 o = int(data['home_mode'], 8)
                 assert o & 0o777 == o
+                if o & (stat.S_IRUSR) == 0:
+                    verrors.add(
+                        f'{schema}.home_mode',
+                        'Home directory must be readable by User.'
+                    )
+                if o & (stat.S_IXUSR) == 0:
+                    verrors.add(
+                        f'{schema}.home_mode',
+                        'Home directory must be executable by User.'
+                    )
             except (AssertionError, ValueError, TypeError):
                 verrors.add(
                     f'{schema}.home_mode',


### PR DESCRIPTION
Re-implement validation from legacy_ui preventing users from setting zpool mountpoints as a home directory.

Require owner read and execute on a home directory.

Original PR: https://github.com/freenas/freenas/pull/5592