### PR TITLE
NAS-107765 / 20.10 / fix generating ganesha.conf

### DIFF
--- a/src/middlewared/middlewared/etc_files/ganesha/ganesha.conf.mako
+++ b/src/middlewared/middlewared/etc_files/ganesha/ganesha.conf.mako
@@ -15,59 +15,44 @@
     export_id = itertools.count(1)
 %>
 
-NFS_CORE_PARAM
-{
+NFS_CORE_PARAM {
     % if config["mountd_port"]:
-        MNT_Port = ${config["mountd_port"]};
+    MNT_Port = ${config["mountd_port"]};
     % endif;
     % if config["rpclockd_port"]:
-        NLM_Port = ${config["rpclockd_port"]};
+    NLM_Port = ${config["rpclockd_port"]};
     % endif;
-
     % if bindip:
-        Bind_addr = ${bindip[0]};
-    % endif;
-
-    % if config["v4"]:
-        Protocols = 3, 4;
-    % else:
-        Protocols = 3;
+    Bind_addr = ${bindip[0]};
     % endif;
 }
-
 % if config["v4"]:
-    NFSV4
-    {
-        % if config["v4_v3owner"]:
-            Allow_Numeric_Owners = true;
-            Only_Numeric_Owners = true;
-        % endif;
-        % if config["v4_domain"]:
-            DomainName = ${config["v4_domain"]};
-        % endif;
-    }
-
-    % if config["v4_krb_enabled"]:
-        NFS_KRB5
-        {
-            % if gc.get("hostname_virtual"):
-                PrincipalName = nfs@${f'{gc["hostname_virtual"]}.{gc["domain"]}'};
-            % else:
-                PrincipalName = nfs@${gc["domain"]};
-            % endif;
-            KeytabPath = /etc/krb5.keytab;
-            Active_krb5 = YES;
-        }
+NFSV4 {
+    % if config["v4_v3owner"]:
+    Allow_Numeric_Owners = true;
+    Only_Numeric_Owners = true;
     % endif;
-% endif;
-
-EXPORT_DEFAULTS
-{
-    % if sec:
-        SecType = ${", ".join(sec)};
-    % endif
+    % if config["v4_domain"]:
+    DomainName = ${config["v4_domain"]};
+    % endif;
 }
-
+% endif;
+% if config["v4_krb_enabled"]:
+NFS_KRB5 {
+    % if gc.get("hostname_virtual"):
+    PrincipalName = nfs@${f'{gc["hostname_virtual"]}.{gc["domain"]}'};
+    % else:
+    PrincipalName = nfs@${gc["domain"]};
+    % endif;
+    KeytabPath = /etc/krb5.keytab;
+    Active_krb5 = YES;
+}
+% endif;
+% if sec:
+EXPORT_DEFAULTS {
+    SecType = ${", ".join(sec)};
+}
+% endif;
 % for share in shares:
     <%
         locked_datasets = None
@@ -86,95 +71,92 @@ EXPORT_DEFAULTS
                 'Skipping generation of %r path for NFS share as the underlying resource is locked', path
             )
             continue
-    %>\
-        EXPORT
-        {
-            Export_Id = ${next(export_id)};
-            Path = ${path};
-            % if config["v4"]:
-                Pseudo = ${alias};
-            % endif;
-            Tag = ${alias};
-
-            % if config["udp"]:
-                Transports = TCP, UDP;
-            % else:
-                Transports = TCP;
-            % endif
-
-            % if clients:
-                Access_Type = None;
-
-                CLIENT
-                {
-                    Clients = ${", ".join(clients)};
-
-                    Access_Type = ${"RO" if share["ro"] else "RW"};
-                }
-            % else:
-                Access_Type = ${"RO" if share["ro"] else "RW"};
-            % endif;
-
-            % if share["mapall_user"]:
-                Squash = AllSquash;
-                <%
-                user = middleware.call_sync(
-                    "user.query",
-                    [("username", "=", share["mapall_user"])],
-                    {"extra": {"search_dscache": True}},
-                )
-                group = []
-                if share["mapall_group"]:
-                    group = middleware.call_sync(
-                        "group.query",
-                        [("group", "=", share["mapall_group"])],
-                        {"extra": {"search_dscache": True}},
-                    )
-                %>
-                % if user:
-                    Anonymous_Uid = ${user[0]["uid"]};
-                % endif
-                % if group:
-                    Anonymous_Gid = ${group[0]["gid"]};
-                % endif
-            % elif share["maproot_user"]:
-                Squash = RootSquash;
-                <%
-                user = middleware.call_sync(
-                    "user.query",
-                    [("username", "=", share["maproot_user"])],
-                    {"extra": {"search_dscache": True}},
-                )
-                group = []
-                if share["maproot_group"]:
-                    group = middleware.call_sync(
-                        "group.query",
-                        [("group", "=", share["maproot_group"])],
-                        {"extra": {"search_dscache": True}},
-                    )
-                %>
-                % if user:
-                    Anonymous_Uid = ${user[0]["uid"]};
-                % endif
-                % if group:
-                    Anonymous_Gid = ${group[0]["gid"]};
-                % endif
-            % else:
-                Squash = None;
-            % endif
-
-            % if config["userd_manage_gids"]:
-                Manage_Gids = true;
-            % endif;
-
-            % if config["v4"] and share["security"]:
-                SecType = ${", ".join([s.lower() for s in share["security"]])};
-            % endif
-
-            FSAL
-            {
-                Name = VFS;
-            }
-        }
-    % endfor
-% endfor
+    %>
+EXPORT {
+    Export_Id = ${next(export_id)};
+    Path = ${path};
+    % if not config["v4"]:
+    Protocols = 3;
+    % else:
+    Protocols = 3, 4;
+    % endif;
+    % if config["v4"] and share["aliases"]:
+    Pseudo = ${alias};
+    % elif not config["v4"] and share["aliases"]:
+    Tag = ${alias.lstrip('/')};
+    % elif config["v4"] and not share["aliases"]:
+    Pseduo = /${path.split('/')[-1]};
+    % endif;
+    % if config["udp"]:
+    Transports = TCP, UDP;
+    % else:
+    Transports = TCP;
+    % endif;
+    % if clients:
+    Access_Type = None;
+    CLIENT {
+        Clients = ${", ".join(clients)};
+        Access_Type = ${"RO" if share["ro"] else "RW"};
+    }
+    % else:
+    Access_Type = ${"RO" if share["ro"] else "RW"};
+    % endif;
+    % if share["mapall_user"]:
+    Squash = AllSquash;
+    <%
+        user = middleware.call_sync(
+            "user.query",
+            [("username", "=", share["mapall_user"])],
+            {"extra": {"search_dscache": True}},
+        )
+        group = []
+        if share["mapall_group"]:
+            group = middleware.call_sync(
+                "group.query",
+                [("group", "=", share["mapall_group"])],
+                {"extra": {"search_dscache": True}},
+            )
+    %>
+    % if user:
+    Anonymous_Uid = ${user[0]["uid"]};
+    % endif;
+    % if group:
+    Anonymous_Gid = ${group[0]["gid"]};
+    % endif;
+    % elif share["maproot_user"]:
+    Squash = RootSquash;
+    <%
+        user = middleware.call_sync(
+            "user.query",
+            [("username", "=", share["maproot_user"])],
+            {"extra": {"search_dscache": True}},
+        )
+        group = []
+        if share["maproot_group"]:
+            group = middleware.call_sync(
+                "group.query",
+                [("group", "=", share["maproot_group"])],
+                {"extra": {"search_dscache": True}},
+            )
+    %>
+    % if user:
+    Anonymous_Uid = ${user[0]["uid"]};
+    % endif;
+    % if group:
+    Anonymous_Gid = ${group[0]["gid"]};
+    % endif;
+    % else:
+    Squash = None;
+    % endif;
+    % if config["userd_manage_gids"]:
+    Manage_Gids = true;
+    % endif;
+    % if config["v4"] and share["security"]:
+    SecType = ${", ".join([s.lower() for s in share["security"]])};
+    % endif;
+    FSAL {
+        Name = VFS;
+    }
+}
+    % endfor;
+% endfor;


### PR DESCRIPTION
Multiple issues with ganesha.conf generation.

1. ganesha supports a per export protocol so specifying the protocol for each export is required
2. the `Tag` parameter cannot start with a leading `/`
3. the `Tag` parameter is ignored if NFSv4 is enabled
4. the `Tag` parameter does not need to be added unless an alias was given to us
5. if NFSv4 is enabled and there are no aliases, then default to making the `Pseudo` parameter the last part of the `path`
6. the formatting was off and made the ganesha.conf almost unreadable so fix that up