### PR TITLE
NAS-107650 / 20.10 / Fix TypeError: 'NoneType' object is not subscriptable (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/disk_/encryption_freebsd.py
+++ b/src/middlewared/middlewared/plugins/disk_/encryption_freebsd.py
@@ -375,6 +375,9 @@ class DiskService(Service, DiskEncryptionBase):
 
         for g in klass_part.geoms:
             for p in g.providers:
+                if p.config is None:
+                    continue
+
                 if p.config['type'] != 'freebsd-zfs':
                     continue
 

--- a/src/middlewared/middlewared/plugins/disk_/identify_freebsd.py
+++ b/src/middlewared/middlewared/plugins/disk_/identify_freebsd.py
@@ -23,6 +23,8 @@ class DiskService(Service, DiskIdentifyBase):
         if klass:
             for g in filter(lambda v: v.name == name, klass.geoms):
                 for p in g.providers:
+                    if p.config is None:
+                        continue
                     if p.config['rawtype'] in await self.middleware.call('disk.get_valid_zfs_partition_type_uuids'):
                         return f'{{uuid}}{p.config["rawuuid"]}'
 


### PR DESCRIPTION
Found the following in Damian's middleware log, happened more than once
```
[2020/09/20 07:36:36] (ERROR) middlewared.job.run():373 - Job <bound method accepts.<locals>.wrap.<locals>.nf of <middlewared.plugins.disk_.sync.DiskService object at 0x81a27abe0>>
 failed
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/middlewared/job.py", line 361, in run
    await self.future
  File "/usr/local/lib/python3.8/site-packages/middlewared/job.py", line 397, in __run_body
    rv = await self.method(*([self] + args))
  File "/usr/local/lib/python3.8/site-packages/middlewared/schema.py", line 973, in nf
    return await f(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/middlewared/plugins/disk_/sync.py", line 103, in sync_all
    await self.middleware.call('disk.device_to_identifier', name) != disk['disk_identifier']
  File "/usr/local/lib/python3.8/site-packages/middlewared/main.py", line 1233, in call
    return await self._call(
  File "/usr/local/lib/python3.8/site-packages/middlewared/main.py", line 1191, in _call
    return await methodobj(*prepared_call.args)
  File "/usr/local/lib/python3.8/site-packages/middlewared/schema.py", line 973, in nf
    return await f(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/middlewared/plugins/disk_/identify_freebsd.py", line 26, in device_to_identifier
    if p.config['rawtype'] in await self.middleware.call('disk.get_valid_zfs_partition_type_uuids'):
TypeError: 'NoneType' object is not subscriptable
```

Original PR: https://github.com/freenas/freenas/pull/5702