### PR TITLE
NAS-107456 / 20.10 / cpu model doesnt change after boot so cache the results

### DIFF
--- a/src/middlewared/middlewared/utils/osc/linux/system.py
+++ b/src/middlewared/middlewared/utils/osc/linux/system.py
@@ -8,10 +8,10 @@ logger = logging.getLogger(__name__)
 __all__ = ['get_cpu_model']
 
 
-RE_CPU_MODEL = re.compile(r'model name\s*:\s*(.*)')
+RE_CPU_MODEL = re.compile(r'^model name\s*:\s*(.*)')
 
 
 def get_cpu_model():
     with open('/proc/cpuinfo', 'r') as f:
-        model = RE_CPU_MODEL.findall(f.read())
-        return model[0].strip() if model else None
+        model = RE_CPU_MODEL.search(f.read(), re.M)
+        return model.group(1) if model else None


### PR DESCRIPTION
Profiling middlewared on SCALE showed 2 issues wrt to CPU model.

1. our regex was inefficient
2. repeatedly querying for the CPU model isn't logical since that is a static string that doesn't change after boot.