### PR TITLE
NAS-108110 / 12.0 / fix exporting zpools on freeBSD (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -4057,7 +4057,9 @@ def parse_lsof(lsof, dirs):
             try:
                 pid = int(line[1:])
             except ValueError:
-                pass
+                # no reason to continue if we dont have
+                # a PID associated with the process
+                continue
 
         if line.startswith("c"):
             command = line[1:]
@@ -4105,7 +4107,9 @@ def parse_fstat(fstat, dirs):
         try:
             pid = int(line[2])
         except ValueError:
-            pass
+            # no reason to continue if we dont have
+            # a PID associated with the process
+            continue
 
         command = line[1]
         path = line[4]


### PR DESCRIPTION
A few things about lsof on  freeSBD

- it's broken and will cause a CPU core to spin at 100% and also eat TONS of ram (so much ram, that it can go into swap space and ultimately cause crashes of userspace processes)
- it's man page isn't being built on freeBSD for reasons that I don't really want to troubleshoot
- it gives a warning about the fact the version of lsof was compiled for 12.0-RELEASE but we're not using that freeBSD release in our TN-12.0-RELEASE

Replace it with the in base `fstat` utility. It's orders of magnitude quicker, and doesn't cause random memory exhaustion.

With this change, I'm able to export zpools with running services on TN-12.0 without issues. Furthermore, this fixes a bug where even if `lsof` was successful, it actually didn't work the way we thought it did. So this fixes those 2 issues.

Original PR: https://github.com/freenas/freenas/pull/5951