### PR TITLE
NAS-107790 / 20.10 / Send pool.query event on pool changes

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -250,6 +250,7 @@ class PoolService(CRUDService):
         datastore = 'storage.volume'
         datastore_extend = 'pool.pool_extend'
         datastore_prefix = 'vol_'
+        event_send = False
 
     @item_method
     @accepts(
@@ -756,6 +757,7 @@ class PoolService(CRUDService):
         await self.middleware.call_hook(
             'dataset.post_create', {'encrypted': bool(encryption_dict), **encrypted_dataset_data}
         )
+        self.middleware.send_event('pool.query', 'ADDED', id=pool_id, fields=pool)
         return pool
 
     @private

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -772,6 +772,7 @@ class PoolService(CRUDService):
         'pool_create', 'pool_update',
         ('rm', {'name': 'name'}),
         ('rm', {'name': 'encryption'}),
+        ('rm', {'name': 'encryption_options'}),
         ('rm', {'name': 'deduplication'}),
         ('edit', {'name': 'topology', 'method': lambda x: setattr(x, 'update', True)}),
     ))

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -1581,6 +1581,7 @@ class PoolService(CRUDService):
         asyncio.ensure_future(self.middleware.call('disk.swaps_configure'))
 
         await self.middleware.call_hook('pool.post_export', pool=pool['name'], options=options)
+        self.middleware.send_event('pool.query', 'CHANGED', id=oid, cleared=True)
 
     @item_method
     @accepts(Int('id'))

--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -1416,6 +1416,7 @@ class PoolService(CRUDService):
             }
         )
         await self.middleware.call('pool.dataset.sync_db_keys', pool['name'])
+        self.middleware.send_event('pool.query', 'ADDED', id=pool_id, fields=pool)
 
         return True
 

--- a/src/middlewared/middlewared/plugins/zfs_/zfs_events.py
+++ b/src/middlewared/middlewared/plugins/zfs_/zfs_events.py
@@ -197,6 +197,13 @@ async def zfs_events(middleware, data):
                 ]
             )
             await middleware.call_hook('dataset.post_delete', data['history_dsname'])
+    elif (
+        event_id == 'sysevent.fs.zfs.history_event' and not data.get('history_dsname') and data.get('pool')
+    ):
+        pool = await retrieve_pool_from_db(middleware, data['pool'])
+        if not pool:
+            return
+        middleware.send_event('pool.dataset.query', 'CHANGED', id=pool['id'], fields=pool)
 
 
 def setup(middleware):

--- a/src/middlewared/middlewared/plugins/zfs_/zfs_events.py
+++ b/src/middlewared/middlewared/plugins/zfs_/zfs_events.py
@@ -200,13 +200,6 @@ async def zfs_events(middleware, data):
                 ]
             )
             await middleware.call_hook('dataset.post_delete', data['history_dsname'])
-    elif (
-        event_id == 'sysevent.fs.zfs.history_event' and not data.get('history_dsname') and data.get('pool')
-    ):
-        pool = await retrieve_pool_from_db(middleware, data['pool'])
-        if not pool:
-            return
-        middleware.send_event('pool.query', 'CHANGED', id=pool['id'], fields=pool)
 
 
 def setup(middleware):


### PR DESCRIPTION
This PR adds changes to send `pool.query` event whenever pool state changes. It should be noted that we do not use zfs events for create/import/deletion of pool because these operations are considered complete by middleware when some other operations like updating db / moving system dataset etc are completed, so we send the `pool.query` event in those endpoints.

For pool property changes, we could use `sysevent.fs.zfs.history_event` event but it is unreliable to use as it's issued otherwise as well like updating a vdev and we can't cleanly separate the cause which triggers this event. At maximum, this results in duplicate `CHANGED` events, if we do desire to use this, we can add the required changes then.