### PR TITLE
NAS-108290 / 12.0 / Fix shell override in nscld.conf (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/nslcd.conf
+++ b/src/middlewared/middlewared/etc_files/local/nslcd.conf
@@ -57,7 +57,7 @@
     scope 	sub
     timelimit	${ldap['timeout']}
     bind_timelimit ${ldap['dns_timeout']}
-    map passwd loginShell /bin/sh
+    map passwd loginShell "/bin/sh"
   % if aux:
     ${'\n'.join(aux)}
   % endif


### PR DESCRIPTION
Apparently, we must enclose the path for the shell in quotes in order for it to be populated correctly in passwd struct. Issue appears to be quite old (going back to initial inclusion of nslcd).

Original PR: https://github.com/freenas/freenas/pull/6007