### PR TITLE
NAS-107666 / 20.10 / Retrieve internally logged zfs events with user initiated events in debug

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/zfs/zfs.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/zfs/zfs.sh
@@ -60,8 +60,8 @@ zfs_func()
 	zpool status -v
 	section_footer
 
-	section_header "zpool history"
-	zpool history
+	section_header "zpool history -i"
+	zpool history -i
 	section_footer
 
 	section_header "zpool get all"


### PR DESCRIPTION
Support requests that we retrieve internally logged zfs events as well in the debug generated by system. This commit introduces that change.