### PR TITLE
NAS-108166 / 12.0 / R-Series support in enclosure API

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/alert/source/license_status.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/alert/source/license_status.py
@@ -106,7 +106,8 @@ class LicenseStatusAlertSource(ThreadedAlertSource):
                         ) % license['model']
                     ))
             else:
-                if hardware[0] in ('M40', 'M50', 'M60', 'X10', 'X20', 'Z20', 'Z30', 'Z35', 'Z50'):
+                if hardware[0] in ('M40', 'M50', 'M60', 'R10', 'R20', 'R40', 'R50', 'X10', 'X20', 'Z20', 'Z30', 'Z35',
+                                   'Z50'):
                     if hardware[0] != license['model']:
                         alerts.append(Alert(
                             LicenseAlertClass,

--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/concatenate.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/concatenate.py
@@ -1,0 +1,68 @@
+from collections import defaultdict
+import itertools
+import operator
+import re
+
+from middlewared.service import Service, private
+
+RE_DRAWER = re.compile(r"^(.+), Drawer #([0-9]+)$")
+
+
+class EnclosureService(Service):
+    @private
+    async def concatenate_enclosures(self, enclosures):
+        concatenated = defaultdict(list)
+        result = []
+        for enclosure in enclosures:
+            if m := re.match(RE_DRAWER, enclosure["model"]):
+                concatenated[m.group(1)].append((int(m.group(2)), enclosure))
+            else:
+                result.append(enclosure)
+
+        for model, items in concatenated.items():
+            items = [i[1] for i in sorted(items, key=operator.itemgetter(0))]
+
+            id = "_".join(map(operator.itemgetter("id"), items))
+            name = ", ".join(map(operator.itemgetter("name"), items))
+
+            enclosure = items[0]
+            items = items[1:]
+
+            original_id = enclosure["id"]
+            enclosure["id"] = id
+            enclosure["name"] = name
+            enclosure["model"] = model
+
+            for elements in enclosure["elements"]:
+                for element in elements["elements"]:
+                    element["original"] = {
+                        "enclosure": original_id,
+                        "slot": element["slot"],
+                    }
+
+            for item in items:
+                assert len(enclosure["elements"]) == len(item["elements"])
+
+                for i, elements in enumerate(enclosure["elements"]):
+                    item_elements = item["elements"][i]
+
+                    assert elements["name"] == item_elements["name"]
+                    assert elements["descriptor"] == item_elements["descriptor"]
+
+                    for element in item_elements["elements"]:
+                        elements["elements"].append(dict(
+                            element,
+                            original={
+                                "enclosure_id": item["id"],
+                                "slot": element["slot"],
+                            },
+                        ))
+
+            slot = itertools.count(1)
+            for elements in enclosure["elements"]:
+                for element in elements["elements"]:
+                    element["slot"] = next(slot)
+
+            result.append(enclosure)
+
+        return result

--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/m50_plx.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/m50_plx.py
@@ -92,7 +92,6 @@ class EnclosureService(Service):
                 "name": "Rear NVME U.2 Hotswap Bays",
                 "model": "M50/60 Series",
                 "controller": True,
-                "label": "Rear NVME U.2 Hotswap Bays",
                 "elements": [
                     {
                         "name": "Array Device Slot",

--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/map.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/enclosure_/map.py
@@ -126,7 +126,6 @@ class EnclosureService(Service):
                 "name": "Drive Bays",
                 "model": info["system_product"],
                 "controller": True,
-                "label": "Drive Bays",
                 "elements": [
                     {
                         "name": "Array Device Slot",


### PR DESCRIPTION
For R10 and R20 we'll get one enclosure

For R40 we'll get two enclosures: `R40, Drawers #1-2` and `R40, Drawers #3-4` (I've invented the names, please let me know if I am wrong). They are named the same (`ECStream FS2 c209`) so I guess I order them by appearance order in `/dev/ses*`?

For R50 we'll get two enclosures too: `R50, Drawer #1` and `R50, Drawer #2`, the number I am able to get from the name