### PR TITLE
NAS-107829 / 20.10 / reporting.realtime disk stats

### DIFF
--- a/src/middlewared/middlewared/plugins/reporting/events.py
+++ b/src/middlewared/middlewared/plugins/reporting/events.py
@@ -9,6 +9,8 @@ import time
 from middlewared.event import EventSource
 from middlewared.utils import osc
 
+from .iostat import DiskStats
+
 if osc.IS_FREEBSD:
     import sysctl
     import netif
@@ -50,6 +52,8 @@ class RealtimeEventSource(EventSource):
         cp_time_last = None
         cp_times_last = None
         last_interface_stats = {}
+        if osc.IS_LINUX:
+            disk_stats = DiskStats()
 
         while not self._cancel.is_set():
             data = {}
@@ -185,6 +189,9 @@ class RealtimeEventSource(EventSource):
                         **data['interfaces'][iface_name],
                         'stats_time': stats_time,
                     }
+
+            if osc.IS_LINUX:
+                data['disks'] = disk_stats.get()
 
             self.send_event('ADDED', fields=data)
             time.sleep(2)

--- a/src/middlewared/middlewared/plugins/reporting/iostat.py
+++ b/src/middlewared/middlewared/plugins/reporting/iostat.py
@@ -1,0 +1,79 @@
+from collections import namedtuple
+import time
+
+DiskStat = namedtuple("DiskStat", ["rd_ios", "rd_bytes", "wr_ios", "wr_bytes", "tot_ticks"])
+
+
+class DiskStats:
+    def __init__(self):
+        self.prev = None
+        self.prev_time = None
+        self.current = None
+        self.current_time = None
+        self._read()
+
+    def _read(self):
+        with open("/proc/diskstats") as f:
+            lines = f.readlines()
+
+        self.current = {}
+        for line in lines:
+            line = line.split()
+
+            disk = line[2]
+
+            if disk.startswith("loop"):
+                continue
+
+            parent = disk
+            while parent and (parent[-1].isdigit() or parent[-1] == "p" and parent.startswith("nvme")):
+                parent = parent[:-1]
+            if parent in self.current:
+                continue
+
+            # According to https://github.com/torvalds/linux/blob/7ca8cf5/include/linux/types.h#L120
+            # sectors are always 512 bytes.
+            disk_stat = DiskStat(
+                rd_ios=int(line[3]),
+                rd_bytes=int(line[5]) * 512,
+                wr_ios=int(line[7]),
+                wr_bytes=int(line[9]) * 512,
+                tot_ticks=int(line[12]),
+            )
+
+            self.current[disk] = disk_stat
+
+        self.current_time = time.monotonic()
+
+    def get(self):
+        self.prev = self.current
+        self.prev_time = self.current_time
+        self._read()
+
+        read_ops = 0
+        read_bytes = 0
+        write_ops = 0
+        write_bytes = 0
+        total_ticks = 0
+        count = 0
+        for disk, current in self.current.items():
+            prev = self.prev.get(disk)
+            if prev is None:
+                continue
+
+            read_ops += current.rd_ios - prev.rd_ios
+            read_bytes += current.rd_bytes - prev.rd_bytes
+            write_ops += current.wr_ios - prev.wr_ios
+            write_bytes += current.wr_bytes - prev.wr_bytes
+            total_ticks += current.tot_ticks - prev.tot_ticks
+            count += 1
+
+        t = self.current_time - self.prev_time
+
+        return {
+            "read_ops": int(read_ops / t),
+            "read_bytes": int(read_bytes / t),
+            "write_ops": int(write_ops / t),
+            "write_bytes": int(write_bytes / t),
+            "busy": total_ticks / count / 1000 / t,
+        }


### PR DESCRIPTION
Two considerations:
- I mocked `/proc/diskstats` with 260 disks (780 lines: disk + two partitions), average iteration time was `0.0014 sec`, with test running every two seconds it is 0.07% of one CPU core and that makes me think Cython version is not really necessary.
- Average of "DIsk IO utilization" across all disks seems does not seem to be an indicative metric (If I have 100 disks and one of them is loaded 100% while others are idling, it will show 1%), I chose to expose Maximum, please correct me if I am wrong.