### PR TITLE
NAS-108047 / 20.12 / make keepalived.conf and vrrp events aware of IPv6 on SCALE HA

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/event_linux.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/event_linux.py
@@ -663,7 +663,7 @@ async def vrrp_fifo_hook(middleware, data):
     # since both of them are static in our use case
     data = data.split()
 
-    ifname = data[1].strip('"')  # interface
+    ifname = data[1].split('_')[0].strip('"')  # interface
     event = data[2]  # the state that is being transititoned to
 
     # we only care about MASTER or BACKUP events currently


### PR DESCRIPTION
Wait to merge this until: https://github.com/freenas/freenas/pull/5811 is merged.

IPv6 support on HA required me to make a change to how keepalived.conf was generated therefore causing the associated vrrp event to change as well.

I've accounted for both of those ensuring IPv4 and IPv6 work wrt to HA on SCALE