### PR TITLE
NAS-106110 / 11.3 / Donot raise UPS alert during self test (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/ups.py
+++ b/src/middlewared/middlewared/plugins/ups.py
@@ -14,6 +14,8 @@ from middlewared.validators import Email, Range, Port
 
 
 DRIVER_BIN_DIR = '/usr/local/libexec/nut'
+RE_TEST_IN_PROGRESS = re.compile(r'ups.test.result:\s*TestInProgress')
+RE_UPS_STATUS = re.compile(r'ups.status: (.*)')
 
 
 class UPSService(SystemServiceService):
@@ -226,21 +228,22 @@ class UPSService(SystemServiceService):
     async def upssched_event(self, notify_type):
         config = await self.config()
         upsc_identifier = config['complete_identifier']
+        cp = await run('/usr/local/bin/upsc', upsc_identifier, check=False)
+        if cp.returncode:
+            stats_output = ''
+            self.logger.error('Failed to retrieve ups information: %s', cp.stderr.decode())
+        else:
+            stats_output = cp.stdout.decode()
+
+        if RE_TEST_IN_PROGRESS.search(stats_output):
+            self.logger.debug('Self test is in progress and %r notify event should be ignored', notify_type)
+            return
+
         if notify_type.lower() == 'shutdown':
             # Before we start FSD with upsmon, lets ensure that ups is not ONLINE (OL).
             # There are cases where battery/charger issues can result in ups.status being "OL LB" at the
             # same time. This will ensure that we don't initiate a shutdown if ups is OL.
-            stats_output = (
-                await run(
-                    '/usr/local/bin/upsc', upsc_identifier,
-                    check=False
-                )
-            ).stdout
-
-            ups_status = re.findall(
-                fr'ups.status: (.*)',
-                '' if not stats_output else stats_output.decode()
-            )
+            ups_status = RE_UPS_STATUS.findall(stats_output)
             if ups_status and 'ol' in ups_status[0].lower():
                 self.middleware.logger.debug(
                     f'Shutdown not initiated as ups.status ({ups_status[0]}) indicates '


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x ac692021d650b7937ac8a3a29bd7538cc0740e75

There are some UPS models which run a self test at scheduled intervals where they go on battery and back during the test. We should not raise an alert in this case as this is scheduled and expected and gives a false alarm.

Original PR: https://github.com/freenas/freenas/pull/5622