### PR TITLE
NAS-108354 / 20.12 / Add validation to ensure valid mac address is provided for VM nic device

### DIFF
--- a/src/middlewared/middlewared/plugins/vm/devices/nic.py
+++ b/src/middlewared/middlewared/plugins/vm/devices/nic.py
@@ -3,6 +3,7 @@ import random
 from middlewared.plugins.interface.netif import netif
 from middlewared.schema import Dict, Str
 from middlewared.service import CallError
+from middlewared.validators import MACAddr
 
 from .device import Device
 from .utils import create_element
@@ -14,7 +15,7 @@ class NIC(Device):
         'attributes',
         Str('type', enum=['E1000', 'VIRTIO'], default='E1000'),
         Str('nic_attach', default=None, null=True),
-        Str('mac', default=None, null=True),
+        Str('mac', default=None, null=True, validators=[MACAddr(separator=':')]),
     )
 
     def __init__(self, *args, **kwargs):

--- a/src/middlewared/middlewared/validators.py
+++ b/src/middlewared/middlewared/validators.py
@@ -7,6 +7,7 @@ import uuid
 from zettarepl.snapshot.name import validate_snapshot_naming_schema
 
 EMAIL_REGEX = re.compile(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)")
+RE_MAC_ADDRESS = re.compile(r"^([0-9A-Fa-f]{2}[:-]?){5}([0-9A-Fa-f]{2})$")
 
 
 class Email:
@@ -173,8 +174,20 @@ class IpInUse:
 
 
 class MACAddr:
+
+    SEPARATORS = [':', '-']
+
+    def __init__(self, separator=None):
+        if separator:
+            assert separator in self.SEPARATORS
+        self.separator = separator
+
     def __call__(self, value):
-        if not re.match('[0-9a-f]{2}([-:]?)[0-9a-f]{2}(\\1[0-9a-f]{2}){4}$', value.lower()):
+        if not RE_MAC_ADDRESS.match(value.lower()) or (
+            self.separator and (
+                self.separator not in value or ({self.separator} ^ set(self.SEPARATORS)).pop() in value.lower()
+            )
+        ):
             raise ValueError('Please provide a valid MAC address')
 
 


### PR DESCRIPTION
We only allow `:` as valid separators for mac address validation because libvirt only considers them as valid and fails otherwise to properly initialise the domain.