### PR TITLE
NAS-108357 / 20.12 / Add usage stats for kubernetes

### DIFF
--- a/src/middlewared/middlewared/plugins/usage.py
+++ b/src/middlewared/middlewared/plugins/usage.py
@@ -210,6 +210,8 @@ class UsageService(Service):
         # 3) No of backups
         # 4) No of automatic backups taken
         # 5) List of docker images
+        # 6) Configured cluster cidr info
+        k8s_config = await self.middleware.call('kubernetes.config')
         output = {
             'chart_releases': 0,
             # catalog -> train -> item -> versions
@@ -219,6 +221,10 @@ class UsageService(Service):
                 'automatic_backups': 0,
             },
             'docker_images': set(),
+            'kubernetes_config': {
+                'cluster_cidr': k8s_config['cluster_cidr'],
+                'service_cidr': k8s_config['service_cidr'],
+            },
         }
         chart_releases = await self.middleware.call('chart.release.query')
         output['chart_releases'] = len(chart_releases)
@@ -235,6 +241,8 @@ class UsageService(Service):
         })
         for image in await self.middleware.call('docker.images.query'):
             output['docker_images'].update(image['repo_tags'])
+
+        output['docker_images'] = list(output['docker_images'])
 
         return output
 


### PR DESCRIPTION
Following is an example of stats being retrieved:
```
{
  "chart_releases": 4,
  "catalog_items": {
    "OFFICIAL": {
      "test": {
        "ix-chart": {
          "2010.0.2": 3,
          "2010.0.1": 1
        }
      }
    }
  },
  "chart_releases_backups": {
    "total_backups": 3,
    "automatic_backups": 2
  },
  "docker_images": [
    "quay.io/k8scsi/csi-snapshotter:v2.0.1",
    "bitnami/redis:5.0.8-debian-10-r33",
    "nginx:1.15.4",
    "quay.io/k8scsi/csi-resizer:v0.4.0",
    "sonicaj/priv:test2",
    "nginx:latest",
    "rancher/rancher:v2.4.8",
    "nvidia/k8s-device-plugin:1.0.0-beta6",
    "sonicaj/py-libzfs:latest",
    "quay.io/k8scsi/snapshot-controller:v2.0.1",
    "busybox:latest",
    "test/rancher/adsf/adsf:latest",
    "alcide/advisor:stable",
    "gcr.io/triggermesh/aws-event-sources-controller:v0.6.0",
    "nvidia/cuda:10.0-base",
    "rancher/pause:3.1",
    "quay.io/k8scsi/csi-node-driver-registrar:v1.2.0",
    "debian:testing",
    "portainer/portainer-ce:latest",
    "rancher/rancher:latest",
    "rancher/klipper-helm:v0.3.0",
    "quay.io/k8scsi/csi-provisioner:v1.6.0",
    "<none>:<none>",
    "sonicaj/priv:test",
    "rancher/klipper-lb:v0.1.2",
    "plexinc/pms-docker:latest",
    "bitnami/mariadb:10.3.22-debian-10-r44",
    "debian:latest",
    "quay.io/jetstack/cert-manager-cainjector:v0.15.0",
    "quay.io/jetstack/cert-manager-webhook:v0.15.0",
    "quay.io/jetstack/cert-manager-controller:v0.15.0",
    "debian:testing-slim",
    "rancher/coredns-coredns:1.6.9",
    "quay.io/openebs/zfs-driver:ci",
    "nvidia/cuda:10.2-base",
    "rancher/rancher-agent:v2.4.8",
    "linuxserver/qbittorrent:latest",
    "test/rancher:latest"
  ],
  "kubernetes_config": {
    "cluster_cidr": "172.16.0.0/16",
    "service_cidr": "172.17.0.0/16"
  }
}
```