### PR TITLE
NAS-108204 / 20.12 / nfsv4 shares do not export properly

### DIFF
--- a/src/middlewared/middlewared/etc_files/ganesha/ganesha.conf.mako
+++ b/src/middlewared/middlewared/etc_files/ganesha/ganesha.conf.mako
@@ -85,7 +85,7 @@ EXPORT {
     % elif not config["v4"] and share["aliases"]:
     Tag = ${alias.lstrip('/')};
     % elif config["v4"] and not share["aliases"]:
-    Pseduo = /${path.split('/')[-1]};
+    Pseudo = /${path.split('/')[-1]};
     % endif;
     % if config["udp"]:
     Transports = TCP, UDP;


### PR DESCRIPTION
The nfs-ganesha config for nfsv4 that gets generated from template is invalid due to a typo in the template. This typo prevents nfsv4 shares from being exported properly.