### PR TITLE
NAS-107488 / 20.10 / remove duplicate nfsstat calls in freenas-debug

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/nfs_freebsd/nfs.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/nfs_freebsd/nfs.sh
@@ -78,19 +78,11 @@ nfs_func()
 	nfsstat
 	section_footer
 
-	section_header "nfsstat -c"
-	nfsstat -c
-	section_footer
-
-	section_header "nfsstat -s"
-	nfsstat -s
-	section_footer
-
 	section_header "nfsv4 locks: nfsdumpstate"
 	nfsdumpstate
 	section_footer
 
-	section_header "Configuration"
+	section_header "Middleware Configuration"
 	midclt call nfs.config | jq
 	midclt call sharing.nfs.query | jq
 	section_footer


### PR DESCRIPTION
We already call `nfsstat` in this file. There is no reason to call it 2 more times specifying the server/client flags.