### PR TITLE
NAS-108218 / 12.0 / Serialize LDAP queries and avoid extra calls to started methods (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -843,7 +843,12 @@ class ActiveDirectoryService(ConfigService):
 
         await self.middleware.call('activedirectory.conn_check', config)
 
-        if (await self.get_state()) != 'HEALTHY':
+        try:
+            cached_state = await self.middleware.call_sync('cache.get', 'DS_STATE')
+
+            if cached_state['activedirectory'] != 'HEALTHY':
+                await self.set_state(DSStatus['HEALTHY'])
+        except KeyError:
             await self.set_state(DSStatus['HEALTHY'])
 
         return True

--- a/src/middlewared/middlewared/plugins/cache.py
+++ b/src/middlewared/middlewared/plugins/cache.py
@@ -136,7 +136,7 @@ class DSCache(Service):
 
     def initialize(self):
         for ds in [('activedirectory', 'AD'), ('ldap', 'LDAP'), ('nis', 'NIS')]:
-            if self.middleware.call_sync(f'{ds[0]}.get_state') != 'DISABLED':
+            if (self.middleware.call_sync(f'{ds[0]}.config'))['enable']:
                 try:
                     with open(f'/var/db/system/.{ds[1]}_cache_backup', 'rb') as f:
                         pickled_cache = pickle.load(f)
@@ -146,7 +146,7 @@ class DSCache(Service):
 
     def backup(self):
         for ds in [('activedirectory', 'AD'), ('ldap', 'LDAP'), ('nis', 'NIS')]:
-            if self.middleware.call_sync(f'{ds[0]}.get_state') != 'DISABLED':
+            if (self.middleware.call_sync(f'{ds[0]}.config'))['enable']:
                 try:
                     ds_cache = self.middleware.call_sync('cache.get', f'{ds[1]}_cache')
                     with open(f'/var/db/system/.{ds[1]}_cache_backup', 'wb') as f:

--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -1108,6 +1108,9 @@ class KerberosKeytabService(CRUDService):
         assume that samba has updated it behind the scenes and that the configuration
         database needs to be updated to reflect the change.
         """
+        if not await self.middleware.call('system.ready'):
+            return
+
         old_mtime = 0
         ad_state = await self.middleware.call('activedirectory.get_state')
         if ad_state == 'DISABLED' or not os.path.exists(keytab['SYSTEM'].value):

--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -729,29 +729,50 @@ class LDAPService(ConfigService):
         return ret
 
     @private
-    def validate_credentials(self, ldap=None):
-        ret = False
-        if ldap is None:
-            ldap = self.middleware.call_sync('ldap.config')
+    @job(lock="ldapquery")
+    def do_ldap_query(self, job, ldap_conf, action, args):
+        supported_actions = [
+            'get_samba_domains',
+            'get_root_DSE',
+            'get_dn',
+            'validate_credentials',
+        ]
+        if action not in supported_actions:
+            raise CallError(f"Unsuported LDAP query: {action}")
 
-        with LDAPQuery(conf=ldap, logger=self.logger, hosts=ldap['uri_list']) as LDAP:
-            ret = LDAP.validate_credentials()
+        if ldap_conf is None:
+            ldap_conf = self.middleware.call_sync('ldap.config')
+
+        with LDAPQuery(conf=ldap_conf, logger=self.logger, hosts=ldap_conf['uri_list']) as LDAP:
+            if action == "get_samba_domains":
+                ret = LDAP.get_samba_domains()
+
+            elif action == "get_root_DSE":
+                ret = LDAP.get_root_DSE()
+
+            elif action == "get_dn":
+                dn = ldap_conf['basedn'] if args is None else args
+                ret = LDAP.get_dn(dn)
+
+            elif action == "validate_credentials":
+                ret = LDAP.validate_credentials()
 
         return ret
 
     @private
-    def get_samba_domains(self, ldap=None):
-        ret = []
-        if ldap is None:
-            ldap = self.middleware.call_sync('ldap.config')
-
-        with LDAPQuery(conf=ldap, logger=self.logger, hosts=ldap['uri_list']) as LDAP:
-            ret = LDAP.get_samba_domains()
-
+    def validate_credentials(self, ldap_config=None):
+        ldap_job = self.middleware.call_sync("ldap.do_ldap_query", ldap_config, "validate_credentials", None)
+        ret = ldap_job.wait_sync()
         return ret
 
     @private
-    def get_root_DSE(self, ldap=None):
+    def get_samba_domains(self, ldap_config=None):
+        ldap_job = self.middleware.call_sync("ldap.do_ldap_query", ldap_config, "get_samba_domains", None)
+        ret = ldap_job.wait_sync()
+        return ret
+
+    @private
+    def get_root_DSE(self, ldap_config=None):
         """
         root DSE is defined in RFC4512, and must include the following:
 
@@ -772,29 +793,17 @@ class LDAPService(ConfigService):
 
         In practice, this full data is not returned from many LDAP servers
         """
-        ret = []
-        if ldap is None:
-            ldap = self.middleware.call_sync('ldap.config')
-
-        with LDAPQuery(conf=ldap, logger=self.logger, hosts=ldap['uri_list']) as LDAP:
-            ret = LDAP.get_root_DSE()
-
+        ldap_job = self.middleware.call_sync("ldap.do_ldap_query", ldap_config, "get_root_DSE", None)
+        ret = ldap_job.wait_sync()
         return ret
 
     @private
-    def get_dn(self, dn=None, ldap=None):
+    def get_dn(self, dn=None, ldap_config=None):
         """
         Outputs contents of specified DN in JSON. By default will target the basedn.
         """
-        ret = []
-        if ldap is None:
-            ldap = self.middleware.call_sync('ldap.config')
-
-        if dn is None:
-            dn = ldap['basedn']
-        with LDAPQuery(conf=ldap, logger=self.logger, hosts=ldap['uri_list']) as LDAP:
-            ret = LDAP.get_dn(dn)
-
+        ldap_job = self.middleware.call_sync("ldap.do_ldap_query", ldap_config, "get_dn", dn)
+        ret = ldap_job.wait_sync()
         return ret
 
     @private
@@ -829,7 +838,12 @@ class LDAPService(ConfigService):
         except Exception as e:
             raise CallError(e)
 
-        if (await self.get_state()) != 'HEALTHY':
+        try:
+            cached_state = await self.middleware.call_sync('cache.get', 'DS_STATE')
+
+            if cached_state['ldap'] != 'HEALTHY':
+                await self.set_state(DSStatus['HEALTHY'])
+        except KeyError:
             await self.set_state(DSStatus['HEALTHY'])
 
         return True

--- a/src/middlewared/middlewared/plugins/nis.py
+++ b/src/middlewared/middlewared/plugins/nis.py
@@ -158,7 +158,12 @@ class NISService(ConfigService):
         except asyncio.TimeoutError:
             raise CallError('nis.started check timed out after 5 seconds.')
 
-        if (await self.get_state()) != 'HEALTHY':
+        try:
+            cached_state = await self.middleware.call_sync('cache.get', 'DS_STATE')
+
+            if cached_state['nis'] != 'HEALTHY':
+                await self.set_state(DSStatus['HEALTHY'])
+        except KeyError:
             await self.set_state(DSStatus['HEALTHY'])
 
         return ret

--- a/src/middlewared/middlewared/plugins/smb_/registry.py
+++ b/src/middlewared/middlewared/plugins/smb_/registry.py
@@ -146,7 +146,7 @@ class SharingSMBService(Service):
                 await self.middleware.call('sharing.smb.strip_comments', share)
 
         if gl['ad_enabled'] is None:
-            gl['ad_enabled'] = False if (await self.middleware.call('activedirectory.get_state')) == "DISABLED" else True
+            gl['ad_enabled'] = (await self.middleware.call('activedirectory.config'))['enable']
 
         if gl['fruit_enabled'] is None:
             gl['fruit_enabled'] = (await self.middleware.call('smb.config'))['aapl_extensions']


### PR DESCRIPTION
Ensure that py-ldap usage is serialized in a middleware job. These
should be infrequent, and so impact should be minimal. Also make sure
we avoid potential calls to 'started' methods for directory services
when we only need to know whether they are enabled.

Original PR: https://github.com/freenas/freenas/pull/5972