### PR TITLE
NAS-107753 / 20.12 / Prevent LDAP queries for local user info (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/pam.d/common-account.mako
+++ b/src/middlewared/middlewared/etc_files/pam.d/common-account.mako
@@ -1,0 +1,27 @@
+#
+# /etc/pam.d/common-account - authorization settings common to all services
+#
+# This file is included from other service-specific PAM config files,
+# and should contain a list of the authorization modules that define
+# the central access policy for use on the system.  The default is to
+# only deny service to users whose accounts are expired in /etc/shadow.
+#
+<%namespace name="pam" file="pam.inc.mako" />\
+<%
+        dsp = pam.getDirectoryServicePam(middleware=middleware, file='sshd')
+%>\
+
+% if dsp.enabled() and dsp.name() != 'NIS':
+${dsp.pam_account()}
+% endif
+# here's the fallback if no module succeeds
+# here are the per-package modules (the "Primary" block)
+account	[success=1 new_authtok_reqd=done default=ignore]	pam_unix.so
+# here's the fallback if no module succeeds
+account	requisite			pam_deny.so
+# prime the stack with a positive return value if there isn't one already;
+# this avoids us returning an error just because nothing sets a success code
+# since the modules above will each just jump around
+account	required			pam_permit.so
+# and here are more per-package modules (the "Additional" block)
+# end of pam-auth-update config

--- a/src/middlewared/middlewared/etc_files/pam.d/common-password.mako
+++ b/src/middlewared/middlewared/etc_files/pam.d/common-password.mako
@@ -1,0 +1,36 @@
+#
+# /etc/pam.d/common-password - password-related modules common to all services
+#
+# This file is included from other service-specific PAM config files,
+# and should contain a list of modules that define the services to be
+# used to change user passwords.  The default is pam_unix.
+
+# Explanation of pam_unix options:
+#
+# The "sha512" option enables salted SHA512 passwords.  Without this option,
+# the default is Unix crypt.  Prior releases used the option "md5".
+#
+# The "obscure" option replaces the old `OBSCURE_CHECKS_ENAB' option in
+# login.defs.
+#
+# See the pam_unix manpage for other options.
+
+<%namespace name="pam" file="pam.inc.mako" />\
+<%
+        dsp = pam.getDirectoryServicePam(middleware=middleware, file='sshd')
+%>\
+
+% if dsp.enabled() and dsp.name() != 'NIS':
+${dsp.pam_auth()}
+% endif
+
+# here are the per-package modules (the "Primary" block)
+password	[success=1 default=ignore]	pam_unix.so obscure sha512
+# here's the fallback if no module succeeds
+password	requisite			pam_deny.so
+# prime the stack with a positive return value if there isn't one already;
+# this avoids us returning an error just because nothing sets a success code
+# since the modules above will each just jump around
+password	required			pam_permit.so
+# and here are more per-package modules (the "Additional" block)
+# end of pam-auth-update config

--- a/src/middlewared/middlewared/etc_files/pam.d/common-session-noninteractive.mako
+++ b/src/middlewared/middlewared/etc_files/pam.d/common-session-noninteractive.mako
@@ -1,0 +1,27 @@
+#
+# /etc/pam.d/common-session-noninteractive - session-related modules
+# common to all non-interactive services
+#
+# This file is included from other service-specific PAM config files,
+# and should contain a list of modules that define tasks to be performed
+# at the start and end of all non-interactive sessions.
+#
+<%namespace name="pam" file="pam.inc.mako" />\
+<%
+        dsp = pam.getDirectoryServicePam(middleware=middleware, file='sshd')
+%>\
+
+# here are the per-package modules (the "Primary" block)
+session	[default=1]			pam_permit.so
+# here's the fallback if no module succeeds
+session	requisite			pam_deny.so
+# prime the stack with a positive return value if there isn't one already;
+# this avoids us returning an error just because nothing sets a success code
+# since the modules above will each just jump around
+session	required			pam_permit.so
+# and here are more per-package modules (the "Additional" block)
+session	required	pam_unix.so
+% if dsp.enabled() and dsp.name() != 'NIS':
+${dsp.pam_session()}
+% endif
+# end of pam-auth-update config

--- a/src/middlewared/middlewared/etc_files/pam.d/common-session.mako
+++ b/src/middlewared/middlewared/etc_files/pam.d/common-session.mako
@@ -1,0 +1,28 @@
+#
+# /etc/pam.d/common-session - session-related modules common to all services
+#
+# This file is included from other service-specific PAM config files,
+# and should contain a list of modules that define tasks to be performed
+# at the start and end of sessions of *any* kind (both interactive and
+# non-interactive).
+
+<%namespace name="pam" file="pam.inc.mako" />\
+<%
+        dsp = pam.getDirectoryServicePam(middleware=middleware, file='sshd')
+%>\
+
+# here are the per-package modules (the "Primary" block)
+session	[default=1]			pam_permit.so
+# here's the fallback if no module succeeds
+session	requisite			pam_deny.so
+# prime the stack with a positive return value if there isn't one already;
+# this avoids us returning an error just because nothing sets a success code
+# since the modules above will each just jump around
+session	required			pam_permit.so
+# and here are more per-package modules (the "Additional" block)
+% if dsp.enabled() and dsp.name() != 'NIS':
+${dsp.pam_session()}
+% endif
+session	required	pam_unix.so
+session	optional	pam_systemd.so
+# end of pam-auth-update config

--- a/src/middlewared/middlewared/etc_files/pam.d/pam.inc.mako
+++ b/src/middlewared/middlewared/etc_files/pam.d/pam.inc.mako
@@ -2,9 +2,9 @@
     class DirectoryServicePamBase(object):
         def __init__(self, **kwargs):
             self.middleware = kwargs.get('middleware')
-            self.pam_mkhomedir = "/usr/local/lib/pam_mkhomedir.so"
-            self.pam_ldap = "/usr/local/lib/pam_ldap.so"
-            self.pam_winbind = "/usr/local/lib/pam_winbind.so"
+            self.pam_mkhomedir = "pam_mkhomedir.so"
+            self.pam_ldap = "pam_ldap.so"
+            self.pam_winbind = "pam_winbind.so"
             self.pam_krb5 = "pam_krb5.so"
 
         def safe_call(self, *args):

--- a/src/middlewared/middlewared/etc_files/pam.d/pam.inc.mako
+++ b/src/middlewared/middlewared/etc_files/pam.d/pam.inc.mako
@@ -81,31 +81,61 @@
         def is_kerberized(self):
             return True if (self.safe_call('ldap.config'))['kerberos_realm'] else False
 
+        def min_uid(self):
+            config = self.safe_call('ldap.config')
+            min_uid = 1000
+            for param in config['auxiliary_parameters'].splitlines():
+                param = param.strip()
+                if param.startswith('nss_min_uid'):
+                    try:
+                        override = param.split()[1].strip()
+                        if override.isdigit():
+                            min_uid = override
+                    except Exception:
+                        self.middleware.logger.debug(
+                            "Failed to override default minimum UID for pam_ldap",
+                            exc_info=True
+                        )
+            return min_uid
+
         def pam_auth(self):
             module = self.pam_ldap
-            args = ["try_first_pass", "ignore_unknown_user",
-                "ignore_authinfo_unavail", "no_warn"]
+            min_uid = self.min_uid()
+            args = [
+                "try_first_pass",
+                "ignore_unknown_user",
+                "ignore_authinfo_unavail",
+                "no_warn",
+                f"minimum_uid={min_uid}"
+            ]
             krb5_args = ["try_first_pass", "no_warn"]
 
             module_args = " ".join(args)
 
             ldap_entry = f"auth\t\tsufficient\t{module}\t{module_args}"
             krb5_entry = f"auth\t\tsufficient\t{self.pam_krb5}\t\t{' '.join(krb5_args)}"
-            if self.is_kerberized:
+            if self.is_kerberized():
                 return f"{krb5_entry}\n{ldap_entry}"
             else:
                 return ldap_entry
 
         def pam_account(self):
             module = self.pam_ldap
-            args = ["ignore_unknown_user", "ignore_authinfo_unavail", "no_warn"]
+            min_uid = self.min_uid()
+            args = [
+                "try_first_pass",
+                "ignore_unknown_user",
+                "ignore_authinfo_unavail",
+                "no_warn",
+                f"minimum_uid={min_uid}"
+            ]
             krb5_args = ["no_warn"]
 
             module_args = " ".join(args)
 
             ldap_entry = f"account\t\tsufficient\t{module}\t{module_args}"
             krb5_entry = f"account\t\tsufficient\t{self.pam_krb5}\t\t{' '.join(krb5_args)}"
-            if self.is_kerberized:
+            if self.is_kerberized():
                 return f"{krb5_entry}\n{ldap_entry}"
             else:
                 return ldap_entry
@@ -115,15 +145,20 @@
 
         def pam_password(self):
             module = self.pam_ldap
-            args = ["use_authtok", "ignore_unknown_user",
-                "ignore_authinfo_unavail", "no_warn"]
+            min_uid = self.min_uid()
+            args = [
+                "ignore_unknown_user",
+                "ignore_authinfo_unavail",
+                "no_warn",
+                f"minimum_uid={min_uid}"
+            ]
             krb5_args = ["try_first_pass", "no_warn"]
 
             module_args = " ".join(args)
 
             ldap_entry = f"password\tsufficient\t{module}\t{module_args}"
             krb5_entry = f"password\t\tsufficient\t{self.pam_krb5}\t\t{' '.join(krb5_args)}"
-            if self.is_kerberized:
+            if self.is_kerberized():
                 return f"{krb5_entry}\n{ldap_entry}"
             else:
                 return ldap_entry


### PR DESCRIPTION
Also prevent lookups for UIDs < 1000 from LDAP (with ability to override
via LDAP auxiliary parameter).

This PR adds secondary commit that sets up basic PAM customization for directory services on SCALE. In this case, the directory-service specific PAM config is added to the common services that are automatically included in the default OS / service pam configuration file as needed.