### PR TITLE
NAS-108028 / 20.12 / Fix LDAP directory service on SCALE

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf.mako
@@ -383,8 +383,6 @@
                     pc.update({f'idmap config {domain}: ldap_user_dn': idmap['options']['ldap_user_dn']})
                 if idmap['options'].get('ssl'):
                     pc.update({'ldap ssl': 'start tls'})
-                    if idmap['options']['ldap_server'].lower() == "ads":
-                        pc.update({'ldap ssl ads': 'Yes'})
 
             return pc
 

--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -917,9 +917,9 @@ class LDAPService(ConfigService):
         await self.middleware.call('etc.generate', 'pam')
 
         if not await self.nslcd_status():
-            await self.nslcd_cmd('onestart')
+            await self.nslcd_cmd('start')
         else:
-            await self.nslcd_cmd('onerestart')
+            await self.nslcd_cmd('restart')
 
         if ldap['has_samba_schema']:
             await self.middleware.call('etc.generate', 'smb')
@@ -944,7 +944,7 @@ class LDAPService(ConfigService):
             await self.middleware.call('smb.synchronize_passdb')
             await self.middleware.call('smb.synchronize_group_mappings')
         await self.middleware.call('cache.pop', 'LDAP_cache')
-        await self.nslcd_cmd('onestop')
+        await self.nslcd_cmd('stop')
         await self.set_state(DSStatus['DISABLED'])
 
     @private

--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -325,7 +325,7 @@ class SMBService(SystemServiceService):
         if not ldap['ldap_enable']:
             return True
 
-        set_pass = await run(['usr/local/bin/smbpasswd', '-w', ldap['ldap_bindpw']], check=False)
+        set_pass = await run([SMBCmd.SMBPASSWD.value, '-w', ldap['ldap_bindpw']], check=False)
         if set_pass.returncode != 0:
             self.logger.debug(f"Failed to set set ldap bindpw in secrets.tdb: {set_pass.stdout.decode()}")
             return False


### PR DESCRIPTION
This mostly fixes a few minor Linux vs FreeBSD issues and also removes deprecated Samba parameters from the smb4.conf. Majority of work is in nss-pam-ldapd repo.