### PR TITLE
NAS-108016 / 20.12 / Improve dataset querying / creation performance

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -491,24 +491,15 @@ class ZFSDatasetService(CRUDService):
 
         with libzfs.ZFS() as zfs:
             # Handle `id` filter specially to avoiding getting all datasets
+            kwargs = dict(props=props, top_level_props=top_level_props, user_props=user_properties)
             if filters and len(filters) == 1 and list(filters[0][:2]) == ['id', '=']:
-                state_options = {
-                    'snapshots': extra.get('snapshots', False),
-                    'recursive': extra.get('recursive', True),
-                    'snapshots_recursive': extra.get('snapshots_recursive', False)
-                }
-                try:
-                    datasets = [zfs.get_dataset(filters[0][2]).__getstate__(**state_options)]
-                except libzfs.ZFSException:
-                    datasets = []
+                kwargs['datasets'] = [filters[0][2]]
+
+            datasets = zfs.datasets_serialized(**kwargs)
+            if flat:
+                datasets = self.flatten_datasets(datasets)
             else:
-                datasets = zfs.datasets_serialized(
-                    props=props, top_level_props=top_level_props, user_props=user_properties
-                )
-                if flat:
-                    datasets = self.flatten_datasets(datasets)
-                else:
-                    datasets = list(datasets)
+                datasets = list(datasets)
 
         return filter_list(datasets, filters, options)
 


### PR DESCRIPTION
This PR adds following changes:

1) Uses a different endpoint to retrieve serialized datasets data if `id` filter has been applied. It takes less then half the time it used to before with this approach. One thing to note is that we remove `state_options` for `id` filter and I have ensured that there are no usages for those in our codebase. This also helps us be consistent across varying filters and not have special consideration for a single filter.
2) Improves `pool.dataset.create` performance which mainly utilises the gains introduced in (1) and also tries to minimise the times it queries for the same dataset over and over again. Earlier in my environment it used to take around 19 seconds to create a dataset and with current approach takes ~3.44 seconds.