### PR TITLE
NAS-108168 / 12.0 / Fix SMB2 AAPL extension negotiation

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/registry.py
+++ b/src/middlewared/middlewared/plugins/smb_/registry.py
@@ -362,7 +362,7 @@ class SharingSMBService(Service):
             conf["fruit:resource"] = "stream"
 
         if conf["path"]:
-            await self.add_multiprotocol_conf(conf, gl, data['name'])
+            await self.add_multiprotocol_conf(conf, gl, data)
 
         if data['timemachine']:
             conf["fruit:time machine"] = "yes"
@@ -385,8 +385,20 @@ class SharingSMBService(Service):
             if not param.strip():
                 continue
             try:
-                kv = param.split('=', 1)
-                conf[kv[0].strip()] = kv[1].strip()
+                auxparam, val = param.split('=', 1)
+                """
+                vfs_fruit must be added to all shares if fruit is enabled.
+                Support for SMB2 AAPL extensions is determined on first tcon
+                to server, and so if they aren't appended to any vfs objects
+                overrides via auxiliary parameters, then users may experience
+                unexpected behavior.
+                """
+                if auxparam.strip() == "vfs objects" and gl['fruit_enabled']:
+                    vfsobjects = val.strip().split()
+                    vfsobjects.append('fruit')
+                    conf['vfs objects'] = await self.order_vfs_objects(vfsobjects)
+                else:
+                    conf[auxparam.strip()] = val.strip()
             except Exception:
                 self.logger.debug("[%s] contains invalid auxiliary parameter: [%s]",
                                   data['name'], param)


### PR DESCRIPTION
12.0 abstracted away from exposing explicit vfs module configuration
to users (instead opting to use checkboxes). In cases where we couldn't
cleanly migrate the user's VFS objects to our new feature-based config
(acls, streams, etc), we dumped the params into SMB share auxiliary
parameters. This preserves user's existing behavior (pre-12.0), but
can cause issues with time machine support if user opts to add a
time machine share at a later date (or has inconsistently-migrated
shares) since support for the SMB2 protocol extensions is determined
on the first SMB2 tree connect. This means that all shares _must_ have
vfs_fruit enabled (even ones with VFS objects in auxiliary parameters)
if users have them on any other share.
To address this potential issue, check for "vfs objects" lines when
parsing auxiliary parameters and add vfs_fruit if the global option
"aapl_extensions" is set.