### PR TITLE
NAS-107852 / 12.0 / Bug fixes for OpenVPN configuration (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/crypto.py
+++ b/src/middlewared/middlewared/plugins/crypto.py
@@ -1014,7 +1014,8 @@ class CertificateService(CRUDService):
                 'KeyUsage': {
                     'enabled': True,
                     'extension_critical': True,
-                    'digital_signature': True
+                    'digital_signature': True,
+                    'key_agreement': True,
                 }
             },
             'key_length': 2048,

--- a/src/middlewared/middlewared/plugins/vpn.py
+++ b/src/middlewared/middlewared/plugins/vpn.py
@@ -143,6 +143,13 @@ class OpenVPN:
                     )
 
             if mode == 'client':
+                if not cert['common']:
+                    # This is required for openvpn clients - https://community.openvpn.net/openvpn/ticket/81
+                    # Otherwise we get "VERIFY ERROR: could not extract CN from X509 subject string"
+                    verrors.add(
+                        f'{schema}.client_certificate',
+                        'Client certificate requires common name (CN) to be set to verify properly.'
+                    )
                 if not any(
                     k in (extensions.get('KeyUsage') or '')
                     for k in ('Digital Signature', 'Key Agreement')


### PR DESCRIPTION
This PR introduces following changes:
1) Client certificate profile requires KeyAgreement to be set in KeyUsage extension. This PR updates the basic client cert profile highlighting the change.
2) Add validation checking for CN for client certs

Original PR: https://github.com/freenas/freenas/pull/5778