### PR TITLE
NAS-108343 / 12.0 / Do not hide excessive args in method calls

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -1226,7 +1226,8 @@ class Middleware(LoadPluginsMixin, RunInThreadMixin, ServiceCallMixin):
         if not hasattr(method, 'accepts'):
             return args
 
-        return [method.accepts[i].dump(arg) for i, arg in enumerate(args) if i < len(method.accepts)]
+        return [method.accepts[i].dump(arg) if i < len(method.accepts) else arg
+                for i, arg in enumerate(args)]
 
     async def call(self, name, *params, pipes=None, job_on_progress_cb=None, app=None, profile=False):
         serviceobj, methodobj = self._method_lookup(name)


### PR DESCRIPTION
The real cause of issue is resolved by https://github.com/freenas/webui/pull/4886