### PR TITLE
NAS-107684 / 20.10 / Remove random sleeps in k8s lifecycle management

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/netif_linux/netif.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/netif.py
@@ -27,7 +27,7 @@ def create_interface(name):
 
 
 def destroy_interface(name):
-    if name.startswith(("bond", "br", "vlan")):
+    if name.startswith(("bond", "br", "vlan", "kube-bridge")):
         run(["ip", "link", "delete", name])
     else:
         run(["ip", "link", "set", name, "down"])

--- a/src/middlewared/middlewared/plugins/interface/type_linux.py
+++ b/src/middlewared/middlewared/plugins/interface/type_linux.py
@@ -9,7 +9,7 @@ class InterfaceService(Service, InterfaceTypeBase):
         namespace_alias = 'interfaces'
 
     async def type(self, iface_state):
-        if iface_state['name'].startswith('br'):
+        if iface_state['name'].startswith(('br', 'kube-bridge')):
             return InterfaceType.BRIDGE
         elif iface_state['name'].startswith('bond'):
             return InterfaceType.LINK_AGGREGATION

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/cni.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/cni.py
@@ -38,7 +38,7 @@ class KubernetesCNIService(ConfigService):
         await self.middleware.call('service.start', 'kuberouter')
 
         rt = netif.RoutingTable()
-        timeout = 10
+        timeout = 60
         while timeout > 0:
             if 'kube-router' not in rt.routing_tables:
                 await asyncio.sleep(2)

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/cni.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/cni.py
@@ -36,7 +36,19 @@ class KubernetesCNIService(ConfigService):
         )
         await self.middleware.call('etc.generate', 'cni')
         await self.middleware.call('service.start', 'kuberouter')
-        await asyncio.sleep(5)
+
+        rt = netif.RoutingTable()
+        timeout = 10
+        while timeout > 0:
+            if 'kube-router' not in rt.routing_tables:
+                await asyncio.sleep(2)
+                timeout -= 2
+            else:
+                break
+
+        if 'kube-router' not in rt.routing_tables:
+            raise CallError('Unable to locate kube-router routing table. Please refer to kuberouter logs.')
+
         await self.middleware.call('k8s.cni.add_user_route_to_kube_router_table')
 
     async def validate_cni_integrity(self, cni, config=None):

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -112,9 +112,6 @@ class KubernetesService(Service):
     async def status_change_internal(self):
         await self.validate_k8s_fs_setup()
         await self.middleware.call('service.start', 'docker')
-        # This is necessary because docker daemon requires a couple of seconds after starting to initialise itself
-        # properly, if we try to load images without the delay that will fail and will only correct after a restart
-        await asyncio.sleep(5)
         await self.middleware.call('docker.images.load_default_images')
         asyncio.ensure_future(self.middleware.call('service.start', 'kubernetes'))
 

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -12,7 +12,7 @@ class KubernetesService(Service):
     async def post_start(self):
         # TODO: Add support for migrations
         try:
-            timeout = 20
+            timeout = 60
             while timeout > 0:
                 node_config = await self.middleware.call('k8s.node.config')
                 if node_config['node_configured']:

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -11,12 +11,8 @@ class KubernetesService(Service):
     @private
     async def post_start(self):
         # TODO: Add support for migrations
-        async def node_online(middleware):
-            while not (await middleware.call('k8s.node.config'))['node_configured']:
-                await asyncio.sleep(2)
-
         try:
-            timeout = 10
+            timeout = 20
             while timeout > 0:
                 node_config = await self.middleware.call('k8s.node.config')
                 if node_config['node_configured']:


### PR DESCRIPTION
This PR introduces following changes:
1) Removes random sleep which may/may not work on every machine on first initialisation of k3s after the service is started.
2) Removes random sleep waiting for kube-router routing table to appear.
3) Removes sleep after starting docker daemon as in the updated mirror, based on tests done systemd docker unit properly waits for docker daemon to initialise itself instead of us waiting explicitly.
4) Make sure that `kube-bridge` is deleted when k8s is shutdown.