### PR TITLE
NAS-107914 / 12.0 / Add endpoint to update plugin (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/jail_freebsd.py
+++ b/src/middlewared/middlewared/plugins/jail_freebsd.py
@@ -1489,6 +1489,10 @@ class JailService(CRUDService):
     @job(lock=lambda args: f"jail_update:{args[0]}")
     def update_to_latest_patch(self, job, jail, update_pkgs=False):
         """Updates specified jail to latest patch level."""
+        return self.update_to_latest_patch_internal(job, jail, update_pkgs, True)
+
+    @private
+    def update_to_latest_patch_internal(self, job, jail, update_pkgs, update_jail):
         job.set_progress(0, f'Updating {jail}')
         msg_queue = deque(maxlen=10)
 
@@ -1520,7 +1524,7 @@ class JailService(CRUDService):
             jail,
             callback=progress_callback
         )
-        iocage.update(update_pkgs)
+        iocage.update(update_pkgs, update_jail)
 
         return True
 

--- a/src/middlewared/middlewared/plugins/jail_freebsd.py
+++ b/src/middlewared/middlewared/plugins/jail_freebsd.py
@@ -469,6 +469,17 @@ class PluginService(CRUDService):
             for branch in re.findall(r'refs/heads/(.*)', cp.stdout)
         }
 
+    @accepts(
+        Str('jail'),
+        Bool('update_jail', default=True)
+    )
+    @job(lock=lambda args: f'jail_update:{args[0]}')
+    async def update(self, job, jail, update_jail=True):
+        """
+        Updates specified plugin to latest available plugin version and optionally update plugin to latest patch level.
+        """
+        return await self.middleware.call('jail.update_to_latest_patch_internal', job, jail, False, update_jail)
+
     @periodic(interval=86400)
     @private
     def periodic_plugin_update(self):


### PR DESCRIPTION
This PR adds another endpoint to update a plugin. Motivation is to separate the update implementation as for plugin's we want the user to have an optional choice to update the jail itself to latest patch level or not because it might already be to it's latest patch level and just the plugin packages itself need to be updated.

Original PR: https://github.com/freenas/freenas/pull/5853