### PR TITLE
NAS-108009 / 20.12 / Manually toggle value of "passdb backend" in middleware loadparm ctx (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -925,6 +925,7 @@ class LDAPService(ConfigService):
             await self.middleware.call('etc.generate', 'smb')
             await self.middleware.call('smb.store_ldap_admin_password')
             await self.middleware.call('service.restart', 'cifs')
+            await self.middleware.call('smb.set_passdb_backend', 'ldapsam')
 
         await self.set_state(DSStatus['HEALTHY'])
         await self.middleware.call('ldap.fill_cache')
@@ -943,6 +944,7 @@ class LDAPService(ConfigService):
             await self.middleware.call('service.restart', 'cifs')
             await self.middleware.call('smb.synchronize_passdb')
             await self.middleware.call('smb.synchronize_group_mappings')
+            await self.middleware.call('smb.set_passdb_backend', 'tdbsam')
         await self.middleware.call('cache.pop', 'LDAP_cache')
         await self.nslcd_cmd('onestop')
         await self.set_state(DSStatus['DISABLED'])

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -354,6 +354,17 @@ class SMBService(SystemServiceService):
             raise CallError(f'Attempt to query smb4.conf parameter [{parm}] failed with error: {e}')
 
     @private
+    def set_passdb_backend(self, backend_type):
+        if backend_type not in ['tdbsam', 'ldapsam']:
+            raise CallError(f'Unsupported passdb backend type: [{backend_type}]', errno.EINVAL)
+        try:
+            LP_CTX.load(SMBPath.GLOBALCONF.platform())
+        except Exception as e:
+            self.logger.warning("Failed to reload smb.conf: %s", e)
+
+        return LP_CTX.set('passdb backend', backend_type)
+
+    @private
     async def get_next_rid(self):
         next_rid = (await self.config())['next_rid']
         if next_rid == 0:


### PR DESCRIPTION
It appears that LoadParmContext.load(<smb.conf>) is not sufficient
to catch the second change to Samba's passdb backend (first one is
caught and properly reflected). Fixing this may be a bit hairy and
issue does not actually impact file sharing over SMB (or directory
services). The issue does impact logic internal in middleware for
whether or not to manipulate the passdb and group_mapping databases.
For now, workaround will be to add a new method to manually set this
value as needed in the ldap plugin (and at some future time fix
pyparam).

Original PR: https://github.com/freenas/freenas/pull/5881