### PR TITLE
NAS-108182 / 20.12 / integrate nfs-ganesha with gluster

### DIFF
--- a/src/middlewared/middlewared/async_validators.py
+++ b/src/middlewared/middlewared/async_validators.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from middlewared.validators import IpAddress
 
 
-async def check_path_resides_within_volume(verrors, middleware, name, path):
+async def check_path_resides_within_volume(verrors, middleware, name, path, gluster_bypass=False):
 
     # we need to make sure the sharing service is configured within the zpool
     rp = os.path.realpath(path)
@@ -17,26 +17,28 @@ async def check_path_resides_within_volume(verrors, middleware, name, path):
     ):
         verrors.add(name, "The path must reside within a pool mount point")
 
-    # we must also make sure that any sharing service does not point to
-    # anywhere within the ".glusterfs" dataset since the clients need
-    # to go through the appropriate gluster client to write to the cluster.
-    # If data is modified directly on the gluster resources, then it will
-    # cause a split-brain scenario which means the data that was modified
-    # would not be sync'ed with other nodes in the cluster.
-    rp = Path(rp)
+    # currently only nfs sharing service (on SCALE) supports gluster config
+    if not gluster_bypass:
+        # we must also make sure that any sharing service does not point to
+        # anywhere within the ".glusterfs" dataset since the clients need
+        # to go through the appropriate gluster client to write to the cluster.
+        # If data is modified directly on the gluster resources, then it will
+        # cause a split-brain scenario which means the data that was modified
+        # would not be sync'ed with other nodes in the cluster.
+        rp = Path(rp)
 
-    using_gluster_path = False
-    if rp.is_mount() and rp.name == '.glusterfs':
-        using_gluster_path = True
-    else:
-        # subtract 2 here to remove the '/' and 'mnt' parents
-        for i in range(0, len(rp.parents) - 2):
-            if rp.parents[i].is_mount() and rp.parents[i].name == ".glusterfs":
-                using_gluster_path = True
-                break
+        using_gluster_path = False
+        if rp.is_mount() and rp.name == '.glusterfs':
+            using_gluster_path = True
+        else:
+            # subtract 2 here to remove the '/' and 'mnt' parents
+            for i in range(0, len(rp.parents) - 2):
+                if rp.parents[i].is_mount() and rp.parents[i].name == ".glusterfs":
+                    using_gluster_path = True
+                    break
 
-    if using_gluster_path:
-        verrors.add(name, "A path being used by Gluster is not allowed")
+        if using_gluster_path:
+            verrors.add(name, "A path being used by Gluster is not allowed")
 
 
 async def resolve_hostname(middleware, verrors, name, hostname):

--- a/src/middlewared/middlewared/plugins/nfs.py
+++ b/src/middlewared/middlewared/plugins/nfs.py
@@ -393,10 +393,15 @@ class SharingNFSService(SharingService):
         if data["alldirs"] and len(data["paths"]) > 1:
             verrors.add(f"{schema_name}.alldirs", "This option can only be used for shares that contain single path")
 
+        # if any of the `paths` that were passed to us by user are within the gluster volume
+        # mountpoint then we need to pass the `gluster_bypass` kwarg so that we don't raise a
+        # validation error complaining about using a gluster path within the zpool mountpoint
+        bypass = any('.glusterfs' in i for i in data["paths"] + data["aliases"])
+
         # need to make sure that the nfs share is within the zpool mountpoint
         for idx, i in enumerate(data["paths"]):
             await check_path_resides_within_volume(
-                verrors, self.middleware, f'{schema_name}.paths.{idx}', i
+                verrors, self.middleware, f'{schema_name}.paths.{idx}', i, gluster_bypass=bypass
             )
 
         await self.middleware.run_in_thread(self.validate_paths, data, schema_name, verrors)


### PR DESCRIPTION
- query middleware for gluster peer information once so we dont have to call that for every nfs share that's in the db
- validation is completely hinged on the fact that the top-level dataset is always `/mnt/tank/.glusterfs` (this is being enforced by TC so no worries there)