### PR TITLE
NAS-108264 / 20.12 / Reconfigure SMB shares on toggle of aapl_extensions (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -512,6 +512,23 @@ class SMBService(SystemServiceService):
         return await self.get_smb_ha_mode()
 
     @private
+    async def apply_aapl_changes(self):
+        shares = await self.middleware.call('sharing.smb.query')
+        for share in shares:
+            diff = await self.middleware.call(
+                'sharing.smb.diff_middleware_and_registry', share['name'], share
+            )
+
+            if diff is None:
+                self.logger.warning("Share [%s] does not exist in registry.",
+                                    share['name'])
+                continue
+
+            share_name = share['name'] if not share['home'] else 'homes'
+            await self.middleware.call('sharing.smb.apply_conf_diff',
+                                       'REGISTRY', share_name, diff)
+
+    @private
     async def validate_smb(self, new, verrors):
         try:
             await self.middleware.call('sharing.smb.validate_aux_params',
@@ -679,6 +696,13 @@ class SMBService(SystemServiceService):
 
         await self._update_service(old, new)
         await self.reset_smb_ha_mode()
+
+        """
+        Toggling aapl_extensions will require changes to all shares
+        on server (enabling vfs_fruit and possibly changing catia params).
+        """
+        if old['aapl_extensions'] != new['aapl_extensions']:
+            await self.apply_aapl_changes()
 
         return await self.config()
 


### PR DESCRIPTION
Ensure that SMB shares are reconfigured properly during changes enabling / disabling vfs_fruit.

Original PR: https://github.com/freenas/freenas/pull/5995