### PR TITLE
NAS-108305 / 20.12 / Allow using latest as a valid item version for catalog items

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -65,7 +65,9 @@ class CatalogService(Service):
 
         item_data.update({k: item_data.get(k) for k in ITEM_KEYS})
 
-        for version in filter(lambda p: os.path.isdir(os.path.join(item_path, p)), os.listdir(item_path)):
+        for version in sorted(
+            filter(lambda p: os.path.isdir(os.path.join(item_path, p)), os.listdir(item_path)), reverse=True
+        ):
             item_data['versions'][version] = self.item_version_details(os.path.join(item_path, version))
         return item_data
 

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -3,6 +3,8 @@ import markdown
 import os
 import yaml
 
+from pkg_resources import parse_version
+
 from middlewared.schema import Bool, Dict, Str
 from middlewared.service import accepts, private, Service
 
@@ -66,7 +68,8 @@ class CatalogService(Service):
         item_data.update({k: item_data.get(k) for k in ITEM_KEYS})
 
         for version in sorted(
-            filter(lambda p: os.path.isdir(os.path.join(item_path, p)), os.listdir(item_path)), reverse=True
+            filter(lambda p: os.path.isdir(os.path.join(item_path, p)), os.listdir(item_path)),
+            reverse=True, key=parse_version,
         ):
             item_data['versions'][version] = self.item_version_details(os.path.join(item_path, version))
         return item_data

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_utils.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_utils.py
@@ -1,0 +1,11 @@
+from middlewared.service import private, Service
+
+
+class ChartReleaseService(Service):
+
+    class Config:
+        namespace = 'chart.release'
+
+    @private
+    async def get_latest_version_from_item_versions(self, item_versions):
+        return sorted(item_versions or ['latest'], reverse=True)[0]


### PR DESCRIPTION
This PR aims to introduce `latest` string as a valid item version string for creating / upgrading chart releases. Motivation is to make it users to deploy latest version of a catalog item without looking up what the latest version actually is.