### PR TITLE
NAS-108186 / 20.12 / Correctly populate k8s node password under etc on upgrades

### DIFF
--- a/src/middlewared/middlewared/etc_files/rancher/node/node_passwd.py
+++ b/src/middlewared/middlewared/etc_files/rancher/node/node_passwd.py
@@ -1,0 +1,21 @@
+import os
+
+
+def render(service, middleware):
+    k8s_config = middleware.call_sync('kubernetes.config')
+    if not k8s_config['dataset']:
+        return
+
+    k3s_node_passwd_file = os.path.join('/mnt', k8s_config['dataset'], 'k3s/server/cred/node-passwd')
+    if not os.path.exists(k3s_node_passwd_file):
+        # The only time this will happen is the first time k8s is configured and at that time it's okay
+        # as k3s will populate the correct password under /etc but on subsequent upgrades of the system
+        # that will be lost
+        return
+
+    with open(k3s_node_passwd_file, 'r') as f:
+        passwd = f.read().strip().split(',')[0].strip()
+
+    os.makedirs('/etc/rancher/node', exist_ok=True)
+    with open('/etc/rancher/node/password', 'w') as f:
+        f.write(passwd)

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -307,6 +307,7 @@ class EtcService(Service):
         ],
         'k3s': [
             {'type': 'py', 'path': 'rancher/k3s/flags', 'platform': 'Linux', 'checkpoint': None},
+            {'type': 'py', 'path': 'rancher/node/node_passwd', 'platform': 'Linux', 'checkpoint': None},
         ],
         'cni': [
             {'type': 'py', 'path': 'cni/multus', 'platform': 'Linux', 'checkpoint': None},


### PR DESCRIPTION
K3s stores node password under /etc even when we want it to operate under a different directory, so on an upgrade of the system, node password is lost as BE changes and k8s fails to initialise pods. This fixes that by ensuring we have the correct node password under /etc.