### PR TITLE
NAS-107994 / 20.12 / change glusterd working-directory so metadata isn't lost on OS upgrades

### DIFF
--- a/src/middlewared/middlewared/etc_files/glusterd.conf.mako
+++ b/src/middlewared/middlewared/etc_files/glusterd.conf.mako
@@ -1,0 +1,20 @@
+<%
+    sysdataset_path = middleware.call_sync('systemdataset.config')['path']
+    work_dir = sysdataset_path + '/glusterd'
+%>\
+
+volume management
+    type mgmt/glusterd
+    option working-directory ${work_dir}
+    option transport-type socket
+    option transport.socket.keepalive-time 10
+    option transport.socket.keepalive-interval 2
+    option transport.socket.read-fail-log off
+    option transport.socket.listen-port 24007
+    option ping-timeout 0
+    option event-threads 1
+#   option lock-timer 180
+#   option transport.address-family inet6
+#   option base-port 49152
+    option max-port  60999
+end-volume

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -194,6 +194,16 @@ class EtcService(Service):
         'pf': [
             {'type': 'py', 'path': 'pf', 'platform': 'FreeBSD'},
         ],
+        'glusterd': [
+            {
+                'type': 'mako',
+                'path': 'glusterfs/glusterd.vol',
+                'local_path': 'glusterd.conf',
+                'user': 'root', 'group': 'root', 'mode': 0o644,
+                'checkpoint': 'pool_import',
+                'platform': 'Linux',
+            },
+        ],
         'keepalived': [
             {
                 'type': 'mako',


### PR DESCRIPTION
- get rid of `is_freenas` calls in `sysdataset.py` plugin
- setup a `glusterd` dataset underneath the `.system` dataset
- stop/restart/reconfigure glusterd in the event the system dataset changes