### PR TITLE
NAS-108214 / 20.12 / Bug fix for retrieving bridge members

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/netif_linux/bridge.py
+++ b/src/middlewared/middlewared/plugins/interface/netif_linux/bridge.py
@@ -28,5 +28,5 @@ class BridgeMixin:
         return [
             link["ifname"]
             for link in json.loads(run(["bridge", "-json", "link"]).stdout)
-            if link["master"] == self.name
+            if link.get("master") == self.name
         ]


### PR DESCRIPTION
This commit fixes an issue where if we have unused ifaces, we don't have master key existing for them and bridge interface fails to configure.