### PR TITLE
NAS-108273 / 20.12 / Properly account for missing vnc_resolution attribute in vnc device

### DIFF
--- a/src/middlewared/middlewared/plugins/usage.py
+++ b/src/middlewared/middlewared/plugins/usage.py
@@ -500,9 +500,9 @@ class UsageService(Service):
 
                     vnc_list.append(
                         {
-                            'wait': attrs['wait'],
-                            'vnc_resolution': attrs['vnc_resolution'],
-                            'web': attrs['vnc_web']
+                            'wait': attrs.get('wait'),
+                            'vnc_resolution': attrs.get('vnc_resolution'),
+                            'web': attrs.get('vnc_web')
                         }
                     )
 

--- a/src/middlewared/middlewared/plugins/vm/devices/nic.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/nic.py
@@ -29,7 +29,7 @@ class NIC(Device):
         return ':'.join(['%02x' % x for x in mac_address])
 
     def setup_nic_attach(self):
-        nic_attach = self.data['attributes']['nic_attach']
+        nic_attach = self.data['attributes'].get('nic_attach')
         interfaces = netif.list_interfaces()
         if nic_attach and nic_attach not in interfaces:
             raise CallError(f'{nic_attach} not found.')

--- a/src/middlewared/middlewared/plugins/vm/devices/vnc.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/vnc.py
@@ -50,7 +50,7 @@ class VNC(Device):
 
     def hypervisor_args_freebsd(self, *args, **kwargs):
         attrs = self.data['attributes']
-        width, height = (attrs['vnc_resolution'] or '1024x768').split('x')
+        width, height = (attrs.get('vnc_resolution') or '1024x768').split('x')
         return '-s ' + ','.join(filter(
             bool, [
                 '29',
@@ -59,7 +59,7 @@ class VNC(Device):
                 f'tcp={attrs["vnc_bind"]}:{attrs["vnc_port"]}',
                 f'w={width}',
                 f'h={height}',
-                f'password={attrs["vnc_password"]}' if attrs['vnc_password'] else None,
+                f'password={attrs["vnc_password"]}' if attrs.get('vnc_password') else None,
                 'wait' if attrs.get('wait') else None,
             ]
         ))

--- a/src/middlewared/middlewared/plugins/vm/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/vm/lifecycle.py
@@ -64,7 +64,9 @@ class VMService(Service, VMSupervisorMixin):
                     self._add_with_vm_data(vm_data)
                 except Exception as e:
                     # Whatever happens, we don't want middlewared not booting
-                    self.middleware.logger.error('Unable to setup %r VM object: %s', vm_data['name'], str(e))
+                    self.middleware.logger.error(
+                        'Unable to setup %r VM object: %s', vm_data['name'], str(e), exc_info=True
+                    )
         else:
             self.middleware.logger.error('Failed to establish libvirt connection')
 


### PR DESCRIPTION
This PR fixes an issue where on old systems we could have created vm vnc devices with missing `vnc_resolution` key.