### PR TITLE
NAS-107724 / 20.10 / make sure keepalived starts properly

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
@@ -1489,7 +1489,7 @@ async def hook_setup_ha(middleware, *args, **kwargs):
     if not await middleware.call('failover.licensed'):
         return
 
-    if not await middleware.call('interface.query', [('failover_vhid', '!=', None)]):
+    if not await middleware.call('interface.query', [('failover_virtual_aliases', '!=', None)]):
         return
 
     if not await middleware.call('pool.query'):

--- a/src/middlewared/middlewared/etc_files/keepalived.conf.mako
+++ b/src/middlewared/middlewared/etc_files/keepalived.conf.mako
@@ -20,7 +20,7 @@
         advert_int = round(((128 * config['timeout']) / 385), 2)
 
     info = middleware.call_sync('interface.query')
-    info = [i for i in info if len(i['aliases'])]
+    info = [i for i in info if len(i['failover_virtual_aliases'])]
 
     if not info:
         middleware.logger.error(

--- a/src/middlewared/middlewared/plugins/device_/vrrp_events_linux.py
+++ b/src/middlewared/middlewared/plugins/device_/vrrp_events_linux.py
@@ -8,18 +8,6 @@ TIMEOUT = 2
 VRRP_THREAD = None
 
 
-def vrrp_hook_license_update(middleware, prev_product_type, *args, **kwargs):
-
-    global VRRP_THREAD
-
-    # get new product_type
-    new_product_type = middleware.call_sync('system.product_type')
-
-    if prev_product_type != 'SCALE_ENTERPRISE' and new_product_type == 'SCALE_ENTERPRISE':
-        if VRRP_THREAD is None:
-            VRRP_THREAD = start_daemon_thread(target=vrrp_fifo_listen, args=(middleware,))
-
-
 def vrrp_fifo_listen(middleware):
 
     # create the fifo, ignoring if it already exists
@@ -44,10 +32,6 @@ def vrrp_fifo_listen(middleware):
 async def setup(middleware):
 
     global VRRP_THREAD
-
-    # register hook to be called if/when a license has been uploaded
-    # to system changing the product type to 'SCALE_ENTERPRISE'
-    middleware.register_hook('system.post_license_update', vrrp_hook_license_update, sync=False)
 
     # only run on licensed systems
     if await middleware.call('failover.licensed'):

--- a/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
+++ b/src/middlewared/middlewared/plugins/service_/services/pseudo/misc.py
@@ -46,13 +46,11 @@ class FailoverService(PseudoServiceBase):
 
     restartable = True
 
+    # this is a NO-OP on SCALE HA by design
     async def restart(self):
         if osc.IS_FREEBSD:
             await self.middleware.call('etc.generate', 'pf')
             await freebsd_service("devd", "restart")
-
-        if osc.IS_LINUX:
-            await self.middleware.call('service.reload', 'keepalived')
 
 
 class KmipService(PseudoServiceBase):


### PR DESCRIPTION
This fixes a few issues.

1. call_sync was being made in main thread
--fixed by removing `vrrp_hook_license_update` because if a system is licensed HA for the first time, then there will be no failover interfaces configured which means that portion of code is a NO-OP

2. don't reload keepalived in the `failover` pseudo service
--unnecessary on SCALE HA

3. generate etc and start/reload the keepalived service on interface configuration

4. don't generate keepalived config if no `failover_virtual_aliases` are found

5. hook_setup_ha wasn't running on SCALE HA because `failover_vhid` never gets set. Instead use `failover_virtual_aliases`