### PR TITLE
NAS-107504 / 20.10 / Fix update.destroy_upload_location (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/update_/upload_location_freebsd.py
+++ b/src/middlewared/middlewared/plugins/update_/upload_location_freebsd.py
@@ -69,7 +69,7 @@ class UpdateService(Service):
         mddev = prov.text
 
         subprocess.run(
-            ['umount', f'/dev/label/{UPLOAD_LABEL}'], capture_output=True, check=False,
+            ['umount', UPLOAD_LOCATION], capture_output=True, check=False,
         )
         cp = subprocess.run(
             ['mdconfig', '-d', '-u', mddev],


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 9e0236f197d911731b19bf2fb6f496144fe78ba5



Original PR: https://github.com/freenas/freenas/pull/5646