### PR TITLE
NAS-108313 / 20.12 / fix failover.control and failover.update

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
@@ -130,8 +130,9 @@ class FailoverService(ConfigService):
         """
         Update failover state.
 
-        `disabled` when true indicates that HA is disabled.
-        `master` sets the state of current node. Standby node will have the opposite value.
+        `disabled` When true indicates that HA will be disabled.
+        `master`  Marks the particular node in the chassis as the master node.
+                    The standby node will have the opposite value.
 
         `timeout` is the time to WAIT until a failover occurs when a network
             event occurs on an interface that is marked critical for failover AND
@@ -149,11 +150,10 @@ class FailoverService(ConfigService):
         new.update(data)
 
         if master is not NOT_PROVIDED:
-            if master is None:
-                # The node making the call is the one we want to make it MASTER by default
-                new['master_node'] = await self.middleware.call('failover.node')
-            else:
-                new['master_node'] = await self._master_node(master)
+            # The node making the call is the one we want to make MASTER by default
+            new['master_node'] = await self.middleware.call('failover.node')
+        else:
+            new['master_node'] = await self._master_node(master)
 
         verrors = ValidationErrors()
         if new['disabled'] is False:
@@ -810,8 +810,11 @@ class FailoverService(ConfigService):
         ),
     )
     async def control(self, action, options=None):
-        if options is None:
-            options = {}
+        if not options:
+            # The node making the call is the one we want to make MASTER by default
+            node = await self._master_node((await self.middleware.call('failover.node')))
+        else:
+            node = await self._master_node(options.get('active'))
 
         failover = await self.middleware.call('datastore.config', 'system.failover')
         if action == 'ENABLE':
@@ -820,19 +823,19 @@ class FailoverService(ConfigService):
                 return False
             update = {
                 'disabled': False,
-                'master_node': await self._master_node(False),
+                'master_node': node,
             }
-            await self.middleware.call('datastore.update', 'system.failover', failover['id'], update)
-            await self.middleware.call('service.restart', 'failover')
         elif action == 'DISABLE':
             if failover['disabled'] is True:
                 # Already disabled
                 return False
             update = {
-                'master_node': await self._master_node(True if options.get('active') else False),
+                'disabled': True,
+                'master_node': node,
             }
-            await self.middleware.call('datastore.update', 'system.failover', failover['id'], update)
-            await self.middleware.call('service.restart', 'failover')
+
+        await self.middleware.call('datastore.update', 'system.failover', failover['id'], update)
+        await self.middleware.call('service.restart', 'failover')
 
     @private
     def upgrade_version(self):


### PR DESCRIPTION
Many bugs fixed here and also make the `failover.control` API behavior match the `failover.update` API behavior.

`failover.control` fixes
- disabling HA didn't actually disable anything (this breaks `hactl` since it uses this API)
- `options` will never be `None` and gets passed in as `{}` when that attribute isn't given to us
- if the `active` attribute wasn't provided and HA was disabled, it actually designated the standby node as the master node which is the exact opposite behavior of what `failover.update` API does.

`failover.update` fixes
- if `master` is `NOT_PROVIDED` it will never be `None` which means the `master` variable wasn't being set appropriately