### PR TITLE
Mark vnet / openvpn- interfaces as internal interfaces

### DIFF
--- a/src/middlewared/middlewared/plugins/interface/info_linux.py
+++ b/src/middlewared/middlewared/plugins/interface/info_linux.py
@@ -9,4 +9,4 @@ class InterfaceService(Service, InterfaceInfoBase):
         namespace_alias = 'interfaces'
 
     async def internal_interfaces(self):
-        return ['lo', 'tun', 'tap', 'bond', 'docker', 'veth', 'kube-bridge', 'kube-dummy-if']
+        return ['lo', 'tun', 'tap', 'bond', 'docker', 'veth', 'kube-bridge', 'kube-dummy-if', 'vnet', 'openvpn']


### PR DESCRIPTION
Libvirt interfaces are named as `vnetX` and we should not try to configure those or interfaces configured with `openvpn`.