### PR TITLE
NAS-108181 / 20.12 / Account for serial being none

### DIFF
--- a/src/middlewared/middlewared/plugins/device_/device_info_linux.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info_linux.py
@@ -166,7 +166,7 @@ class DeviceService(Service, DeviceInfoBase):
                 disk['rotationrate'] = self.get_rotational_rate(device_path)
 
             # get model and serial
-            disk['ident'] = disk['serial'] = disk_data.get('serial', '').strip()
+            disk['ident'] = disk['serial'] = (disk_data.get('serial') or '').strip()
             disk['descr'] = disk['model'] = disk_data.get('model').strip()
 
             # get all relevant size attributes of disk


### PR DESCRIPTION
When using lsblk, serial can be none as well in vms resulting in disks not syncing.