### PR TITLE
NAS-107459 / 11.3 / open file and then loop to reduce cpu cycles

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -1873,8 +1873,8 @@ class WBStatusThread(threading.Thread):
         self.state = new_state
 
     def read_messages(self):
-        while not self.finished.is_set():
-            with open('/var/run/samba4/.wb_fifo') as f:
+        with open('/var/run/samba4/.wb_fifo') as f:
+            while not self.finished.is_set():
                 data = f.read()
                 for msg in data.splitlines():
                     self.parse_msg(msg)


### PR DESCRIPTION
profiling middlewared has shown that activedirectory plugin uses quite a few cpu cycles. Instead of looping and opening the file repeatedly, open the file once and then loop.