### PR TITLE
NAS-107836 / 20.10 / ensure heartbeat interface is configured at boot on SCALE HA

### DIFF
--- a/debian/debian/ix-netif.service
+++ b/debian/debian/ix-netif.service
@@ -10,6 +10,7 @@ Conflicts=systemd-networkd.service
 
 [Service]
 Type=oneshot
+ExecStart=-midclt -t 60 call failover.internal_interface.pre_sync true
 ExecStart=-midclt -t 120 call interface.sync true
 ExecStartPost=midclt call etc.generate_checkpoint interface_sync
 StandardOutput=null


### PR DESCRIPTION
`Type=oneshot` allows multiple `ExecStart` entries so we need to ensure that the heartbeat interface on enterprise HA hardware is configured before we configure the interfaces on SCALE HA during boot up.