### PR TITLE
NAS-105947 / 20.12 / Added regression testing for netwait (by ericbsd)

### DIFF
--- a/tests/api2/test_003_network.py
+++ b/tests/api2/test_003_network.py
@@ -6,11 +6,10 @@
 import pytest
 import sys
 import os
-
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from auto_config import ha, interface
-from functions import GET, PUT
+from auto_config import ha, interface, user, password
+from functions import GET, PUT, SSH_TEST
 
 if ha and "domain" in os.environ:
     domain = os.environ["domain"]
@@ -71,8 +70,7 @@ def test_03_configure_setting_domain_hostname_and_dns():
 
 
 @pytest.mark.skipif(ha, reason='Skipping test for HA')
-@pytest.mark.parametrize('dkeys', ["domain", "hostname", "ipv4gateway",
-                                   "nameserver1"])
+@pytest.mark.parametrize('dkeys', ["domain", "hostname", "ipv4gateway", "nameserver1"])
 def test_04_looking_put_network_configuration_output_(dkeys):
     assert results.json()[dkeys] == payload[dkeys], results.text
 
@@ -115,3 +113,74 @@ def test_09_verify_network_general_summary_ips():
     for value in results.json()['ips'][interface]['IPV4']:
         if ip in value:
             assert ip in value, results.text
+
+
+def test_10_enable_netwait():
+    global payload, results
+    payload = {
+        "netwait_enabled": True,
+        "netwait_ip": [gateway, '8.8.8.8'],
+    }
+    results = PUT("/network/configuration/", payload)
+    assert results.status_code == 200, results.text
+    assert isinstance(results.json(), dict), results.text
+
+
+@pytest.mark.parametrize('dkeys', ["netwait_enabled", "netwait_ip"])
+def test_11_verify_put_network_configuration_output_(dkeys):
+    assert results.json()[dkeys] == payload[dkeys], results.text
+
+
+def test_12_get_network_configuration_info_for_netwait():
+    global results
+    results = GET("/network/configuration/")
+    assert results.status_code == 200, results.text
+    assert isinstance(results.json(), dict), results.text
+
+
+@pytest.mark.parametrize('dkeys', ["netwait_enabled", "netwait_ip"])
+def test_13_verify_get_network_configuration_output_(dkeys):
+    assert results.json()[dkeys] == payload[dkeys], results.text
+
+
+@pytest.mark.skipif(ha, reason='Skipping test for HA')
+def test_14_verify_that_netwait_is_in_rc_conf_freenas():
+    cmd = 'cat /etc/rc.conf.freenas | grep netwait'
+    ssh_results = SSH_TEST(cmd, user, password, ip)
+    assert ssh_results['result'] is True, ssh_results['output']
+    assert 'netwait_enable="YES"' in ssh_results['output'], ssh_results['output']
+    assert f'netwait_ip="{gateway} 8.8.8.8"' in ssh_results['output'], ssh_results['output']
+
+
+def test_15_disable_netwait():
+    global payload, results
+    payload = {
+        "netwait_enabled": False,
+        "netwait_ip": [],
+    }
+    results = PUT("/network/configuration/", payload)
+    assert results.status_code == 200, results.text
+    assert isinstance(results.json(), dict), results.text
+
+
+@pytest.mark.parametrize('dkeys', ["netwait_enabled", "netwait_ip"])
+def test_16_verify_put_network_configuration_output_(dkeys):
+    assert results.json()[dkeys] == payload[dkeys], results.text
+
+
+def test_17_get_network_configuration_info_for_netwait():
+    global results
+    results = GET("/network/configuration/")
+    assert results.status_code == 200, results.text
+    assert isinstance(results.json(), dict), results.text
+
+
+@pytest.mark.parametrize('dkeys', ["netwait_enabled", "netwait_ip"])
+def test_18_verify_get_network_configuration_output_(dkeys):
+    assert results.json()[dkeys] == payload[dkeys], results.text
+
+
+def test_19_verify_that_netwait_is_not_in_rc_conf_freenas():
+    cmd = 'cat /etc/rc.conf.freenas | grep netwait'
+    ssh_results = SSH_TEST(cmd, user, password, ip)
+    assert ssh_results['result'] is False, ssh_results['output']

--- a/tests/api2/test_003_network.py
+++ b/tests/api2/test_003_network.py
@@ -8,7 +8,7 @@ import sys
 import os
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from auto_config import ha, interface, user, password
+from auto_config import ha, scale, interface, user, password
 from functions import GET, PUT, SSH_TEST
 
 if ha and "domain" in os.environ:
@@ -115,6 +115,7 @@ def test_09_verify_network_general_summary_ips():
             assert ip in value, results.text
 
 
+@pytest.mark.skipif(ha or scale, reason='Skipping test for HA')
 def test_10_enable_netwait():
     global payload, results
     payload = {
@@ -126,11 +127,13 @@ def test_10_enable_netwait():
     assert isinstance(results.json(), dict), results.text
 
 
+@pytest.mark.skipif(ha or scale, reason='Skipping test for HA')
 @pytest.mark.parametrize('dkeys', ["netwait_enabled", "netwait_ip"])
 def test_11_verify_put_network_configuration_output_(dkeys):
     assert results.json()[dkeys] == payload[dkeys], results.text
 
 
+@pytest.mark.skipif(ha or scale, reason='Skipping test for HA')
 def test_12_get_network_configuration_info_for_netwait():
     global results
     results = GET("/network/configuration/")
@@ -138,12 +141,13 @@ def test_12_get_network_configuration_info_for_netwait():
     assert isinstance(results.json(), dict), results.text
 
 
+@pytest.mark.skipif(ha or scale, reason='Skipping test for HA')
 @pytest.mark.parametrize('dkeys', ["netwait_enabled", "netwait_ip"])
 def test_13_verify_get_network_configuration_output_(dkeys):
     assert results.json()[dkeys] == payload[dkeys], results.text
 
 
-@pytest.mark.skipif(ha, reason='Skipping test for HA')
+@pytest.mark.skipif(ha or scale, reason='Skipping test for HA')
 def test_14_verify_that_netwait_is_in_rc_conf_freenas():
     cmd = 'cat /etc/rc.conf.freenas | grep netwait'
     ssh_results = SSH_TEST(cmd, user, password, ip)
@@ -152,6 +156,7 @@ def test_14_verify_that_netwait_is_in_rc_conf_freenas():
     assert f'netwait_ip="{gateway} 8.8.8.8"' in ssh_results['output'], ssh_results['output']
 
 
+@pytest.mark.skipif(ha or scale, reason='Skipping test for HA')
 def test_15_disable_netwait():
     global payload, results
     payload = {
@@ -163,11 +168,13 @@ def test_15_disable_netwait():
     assert isinstance(results.json(), dict), results.text
 
 
+@pytest.mark.skipif(ha or scale, reason='Skipping test for HA')
 @pytest.mark.parametrize('dkeys', ["netwait_enabled", "netwait_ip"])
 def test_16_verify_put_network_configuration_output_(dkeys):
     assert results.json()[dkeys] == payload[dkeys], results.text
 
 
+@pytest.mark.skipif(ha or scale, reason='Skipping test for HA')
 def test_17_get_network_configuration_info_for_netwait():
     global results
     results = GET("/network/configuration/")
@@ -175,11 +182,13 @@ def test_17_get_network_configuration_info_for_netwait():
     assert isinstance(results.json(), dict), results.text
 
 
+@pytest.mark.skipif(ha or scale, reason='Skipping test for HA')
 @pytest.mark.parametrize('dkeys', ["netwait_enabled", "netwait_ip"])
 def test_18_verify_get_network_configuration_output_(dkeys):
     assert results.json()[dkeys] == payload[dkeys], results.text
 
 
+@pytest.mark.skipif(ha or scale, reason='Skipping test for HA')
 def test_19_verify_that_netwait_is_not_in_rc_conf_freenas():
     cmd = 'cat /etc/rc.conf.freenas | grep netwait'
     ssh_results = SSH_TEST(cmd, user, password, ip)


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 6d69a7159213fd085cf6501761f3ff0fea3d1640

added test to enable netwait
added test to verify put network configuration output
added test to get network configuration info for netwait
added test to verify get network configuration output
added test to verify that netwait is in rc.conf.freenas
added test to disable netwait
added test to verify that netwait is not in rc.conf.freenas

Original PR: https://github.com/freenas/freenas/pull/5929