### PR TITLE
Initialize directory service state to JOINING if enabled

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -841,6 +841,13 @@ class ActiveDirectoryService(ConfigService):
             raise CallError('Automatically disabling ActiveDirectory service due to invalid configuration.',
                             errno.EINVAL)
 
+        """
+        Initialize state to "JOINING" until after booted.
+        """
+        if not await self.middleware.call('system.ready'):
+            await self.set_state(DSStatus['JOINING'])
+            return True
+
         await self.middleware.call('activedirectory.conn_check', config)
 
         if (await self.get_state()) != 'HEALTHY':

--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -820,6 +820,13 @@ class LDAPService(ConfigService):
             raise CallError('Automatically disabling LDAP service due to invalid configuration.',
                             errno.EINVAL)
 
+        """
+        Initialize state to "JOINING" until after booted.
+        """
+        if not await self.middleware.call('system.ready'):
+            await self.set_state(DSStatus['JOINING'])
+            return True
+
         try:
             await asyncio.wait_for(self.middleware.call('ldap.get_root_DSE', ldap),
                                    timeout=ldap['timeout'])

--- a/src/middlewared/middlewared/plugins/nis.py
+++ b/src/middlewared/middlewared/plugins/nis.py
@@ -153,6 +153,14 @@ class NISService(ConfigService):
         ret = False
         if not (await self.config())['enable']:
             return ret
+
+        """
+        Initialize state to "JOINING" until after booted.
+        """
+        if not await self.middleware.call('system.ready'):
+            await self.set_state(DSStatus['JOINING'])
+            return True
+
         try:
             ret = await asyncio.wait_for(self.__ypwhich(), timeout=5.0)
         except asyncio.TimeoutError:


### PR DESCRIPTION
Return JOINING for enabled directory services until after the system is
ready. The state will be updated during next directory service health
check.