### PR TITLE
NAS-102208 / 20.12 / disallow journal thread from making remote db changes

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
@@ -1420,8 +1420,8 @@ class JournalSync:
     def _os_versions_match(self):
 
         try:
-            loc = self.middleware.call_sync('failover.get_os_version')
-            rem = self.middleware.call_sync('failover.call_remote', 'failover.get_os_version')
+            rem = self.middleware.call_sync('failover.get_remote_os_version')
+            loc = self.middleware.call_sync('system.version')
         except Exception:
             return False
 
@@ -1442,18 +1442,23 @@ async def journal_ha(middleware):
 
 
 def journal_sync(middleware):
+
+    alert = True
     while True:
         try:
             journal = Journal()
             journal_sync = JournalSync(middleware, sql_queue, journal)
             while True:
                 journal_sync.process()
-        except Exception as e:
-            if isinstance(e, OSVersionMismatch):
+                alert = True
+        except OSVersionMismatch:
+            if alert:
                 logger.warning('OS version does not match remote node. Not syncing journal')
-            else:
-                logger.warning('Failed to sync journal', exc_info=True)
-            time.sleep(5)
+                alert = False
+        except Exception:
+            logger.warning('Failed to sync journal', exc_info=True)
+
+        time.sleep(5)
 
 
 async def interface_pre_sync_hook(middleware):

--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
@@ -79,6 +79,15 @@ class TruenasNodeSessionManagerCredentials(SessionManagerCredentials):
     pass
 
 
+class OSVersionMismatch(Exception):
+
+    """
+    Raised in JournalSync thread when the remote nodes OS version
+    does not match the local nodes OS version.
+    """
+    pass
+
+
 def throttle_condition(middleware, app, *args, **kwargs):
     # app is None means internal middleware call
     if app is None or (app and app.authenticated):
@@ -1322,6 +1331,10 @@ class JournalSync:
 
             self.journal.clear()
 
+        if not self._os_versions_match():
+            if self.journal:
+                raise OSVersionMismatch()
+
         had_journal_items = bool(self.journal)
         flush_succeeded = self._flush_journal()
 
@@ -1404,6 +1417,16 @@ class JournalSync:
     def _update_failover_status(self):
         self.failover_status = self.middleware.call_sync('failover.status')
 
+    def _os_versions_match(self):
+
+        try:
+            loc = self.middleware.call_sync('failover.get_os_version')
+            rem = self.middleware.call_sync('failover.call_remote', 'failover.get_os_version')
+        except Exception:
+            return False
+
+        return loc == rem
+
 
 def hook_datastore_execute_write(middleware, sql, params):
     sql_queue.put((sql, params))
@@ -1425,8 +1448,11 @@ def journal_sync(middleware):
             journal_sync = JournalSync(middleware, sql_queue, journal)
             while True:
                 journal_sync.process()
-        except Exception:
-            logger.warning('Failed to sync journal', exc_info=True)
+        except Exception as e:
+            if isinstance(e, OSVersionMismatch):
+                logger.warning('OS version does not match remote node. Not syncing journal')
+            else:
+                logger.warning('Failed to sync journal', exc_info=True)
             time.sleep(5)
 
 

--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/remote.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/remote.py
@@ -34,7 +34,7 @@ class RemoteClient(object):
         self._subscriptions = defaultdict(list)
         self._on_connect_callbacks = []
         self._on_disconnect_callbacks = []
-        self._os_version = None
+        self._remote_os_version = None
 
     def run(self):
         set_thread_name('ha_connection')
@@ -97,7 +97,7 @@ class RemoteClient(object):
         # we're not trying to alter the remote db if the
         # OS versions do not match since schema changes
         # can (and do) change between upgrades
-        self._os_version = self.get_os_version()
+        self._remote_os_version = self.get_remote_os_version()
 
         for cb in self._on_connect_callbacks:
             try:
@@ -116,7 +116,7 @@ class RemoteClient(object):
         Called everytime connection is closed for whatever reason.
         """
 
-        self._os_version = None
+        self._remote_os_version = None
 
         for cb in self._on_disconnect_callbacks:
             try:
@@ -186,15 +186,15 @@ class RemoteClient(object):
                     break
             time.sleep(0.5)
 
-    def get_os_version(self):
+    def get_remote_os_version(self):
 
-        if self._os_version is None:
+        if self._remote_os_version is None:
             try:
-                self._os_version = self.client.call('system.version')
+                self._remote_os_version = self.client.call('system.version')
             except Exception:
                 logger.error('Failed to determine OS version', exc_info=True)
 
-        return self._os_version
+        return self._remote_os_version
 
 
 class FailoverService(Service):
@@ -237,9 +237,9 @@ class FailoverService(Service):
             raise CallError('Call timeout', errno.ETIMEDOUT)
 
     @private
-    def get_os_version(self):
+    def get_remote_os_version(self):
 
-        return self.CLIENT.get_os_version()
+        return self.CLIENT.get_remote_os_version()
 
     @private
     def sendfile(self, token, src, dst):


### PR DESCRIPTION
This prevents the journal thread from making remote db changes when the OS'es do not match between the nodes. I've cached the os version in `RemoteClient` trying to ensure that any error that could possibly occur while setting that attribute is handled to prevent that class from crashing.

This sets the attribute when the remote client is connected as well as clears it when it is disconnected.