### PR TITLE
NAS-107728 / 20.10 / Fix rcorder (by themylogin)

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-bsdloader
+++ b/src/freenas/etc/ix.rc.d/ix-bsdloader
@@ -4,7 +4,7 @@
 #
 
 # PROVIDE: ix-bsdloader
-# BEFORE: ix-fstab
+# BEFORE: middlewared earlykld
 
 . /etc/rc.freenas
 

--- a/src/freenas/etc/ix.rc.d/ix-update
+++ b/src/freenas/etc/ix.rc.d/ix-update
@@ -4,8 +4,7 @@
 #
 
 # PROVIDE: ix-update
-# REQUIRE: mountcritlocal
-# BEFORE: ix-fstab
+# BEFORE: middlewared earlykld
 
 . /etc/rc.freenas
 


### PR DESCRIPTION
@william-gr ix-update was somewhere at the bottom of list. We've removed ix-fstab a long time ago, something else has broke this. I think this should go in 12.0 release.

Original PR: https://github.com/freenas/freenas/pull/5723