### PR TITLE
NAS-107842 / 20.10 / Bug fix for CSR's not having normalised SAN or CN field value

### DIFF
--- a/src/middlewared/middlewared/plugins/crypto.py
+++ b/src/middlewared/middlewared/plugins/crypto.py
@@ -1340,7 +1340,7 @@ class CertificateService(CRUDService):
             if ':' in domain and domain.split(':', 1)[-1] not in dns_mapping_copy:
                 dns_mapping_copy[domain.split(':', 1)[-1]] = dns_mapping_copy[domain]
             elif ':' not in domain:
-                normalised_san = ':'.join(self.middleware.call_sync('cryptokey.normalize_san', [domain]))
+                normalised_san = ':'.join(self.middleware.call_sync('cryptokey.normalize_san', [domain])[0])
                 if normalised_san not in dns_mapping_copy:
                     dns_mapping_copy[normalised_san] = domain
 


### PR DESCRIPTION
This commit fixes an issue where if user has a CSR without a normalised SAN value or a CSR using CN only, he/she will unable be to create an ACME cert as it fails normalisation.