### PR TITLE
NAS-108218 / 20.12 / Serialize LDAP queries and avoid extra calls to started methods

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -850,7 +850,12 @@ class ActiveDirectoryService(ConfigService):
 
         await self.middleware.call('activedirectory.conn_check', config)
 
-        if (await self.get_state()) != 'HEALTHY':
+        try:
+            cached_state = await self.middleware.call_sync('cache.get', 'DS_STATE')
+
+            if cached_state['activedirectory'] != 'HEALTHY':
+                await self.set_state(DSStatus['HEALTHY'])
+        except KeyError:
             await self.set_state(DSStatus['HEALTHY'])
 
         return True

--- a/src/middlewared/middlewared/plugins/cache.py
+++ b/src/middlewared/middlewared/plugins/cache.py
@@ -136,7 +136,7 @@ class DSCache(Service):
 
     def initialize(self):
         for ds in [('activedirectory', 'AD'), ('ldap', 'LDAP'), ('nis', 'NIS')]:
-            if self.middleware.call_sync(f'{ds[0]}.get_state') != 'DISABLED':
+            if (self.middleware.call_sync(f'{ds[0]}.config'))['enable']:
                 try:
                     with open(f'/var/db/system/.{ds[1]}_cache_backup', 'rb') as f:
                         pickled_cache = pickle.load(f)
@@ -146,7 +146,7 @@ class DSCache(Service):
 
     def backup(self):
         for ds in [('activedirectory', 'AD'), ('ldap', 'LDAP'), ('nis', 'NIS')]:
-            if self.middleware.call_sync(f'{ds[0]}.get_state') != 'DISABLED':
+            if (self.middleware.call_sync(f'{ds[0]}.config'))['enable']:
                 try:
                     ds_cache = self.middleware.call_sync('cache.get', f'{ds[1]}_cache')
                     with open(f'/var/db/system/.{ds[1]}_cache_backup', 'wb') as f:

--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -1114,6 +1114,9 @@ class KerberosKeytabService(CRUDService):
         assume that samba has updated it behind the scenes and that the configuration
         database needs to be updated to reflect the change.
         """
+        if not await self.middleware.call('system.ready'):
+            return
+
         old_mtime = 0
         ad_state = await self.middleware.call('activedirectory.get_state')
         if ad_state == 'DISABLED' or not os.path.exists(keytab['SYSTEM'].value):

--- a/src/middlewared/middlewared/plugins/nis.py
+++ b/src/middlewared/middlewared/plugins/nis.py
@@ -166,7 +166,12 @@ class NISService(ConfigService):
         except asyncio.TimeoutError:
             raise CallError('nis.started check timed out after 5 seconds.')
 
-        if (await self.get_state()) != 'HEALTHY':
+        try:
+            cached_state = await self.middleware.call_sync('cache.get', 'DS_STATE')
+
+            if cached_state['nis'] != 'HEALTHY':
+                await self.set_state(DSStatus['HEALTHY'])
+        except KeyError:
             await self.set_state(DSStatus['HEALTHY'])
 
         return ret

--- a/src/middlewared/middlewared/plugins/smb_/registry.py
+++ b/src/middlewared/middlewared/plugins/smb_/registry.py
@@ -146,7 +146,7 @@ class SharingSMBService(Service):
                 await self.middleware.call('sharing.smb.strip_comments', share)
 
         if gl['ad_enabled'] is None:
-            gl['ad_enabled'] = False if (await self.middleware.call('activedirectory.get_state')) == "DISABLED" else True
+            gl['ad_enabled'] = (await self.middleware.call('activedirectory.config'))['enable']
 
         if gl['fruit_enabled'] is None:
             gl['fruit_enabled'] = (await self.middleware.call('smb.config'))['aapl_extensions']


### PR DESCRIPTION
Ensure that py-ldap usage is serialized in a middleware job. These
should be infrequent, and so impact should be minimal. Also make sure
we avoid potential calls to 'started' methods for directory services
when we only need to know whether they are enabled.