### PR TITLE
NAS-107467 / 20.10 / optimize system.info

### DIFF
--- a/src/middlewared/middlewared/alert/base.py
+++ b/src/middlewared/middlewared/alert/base.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+import socket
 import enum
 import json
 import logging
@@ -243,7 +244,7 @@ class AlertService:
 
     async def _format_alerts(self, alerts, gone_alerts, new_alerts):
         product_name = await self.middleware.call("system.product_name")
-        hostname = (await self.middleware.call("system.info"))["hostname"]
+        hostname = socket.gethostname()
         if not await self.middleware.call("system.is_freenas"):
             node_map = await self.middleware.call("alert.node_map")
         else:
@@ -260,7 +261,7 @@ class ThreadedAlertService(AlertService):
 
     def _format_alerts(self, alerts, gone_alerts, new_alerts):
         product_name = self.middleware.call_sync("system.product_name")
-        hostname = self.middleware.call_sync("system.info")["hostname"]
+        hostname = socket.gethostname()
         if not self.middleware.call_sync("system.is_freenas"):
             node_map = self.middleware.call_sync("alert.node_map")
         else:

--- a/src/middlewared/middlewared/plugins/ups.py
+++ b/src/middlewared/middlewared/plugins/ups.py
@@ -6,6 +6,7 @@ import io
 import os
 import re
 import syslog
+import socket
 
 from middlewared.schema import accepts, Bool, Dict, Int, List, Str
 from middlewared.service import private, SystemServiceService, ValidationErrors
@@ -325,7 +326,7 @@ class UPSService(SystemServiceService):
                 # battery.runtime.low: 900
 
                 ups_name = config['identifier']
-                hostname = (await self.middleware.call('system.info'))['hostname']
+                hostname = socket.gethostname()
                 current_time = datetime.datetime.now(tz=dateutil.tz.tzlocal()).strftime('%a %b %d %H:%M:%S %Z %Y')
                 ups_subject = config['subject'].replace('%d', current_time).replace('%h', hostname)
                 body = f'NOTIFICATION: {notify_type!r}\n\nUPS: {ups_name!r}\n\n'


### PR DESCRIPTION
Generating flamegraphs of the main middlewared process on SCALE for ~38 mins, generating ~230k total samples, showed that of the successfully measured samples, 62% of CPU time is in the main asyncio event loop and of that percentage, 53% of the time is spent in the `system.info` method.

This PR does a few things to try and optimize that method:
1. the base module of the alert plugin was potentially calling `system.info` twice every 5 mins (by default) just to get the hostname. Instead just call `socket.gethostname()` like the `system.info` method was doing anyways
2. the ups plugin was also calling `system.info` to get the hostname. Instead just call `socket.gethostname()` like the `system.info` method was doing anyways
3. subprocess'ing out to run `uptime` isn't necessary as there are built-in ways using python
4. reduced the total number of times we query the kernel for time information as much as possible
5. physical memory size doesn't change after boot so cache the results
6. cpu core count doesn't change after boot so cache the results
7. birthdate of the system, after it has initially been set, doesn't change after boot so cache the results


After my above changes, sampling for roughly the same amount of time, middlewared's time spent on CPU for the asyncio main event loop dropped to 25% and the `system.info` CPU time is now only 16%. There are more areas to optimize, but this is significantly better.