### PR TITLE
NAS-108050 / 12.0 / Do not retrieve unnecessary sysctls in snmp-agent

### DIFF
--- a/src/freenas/usr/local/bin/snmp-agent.py
+++ b/src/freenas/usr/local/bin/snmp-agent.py
@@ -32,8 +32,8 @@ def get_Kstat():
 
 def get_Kstat_FreeBSD():
     Kstats = [
-        "kstat.zfs",
-        "vfs.zfs"
+        "kstat.zfs.misc.arcstats",
+        "vfs.zfs.version.spa",
     ]
 
     Kstat = {}

--- a/src/freenas/usr/local/libexec/freenas-debug/zfs/zfs.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/zfs/zfs.sh
@@ -113,4 +113,17 @@ zfs_func()
 	section_header  "pool joined to storage"
 	cat  /tmp/pool.normal | ${FREENAS_DEBUG_MODULEDIR}/zfs/join_pool.nawk
 	section_footer
+
+	section_header  "kstat"
+	if is_freebsd; then
+		sysctl kstat.zfs.misc.fletcher_4_bench
+		sysctl kstat.zfs.misc.vdev_raidz_bench
+		sysctl kstat.zfs.misc.dbgmsg
+		for pool in $(zpool list -Ho name); do
+			sysctl kstat.zfs.${pool}.misc.state
+			sysctl kstat.zfs.${pool}.multihost
+			sysctl kstat.zfs.${pool}.txgs
+		done
+	fi
+	section_footer
 }


### PR DESCRIPTION
I am not sure about the scope of this ticket, is it only to fix SNMP or also `freenas-debug/sysctl/sysctl.sh`? (it only has `sysctl -a`, I have no idea how to fix this if not in kernel)