### PR TITLE
NAS-108273 / 12.0 / Properly account for missing vnc_resolution attribute in vnc device (by sonicaj)

### DIFF
--- a/src/middlewared/middlewared/plugins/usage.py
+++ b/src/middlewared/middlewared/plugins/usage.py
@@ -477,9 +477,9 @@ class UsageService(Service):
 
                     vnc_list.append(
                         {
-                            'wait': attrs['wait'],
-                            'vnc_resolution': attrs['vnc_resolution'],
-                            'web': attrs['vnc_web']
+                            'wait': attrs.get('wait'),
+                            'vnc_resolution': attrs.get('vnc_resolution'),
+                            'web': attrs.get('vnc_web')
                         }
                     )
 

--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -776,7 +776,7 @@ class NIC(Device):
         return ':'.join(['%02x' % x for x in mac_address])
 
     def pre_start_vm(self, *args, **kwargs):
-        nic_attach = self.data['attributes']['nic_attach']
+        nic_attach = self.data['attributes'].get('nic_attach')
         interfaces = netif.list_interfaces()
         bridge = None
         if nic_attach and nic_attach not in interfaces:
@@ -861,7 +861,7 @@ class VNC(Device):
 
     def bhyve_args(self, *args, **kwargs):
         attrs = self.data['attributes']
-        width, height = (attrs['vnc_resolution'] or '1024x768').split('x')
+        width, height = (attrs.get('vnc_resolution') or '1024x768').split('x')
         return '-s ' + ','.join(filter(
             bool, [
                 '29',
@@ -870,7 +870,7 @@ class VNC(Device):
                 f'tcp={attrs["vnc_bind"]}:{attrs["vnc_port"]}',
                 f'w={width}',
                 f'h={height}',
-                f'password={attrs["vnc_password"]}' if attrs['vnc_password'] else None,
+                f'password={attrs["vnc_password"]}' if attrs.get('vnc_password') else None,
                 'wait' if attrs.get('wait') else None,
             ]
         ))

--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -1854,7 +1854,9 @@ class VMService(CRUDService):
                     self.vms[vm_data['name']] = VMSupervisor(vm_data, self.libvirt_connection, self.middleware)
                 except Exception as e:
                     # Whatever happens, we don't want middlewared not booting
-                    self.middleware.logger.error('Unable to setup %r VM object: %s', vm_data['name'], str(e))
+                    self.middleware.logger.error(
+                        'Unable to setup %r VM object: %s', vm_data['name'], str(e), exc_info=True
+                    )
         else:
             self.middleware.logger.error('Failed to establish libvirt connection')
 


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 8bf34992c2bd80cd39e2d26a79e17f887fd88674
    git cherry-pick -x 12a453924027e7e284dce0c21c7486569d40e912

This PR fixes an issue where on old systems we could have created vm vnc devices with missing `vnc_resolution` key.

Original PR: https://github.com/freenas/freenas/pull/6005