### PR TITLE
NAS-107950 / 12.0 / Avoid larger mbuf jumbo clusters with cxgbe (by freqlabs)

### DIFF
--- a/src/freenas/boot/loader.conf
+++ b/src/freenas/boot/loader.conf
@@ -100,3 +100,8 @@ hint.ntb_transport.0.config=":3"
 # workarounding hardware errata.  The FreeBSD default here is using second
 # window, that IMO is more confusing.
 hw.ntb.msix_mw_idx="-1"
+
+# Avoid allocating mbuf jumbo clusters larger than page size.
+# The larger cluster sizes can induce pathological behavior in the allocator.
+# At 9000 MTU the whole system can be brought to a crawl under heavy RX load.
+hw.cxgbe.largest_rx_cluster=4096


### PR DESCRIPTION
The larger cluster sizes can induce pathological behavior in the allocator.
At 9000 MTU the whole system can be brought to a crawl under heavy RX load.

Limit cxgbe rx cluster size to 4096.

Original PR: https://github.com/freenas/freenas/pull/5836