### PR TITLE
NAS-107618 / 20.10 / freenas-debug: replace pdbedit with smb.passdb_list (by anodos325)

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/smb_freebsd/smb.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/smb_freebsd/smb.sh
@@ -139,7 +139,7 @@ smb_func()
 	section_footer
 
 	section_header "Local users in passdb.tdb"
-	pdbedit -Lv
+	midclt call smb.passdb_list true | jq
 	section_footer
 
 	section_header "Database Dump"


### PR DESCRIPTION
When the LDAP directory service is enabled with a samba schema, pdbedit
-L will perform synchronous LDAP queries to resolve every user in the
LDAP environment. This is somewhat undesireable. Replace this with a
call to middleware's smb.passdb_list, which will return an empty list if
the passdb backend is ldapsam.

Original PR: https://github.com/freenas/freenas/pull/5684