### PR TITLE
NAS-108097 / 12.0 / Reload mDNS after SMB service attachment

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1300,9 +1300,12 @@ class SMBFSAttachmentDelegate(LockableFSAttachmentDelegate):
         """
         libsmbconf will handle any required notifications to clients if
         shares are added or deleted.
+        mDNS may need to be reloaded if a time machine share is located on
+        the share being attached.
         """
         reg_sync = await self.middleware.call('sharing.smb.sync_registry')
         await reg_sync.wait()
+        await self.middleware.call('service.reload', 'mdns')
 
 
 async def setup(middleware):


### PR DESCRIPTION
SMB service attachment may impact _smb._tcp. and _adisk._tcp.
advertisements. Ensure that avahi services are regenerated and
avahi reloaded.