### PR TITLE
NAS-107682 / 20.10 / fix regression in network general on SCALE HA

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -214,7 +214,7 @@ class NetworkConfigurationService(ConfigService):
         Discovery support.
         """
         config = await self.config()
-        new_config = config.copy()
+        new_config = data.copy()
 
         verrors = await self.validate_general_settings(data, 'global_configuration_update')
 
@@ -239,6 +239,10 @@ class NetworkConfigurationService(ConfigService):
         # pop the `hostname_local` key since that's created in the _extend method
         # and doesn't exist in the database
         new_hostname = new_config.pop('hostname_local', None)
+
+        # normalize the `domains` and `netwait_ip` keys
+        new_config['domains'] = ' '.join(new_config.get('domains', []))
+        new_config['netwait_ip'] = ' '.join(new_config.get('netwait_ip', []))
 
         # update the db
         await self.middleware.call(

--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -214,7 +214,8 @@ class NetworkConfigurationService(ConfigService):
         Discovery support.
         """
         config = await self.config()
-        new_config = data.copy()
+        new_config = config.copy()
+        new_config.update(data)
 
         verrors = await self.validate_general_settings(data, 'global_configuration_update')
 


### PR DESCRIPTION
I fixed 2 or 3 issues and optimized the network general section in commit: 38cd173fc2beb166aa7c2d2e0b0839e22ebf021d

However, I introduced 3 subtle regressions.

1. new_config was not being updated with the passed in data
2. domains key was not normalized before being written to db
3. netwait_ip key was not normalized before being written to db

This fixes all of the above issues.