### PR TITLE
NAS-107686 / 20.10 / Clean paths from trailing slashes

### DIFF
--- a/src/middlewared/middlewared/plugins/replication.py
+++ b/src/middlewared/middlewared/plugins/replication.py
@@ -2,7 +2,7 @@ from datetime import datetime, time
 import os
 
 from middlewared.common.attachment import FSAttachmentDelegate
-from middlewared.schema import accepts, Bool, Cron, Dict, Int, List, Patch, Path, Str
+from middlewared.schema import accepts, Bool, Cron, Dataset, Dict, Int, List, Patch, Str
 from middlewared.service import item_method, job, private, CallError, CRUDService, ValidationErrors
 import middlewared.sqlalchemy as sa
 from middlewared.utils.path import is_child
@@ -142,10 +142,10 @@ class ReplicationService(CRUDService):
             Int("netcat_active_side_port_min", null=True, default=None, validators=[Port()]),
             Int("netcat_active_side_port_max", null=True, default=None, validators=[Port()]),
             Str("netcat_passive_side_connect_address", null=True, default=None),
-            List("source_datasets", items=[Path("dataset", empty=False)], required=True, empty=False),
-            Path("target_dataset", required=True, empty=False),
+            List("source_datasets", items=[Dataset("dataset")], required=True, empty=False),
+            Dataset("target_dataset", required=True),
             Bool("recursive", required=True),
-            List("exclude", items=[Path("dataset", empty=False)], default=[]),
+            List("exclude", items=[Dataset("dataset")], default=[]),
             Bool("properties", default=True),
             Bool("replicate", default=False),
             List("periodic_snapshot_tasks", items=[Int("periodic_snapshot_task")], default=[],
@@ -675,7 +675,7 @@ class ReplicationService(CRUDService):
 
     @accepts(
         List("datasets", empty=False, items=[
-            Path("dataset", empty=False),
+            Dataset("dataset")
         ]),
         List("naming_schema", empty=False, items=[
             Str("naming_schema", validators=[ReplicationSnapshotNamingSchema()])
@@ -707,8 +707,8 @@ class ReplicationService(CRUDService):
 
     @accepts(
         Str("direction", enum=["PUSH", "PULL"], required=True),
-        List("source_datasets", items=[Path("dataset", empty=False)], required=True, empty=False),
-        Path("target_dataset", required=True, empty=False),
+        List("source_datasets", items=[Dataset("dataset")], required=True, empty=False),
+        Dataset("target_dataset", required=True),
         Str("transport", enum=["SSH", "SSH+NETCAT", "LOCAL", "LEGACY"], required=True),
         Int("ssh_credentials", null=True, default=None),
     )

--- a/src/middlewared/middlewared/plugins/replication_/crud.py
+++ b/src/middlewared/middlewared/plugins/replication_/crud.py
@@ -1,4 +1,4 @@
-from middlewared.schema import accepts, Dict, Int, Path, Str
+from middlewared.schema import accepts, Dataset, Dict, Int, Str
 from middlewared.service import item_method, Service
 
 
@@ -10,7 +10,7 @@ class ReplicationService(Service):
         Dict(
             "replication_restore",
             Str("name", required=True),
-            Path("target_dataset", required=True, empty=False),
+            Dataset("target_dataset", required=True),
             strict=True,
         )
     )

--- a/src/middlewared/middlewared/plugins/snapshot.py
+++ b/src/middlewared/middlewared/plugins/snapshot.py
@@ -2,7 +2,7 @@ from datetime import time
 import os
 
 from middlewared.common.attachment import FSAttachmentDelegate
-from middlewared.schema import accepts, Bool, Cron, Dict, Int, List, Patch, Path, Str
+from middlewared.schema import accepts, Bool, Cron, Dataset, Dict, Int, List, Patch, Str
 from middlewared.service import CallError, CRUDService, item_method, private, ValidationErrors
 import middlewared.sqlalchemy as sa
 from middlewared.utils.path import is_child
@@ -70,9 +70,9 @@ class PeriodicSnapshotTaskService(CRUDService):
     @accepts(
         Dict(
             'periodic_snapshot_create',
-            Path('dataset', required=True),
+            Dataset('dataset', required=True),
             Bool('recursive', required=True),
-            List('exclude', items=[Path('item', empty=False)], default=[]),
+            List('exclude', items=[Dataset('item')], default=[]),
             Int('lifetime_value', required=True),
             Str('lifetime_unit', enum=['HOUR', 'DAY', 'WEEK', 'MONTH', 'YEAR'], required=True),
             Str('naming_schema', required=True, validators=[ReplicationSnapshotNamingSchema()]),

--- a/src/middlewared/middlewared/schema.py
+++ b/src/middlewared/middlewared/schema.py
@@ -208,16 +208,34 @@ class Str(EnumMixin, Attribute):
 
 class Path(Str):
 
+    def __init__(self, *args, **kwargs):
+        self.forwarding_slash = kwargs.pop('forwarding_slash', True)
+        super().__init__(*args, **kwargs)
+
     def clean(self, value):
         value = super().clean(value)
 
         if value is None:
             return value
 
-        return os.path.normpath(value.strip().strip("/").strip())
+        value = value.strip()
+
+        if self.forwarding_slash:
+            value = value.rstrip("/")
+        else:
+            value = value.strip("/")
+
+        return os.path.normpath(value.strip())
 
 
-class Dir(Str):
+class Dataset(Path):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('empty', False)
+        kwargs.setdefault('forwarding_slash', False)
+        super().__init__(*args, **kwargs)
+
+
+class Dir(Path):
 
     def validate(self, value):
         if value is None:
@@ -237,7 +255,7 @@ class Dir(Str):
         return super().validate(value)
 
 
-class File(Str):
+class File(Path):
 
     def validate(self, value):
         if value is None:


### PR DESCRIPTION
@william-gr I guess in 12.0 backport we only do `rstrip("/")` for the paths passed to the NFS share plugin itself?