### PR TITLE
NAS-108325 / 12.0 / make ix-haready run after securelevel (by yocalebo)

### DIFF
--- a/src/freenas/etc/rc.d/ix-haready
+++ b/src/freenas/etc/rc.d/ix-haready
@@ -9,7 +9,7 @@
 #
 
 # PROVIDE: ix-haready
-# REQUIRES: ix-postinit
+# REQUIRES: ix-postinit securelevel
 # KEYWORD: shutdown
 
 . /etc/rc.subr


### PR DESCRIPTION
`securelevel` calls the `sysctl` daemon which unsets the `net.inet.carp.allow` sysctl tunable that `ix-haready` sets. This ensures all the associated `/etc/sysctl.conf` and `/etc/sysctl.conf.local` settings are applied completely before `ix-haready` sets it.

Original PR: https://github.com/freenas/freenas/pull/5983