### PR TITLE
NAS-108250 / 12.0 / Fix typo in <ds>.started()

### DIFF
--- a/src/middlewared/middlewared/plugins/activedirectory.py
+++ b/src/middlewared/middlewared/plugins/activedirectory.py
@@ -851,7 +851,7 @@ class ActiveDirectoryService(ConfigService):
         await self.middleware.call('activedirectory.conn_check', config)
 
         try:
-            cached_state = await self.middleware.call_sync('cache.get', 'DS_STATE')
+            cached_state = await self.middleware.call('cache.get', 'DS_STATE')
 
             if cached_state['activedirectory'] != 'HEALTHY':
                 await self.set_state(DSStatus['HEALTHY'])

--- a/src/middlewared/middlewared/plugins/ldap.py
+++ b/src/middlewared/middlewared/plugins/ldap.py
@@ -846,7 +846,7 @@ class LDAPService(ConfigService):
             raise CallError(e)
 
         try:
-            cached_state = await self.middleware.call_sync('cache.get', 'DS_STATE')
+            cached_state = await self.middleware.call('cache.get', 'DS_STATE')
 
             if cached_state['ldap'] != 'HEALTHY':
                 await self.set_state(DSStatus['HEALTHY'])

--- a/src/middlewared/middlewared/plugins/nis.py
+++ b/src/middlewared/middlewared/plugins/nis.py
@@ -167,7 +167,7 @@ class NISService(ConfigService):
             raise CallError('nis.started check timed out after 5 seconds.')
 
         try:
-            cached_state = await self.middleware.call_sync('cache.get', 'DS_STATE')
+            cached_state = await self.middleware.call('cache.get', 'DS_STATE')
 
             if cached_state['nis'] != 'HEALTHY':
                 await self.set_state(DSStatus['HEALTHY'])


### PR DESCRIPTION
replace call_sync() with call()