### PR TITLE
NAS-107674 / 11.3 / Less garbage in logs when hardware faults lead to disk.temperatures timeout (by themylogin)

### DIFF
--- a/src/freenas/usr/local/lib/collectd_pyplugins/disktemp.py
+++ b/src/freenas/usr/local/lib/collectd_pyplugins/disktemp.py
@@ -27,7 +27,7 @@ import traceback
 
 import collectd
 
-from middlewared.client import Client
+from middlewared.client import Client, CallTimeout
 
 READ_INTERVAL = 300.0
 
@@ -63,6 +63,8 @@ class DiskTemp(object):
             for disk, temp in temperatures.items():
                 if temp is not None:
                     self.dispatch_value(disk, 'temperature', temp, data_type='temperature')
+        except CallTimeout:
+            collectd.error("Timeout collecting disk temperatures")
         except Exception:
             collectd.error(traceback.format_exc())
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git cherry-pick -x 265675c3abbdb437240b128176c6ca2b727d3893



Original PR: https://github.com/freenas/freenas/pull/5733