### PR TITLE
NAS-107831 / 20.10 / fix multiple issues with failover on SCALE HA

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/event_linux.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/event_linux.py
@@ -156,8 +156,8 @@ class FailoverService(Service):
         try:
             for vol in volumes:
                 if vol['status'] != 'OFFLINE':
-                    self.middleware.call_sync('zfs.pool.export', vol, {'force': True})
-                    logger.info('Exported "%s"', vol)
+                    self.middleware.call_sync('zfs.pool.export', vol['name'], {'force': True})
+                    logger.info('Exported "%s"', vol['name'])
         except Exception as e:
             # catch any exception that could be raised
             # We sleep for 5 seconds here because this is
@@ -165,8 +165,8 @@ class FailoverService(Service):
             # for self.ZPOOL_EXPORT_TIMEOUT and if this
             # thread is_alive(), then we violently reboot
             # the node
-            logger.error('Error exporting "{}" with error {}'.format(vol, e))
-            time.sleep(5)
+            logger.error('Error exporting "%s" with error %s', vol['name'], e)
+            time.sleep(self.ZPOOL_EXPORT_TIMEOUT + 1)
 
     def generate_failover_data(self):
 


### PR DESCRIPTION
A few issues have been fixed:
1. signal is not thread safe so use a thread to export zpools

Finally, I'm able to test failover on real hardware, so I've identified some key differences between VRRP and CARP.

2. MASTER/BACKUP events are being processed by each controller so quickly that receiving an event and then checking if the other controller is MASTER is actually returning true...when it should not. So this is a race and that check has been removed. The `vrrp_master` and `vrrp_backup` jobs already have the necessary validation on whether or not the failover event should be
processed.
3. if we receive a MASTER event but all the zpools are already imported, then there is nothing to do so ignore.
4. get rid of some variables that weren't adding any value
5. only export the zpools if the status `!= 'OFFLINE'`
6. be sure and catch and re-raise IgnoreFailoverEvent in `run_call` to prevent a failover event loop since we restart the keepalived service (which triggers another event)