### PR TITLE
NAS-107845 / 20.10 / make device.get_disks better for SCALE HA

### DIFF
--- a/src/middlewared/middlewared/plugins/device_/device_info_linux.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info_linux.py
@@ -3,14 +3,14 @@ import os
 import pyudev
 import re
 import subprocess
-
-from lxml import etree
+import json
 
 from .device_info_base import DeviceInfoBase
 from middlewared.service import private, Service
 from middlewared.utils import run
 
 RE_DISK_SERIAL = re.compile(r'Unit serial number:\s*(.*)')
+RE_DISK_ROTATION_RATE = re.compile(r'\s*Nominal\s*rotation\s*rate:\s*(.*)')
 RE_GPU_VENDOR = re.compile(r'description:\s*VGA compatible controller[\s\S]*vendor:\s*(.*)')
 RE_NVME_PRIVATE_NAMESPACE = re.compile(r'nvme[0-9]+c')
 RE_SERIAL = re.compile(r'state.*=\s*(\w*).*io (.*)-(\w*)\n.*', re.S | re.A)
@@ -60,7 +60,7 @@ class DeviceService(Service, DeviceInfoBase):
 
     def get_disks(self):
         disks = {}
-        lshw_disks = self.retrieve_lshw_disks_data()
+        disks_data = self.retrieve_disks_data()
 
         for block_device in pyudev.Context().list_devices(subsystem='block', DEVTYPE='disk'):
             if block_device.sys_name.startswith(('sr', 'md', 'dm-', 'loop', 'zd')):
@@ -75,7 +75,7 @@ class DeviceService(Service, DeviceInfoBase):
             # nvme drives won't have this
 
             try:
-                disks[block_device.sys_name] = self.get_disk_details(block_device, self.disk_default.copy(), lshw_disks)
+                disks[block_device.sys_name] = self.get_disk_details(block_device, self.disk_default.copy(), disks_data)
             except Exception as e:
                 self.middleware.logger.debug(
                     'Failed to retrieve disk details for %s : %s', block_device.sys_name, str(e)
@@ -84,24 +84,28 @@ class DeviceService(Service, DeviceInfoBase):
         return disks
 
     @private
-    def retrieve_lshw_disks_data(self):
-        disks_cp = subprocess.Popen(
-            ['lshw', '-xml', '-class', 'disk'], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    def retrieve_disks_data(self):
+
+        lsblk_disks = {}
+        disks_cp = subprocess.run(
+            ['lsblk', '-OJdb'],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
         )
-        output, error = disks_cp.communicate()
-        lshw_disks = {}
-        if output:
-            xml = etree.fromstring(output.decode())
-            for child in filter(lambda c: c.get('class') == 'disk', xml.getchildren()):
-                data = {'rotationrate': None}
-                for c in child.getchildren():
-                    if not len(c.getchildren()):
-                        data[c.tag] = c.text
-                    elif c.tag == 'capabilities':
-                        for capability in filter(lambda d: d.text.endswith('rotations per minute'), c.getchildren()):
-                            data['rotationrate'] = capability.get('id')[:-3]
-                lshw_disks[data['logicalname']] = data
-        return lshw_disks
+        if not disks_cp.returncode:
+            try:
+                lsblk_disks = json.loads(disks_cp.stdout)['blockdevices']
+                lsblk_disks = {i['path']: i for i in lsblk_disks}
+            except Exception as e:
+                self.middleware.logger.error(
+                    'Failed parsing lsblk information with error: %s', e
+                )
+        else:
+            self.middleware.logger.error(
+                'Failed running lsblk command with error: %s', disks_cp.stderr.decode()
+            )
+
+        return lsblk_disks
 
     def get_disk(self, name):
         disk = self.disk_default.copy()
@@ -111,13 +115,32 @@ class DeviceService(Service, DeviceInfoBase):
         except pyudev.DeviceNotFoundByNameError:
             return None
 
-        return self.get_disk_details(block_device, disk, self.retrieve_lshw_disks_data())
+        return self.get_disk_details(block_device, disk, self.retrieve_disks_data())
 
     @private
-    def get_disk_details(self, block_device, disk, lshw_disks):
+    def get_rotational_rate(self, device_path):
+
+        rotation_rate = None
+
+        vpd = subprocess.run(
+            ['sg_vpd', '-p', 'bdc', device_path],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if not vpd.returncode and vpd.stdout:
+            reg = RE_DISK_ROTATION_RATE.search(vpd.stdout.decode())
+            if reg:
+                rotation_rate = reg.groups()[0].split()[0]
+
+        return rotation_rate
+
+    @private
+    def get_disk_details(self, block_device, disk, disks_data):
+
         device_path = os.path.join('/dev', block_device.sys_name)
         disk_sys_path = os.path.join('/sys/block', block_device.sys_name)
         driver_name = os.path.realpath(os.path.join(disk_sys_path, 'device/driver')).split('/')[-1]
+
         number = 0
         if driver_name != 'driver':
             number = sum(
@@ -133,27 +156,29 @@ class DeviceService(Service, DeviceInfoBase):
             'subsystem': os.path.realpath(os.path.join(disk_sys_path, 'device/subsystem')).split('/')[-1],
         })
 
-        disk['sectorsize'] = self.logical_sector_size(block_device.sys_name)
+        if device_path in disks_data:
+            disk_data = disks_data[device_path]
 
-        type_path = os.path.join(disk_sys_path, 'queue/rotational')
-        if os.path.exists(type_path):
-            with open(type_path, 'r') as f:
-                disk['type'] = 'SSD' if f.read().strip() == '0' else 'HDD'
-        else:
-            self.middleware.logger.error(
-                'Unable to retrieve %r disk rotational details at %s', disk['name'], type_path
-            )
-
-        if device_path in lshw_disks:
-            disk_data = lshw_disks[device_path]
+            # get type of disk and rotational rate (if HDD)
+            disk['type'] = 'SSD' if not disk_data['rota'] else 'HDD'
             if disk['type'] == 'HDD':
-                disk['rotationrate'] = disk_data['rotationrate']
+                disk['rotationrate'] = self.get_rotational_rate(device_path)
 
-            disk['ident'] = disk['serial'] = disk_data.get('serial', '')
-            disk['size'] = disk['mediasize'] = int(disk_data['size']) if 'size' in disk_data else None
-            disk['descr'] = disk['model'] = disk_data.get('product')
+            # get model and serial
+            disk['ident'] = disk['serial'] = disk_data.get('serial', '').strip()
+            disk['descr'] = disk['model'] = disk_data.get('model').strip()
+
+            # get all relevant size attributes of disk
+            disk['sectorsize'] = disk_data['log-sec']
+            disk['size'] = disk['mediasize'] = disk_data['size']
             if disk['size'] and disk['sectorsize']:
                 disk['blocks'] = int(disk['size'] / disk['sectorsize'])
+
+            # get lunid
+            if disk.get('tran') == 'nvme':
+                disk['lunid'] = disk_data['wwn'].lstrip('eui.')
+            else:
+                disk['lunid'] = disk_data['wwn'].lstrip('0x')
 
         if not disk['size'] and os.path.exists(os.path.join(disk_sys_path, 'size')):
             with open(os.path.join(disk_sys_path, 'size'), 'r') as f:
@@ -174,24 +199,20 @@ class DeviceService(Service, DeviceInfoBase):
                 if reg:
                     disk['serial'] = disk['ident'] = reg.group(1)
 
-        if not disk['model'] and os.path.exists(os.path.join(disk_sys_path, 'device/model')):
-            # For nvme drives, we are unable to retrieve it via lshw
-            with open(os.path.join(disk_sys_path, 'device/model'), 'r') as f:
-                disk['model'] = disk['descr'] = f.read().strip()
-
-        # We make a device ID query to get DEVICE ID VPD page of the drive if available and then use that identifier
-        # as the lunid - FreeBSD does the same, however it defaults to other schemes if this is unavailable
-        lun_id_cp = subprocess.Popen(
-            ['sg_vpd', '--quiet', '-i', device_path],
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-        )
-        cp_stdout, cp_stderr = lun_id_cp.communicate()
-        if not lun_id_cp.returncode and lun_id_cp.stdout:
-            lunid = cp_stdout.decode().strip()
-            if lunid:
-                disk['lunid'] = lunid.split()[0]
-            if lunid and disk['lunid'].startswith('0x'):
-                disk['lunid'] = disk['lunid'][2:]
+        if not disk['lunid']:
+            # We make a device ID query to get DEVICE ID VPD page of the drive if available and then use that identifier
+            # as the lunid - FreeBSD does the same, however it defaults to other schemes if this is unavailable
+            lun_id_cp = subprocess.Popen(
+                ['sg_vpd', '--quiet', '-i', device_path],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            )
+            cp_stdout, cp_stderr = lun_id_cp.communicate()
+            if not lun_id_cp.returncode and lun_id_cp.stdout:
+                lunid = cp_stdout.decode().strip()
+                if lunid:
+                    disk['lunid'] = lunid.split()[0]
+                if lunid and disk['lunid'].startswith('0x'):
+                    disk['lunid'] = disk['lunid'][2:]
 
         if disk['serial'] and disk['lunid']:
             disk['serial_lunid'] = f'{disk["serial"]}_{disk["lunid"]}'


### PR DESCRIPTION
On SCALE HA, I've noticed the following:

1. on a functional HA system, the webUI was taking 5+ seconds to present the login screen
2. the standby nodes console was being spammed with `reservation conflict` messages

I traced this all down to the `device.get_disks` method. This method was calling `lshw` which was taking 2+ seconds to run on a system with 53 SCSI disks and causing the `reservation conflict` messages. I haven't looked at that source code but it seemed to be "loading" all subsystems no matter if you chose the "DISK" type. It is also opening the underlying disks in "w" mode which is causing the reservation errors. Instead of running `lshw`, I've replaced it with `lsblk`. The only major difference is that I'm having to shell out and run `sg_vpd` to grab the rotational rate of the disk if the type is `HDD`. Even doing this, my local system is ~52% faster and if type is `SSD`, then it can be ~85%+ faster since we don't have to grab the `rotationrate` attribute.

I've removed the private `retrieve_lshw_disks_data` method as there are no public consumers of that method.

`device.get_disks` before the change = 2.3 seconds
`device.get_disks` after the change = 1.1 seconds

`failover.disabled_reasons` before the change = 2.5 seconds
`failover.disabled_reasons` after the change = 1.1 seconds