### PR TITLE
NAS-107673 / 12.0 / Correctly return snapshot data conforming to crud standard (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -994,9 +994,6 @@ class ZFSSnapshot(CRUDService):
     def do_create(self, data):
         """
         Take a snapshot from a given dataset.
-
-        Returns:
-            bool: True if succeed otherwise False.
         """
 
         dataset = data['dataset']
@@ -1035,6 +1032,8 @@ class ZFSSnapshot(CRUDService):
         except libzfs.ZFSException as err:
             self.logger.error(f'Failed to snapshot {dataset}@{name}: {err}')
             raise CallError(f'Failed to snapshot {dataset}@{name}: {err}')
+        else:
+            return self.middleware.call_sync('zfs.snapshot.get_instance', f'{dataset}@{name}')
         finally:
             if vmware_context:
                 self.middleware.call_sync('vmware.snapshot_end', vmware_context)
@@ -1076,6 +1075,8 @@ class ZFSSnapshot(CRUDService):
                 snap.delete(defer=options['defer'])
         except libzfs.ZFSException as e:
             raise CallError(str(e))
+        else:
+            return True
 
     @accepts(Dict(
         'snapshot_clone',


### PR DESCRIPTION
On snapshot creation, we should return created snapshot details following CRUD services standard.

Original PR: https://github.com/freenas/freenas/pull/5768