### PR TITLE
NAS-107353 / 20.10 / Bug fixes for VM's status reporting

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/supervisor/supervisor_base.py
+++ b/src/middlewared/middlewared/plugins/vm/supervisor/supervisor_base.py
@@ -63,10 +63,11 @@ class VMSupervisorBase(LibvirtConnectionMixin):
 
     def status(self):
         domain = self.domain
+        domain_state = DomainState(domain.state()[0])
         return {
             'state': 'STOPPED' if not domain.isActive() else 'RUNNING',
-            'pid': None if not domain.isActive() else self.domain.ID(),
-            'domain_state': DomainState(domain.state()[0]).name,
+            'pid': self.domain.ID() if domain_state == DomainState.RUNNING else None,
+            'domain_state': domain_state.name,
         }
 
     def __define_domain(self):


### PR DESCRIPTION
This PR fixes following issues:
1) Only get pid of a VM if it's in running state
2) On FreeBSD the ID of a VM in libvirt terms is the PID but in SCALE, this is different and the python client does not provide us with a mechanism to get the pid of a VM. So changes have been introduced to correctly retrieve the PID of the VM in scale.