### PR TITLE
NAS-107817 / 20.10 / Remove broken legacy arc_summary

### DIFF
--- a/src/freenas/usr/local/bin/arc_summary
+++ b/src/freenas/usr/local/bin/arc_summary
@@ -1,9 +1,0 @@
-#!/usr/local/bin/python
-import sys
-
-sys.path.insert(0, '/usr/local/www')
-
-from freenasUI.tools.arc_summary import main
-
-if __name__ == '__main__':
-    main()


### PR DESCRIPTION
This was a wrapper for gui/tools/arc_summary.py, which was deleted in 8b0ad7ae226ad9d815e8c5142aa0471999410901

We can use arc_summary from sysutils/openzfs instead.