### PR TITLE
NAS-107501 / 12.0 / Fix pdbedit parsing when SMB service aux param invalid (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1022,6 +1022,21 @@ class SharingSMBService(SharingService):
                     'are not permitted.'
                 )
 
+            if schema_name == 'smb_update.smb_options' and ':' not in kv[0]:
+                """
+                lib/param doesn't validate params containing a colon.
+                this dump_a_parameter() wraps around the respective lp_ctx
+                function in samba that checks the known parameter table.
+                This should be a lightweight validation of GLOBAL params.
+                """
+                try:
+                    LP_CTX.dump_a_parameter(kv[0].strip())
+                except RuntimeError as e:
+                    verrors.add(
+                        f'{schema_name}.auxsmbconf',
+                        str(e)
+                    )
+
         verrors.check()
 
     @private

--- a/src/middlewared/middlewared/plugins/smb_/passdb.py
+++ b/src/middlewared/middlewared/plugins/smb_/passdb.py
@@ -118,6 +118,15 @@ class SMBService(Service):
         if entry == bsduser[0]['smbhash']:
             return
 
+        """
+        If an invalid global auxiliary parameter is present
+        in the smb.conf, then pdbedit will write error messages
+        to stdout (two for each invalid parameter, separated by \n).
+        The last line of output in this case will be the passdb entry
+        in smbpasswd format (-Lw). This is the reason why we pre-emptively
+        splitlines() and use last element of resulting list for our checks.
+        """
+        entry = entry.splitlines()[-1]
         entry = entry.split(':')
 
         if smbpasswd_string[3] != entry[3]:


### PR DESCRIPTION
When user adds invalid auxilary parameter(s) to the smb.conf, pdbedit
invocations (or any utilty that ultimately calls lpcfg_map_parameter()),
will result in additional warning messages being printed even at DEBUG 0
on stdout. This may break parsing of output from the CLI utility, and in
the case of pdbedit, will prevent updating of user password.

This commit will change two things. First is a minimal workaround for the
passdb update to splitlines() and use only last element of resulting list.
Warnings in this specific situation are prepended to the command's output
and so will be safely discarded. Additionally, validation for smb_options
(auxiliary parameters for the SMB service) will be expanded to add a
call to LoadParm.dump_a_parameter(<aux param>). This function will raise
a RuntimeException if the parameter being queried does not exist in Samba's
internal param table.

Original PR: https://github.com/freenas/freenas/pull/5636