### PR TITLE
NAS-108333 / 20.12 / implement ctdb plugin

### DIFF
--- a/src/freenas/etc/systemd/ctdb.service.d/override.conf
+++ b/src/freenas/etc/systemd/ctdb.service.d/override.conf
@@ -1,0 +1,2 @@
+[Unit]
+After=glusterd.service

--- a/src/middlewared/middlewared/alembic/versions/12.1/2020-11-30_13-14_add_ctdb_plugin.py
+++ b/src/middlewared/middlewared/alembic/versions/12.1/2020-11-30_13-14_add_ctdb_plugin.py
@@ -1,0 +1,42 @@
+"""
+add ctdb plugin
+
+Revision ID: f7746f911a45
+Revises: 3d611f8cc676
+Create Date: 2020-11-30 13:14:28.215714+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'f7746f911a45'
+down_revision = '3d611f8cc676'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'ctdb_private_ips',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('ip', sa.String(length=45), nullable=True),
+        sa.PrimaryKeyConstraint('id', name=op.f('pk_ctdb_private_ips'))
+    )
+    op.create_table(
+        'ctdb_public_ips',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('ip', sa.String(length=45), nullable=True),
+        sa.Column('netmask', sa.String(length=3), nullable=True),
+        sa.Column('interface', sa.String(length=256), nullable=True),
+        sa.PrimaryKeyConstraint('id', name=op.f('pk_ctdb_public_ips'))
+    )
+
+    op.execute("INSERT INTO services_services (srv_service, srv_enable) VALUES ('ctdb', 0)")
+
+def downgrade():
+    op.drop_table('ctdb_public_ips')
+    op.drop_table('ctdb_private_ips')
+
+    op.execute("DELETE FROM services_services WHERE srv_service = 'ctdb'")

--- a/src/middlewared/middlewared/etc_files/ctdb.conf.mako
+++ b/src/middlewared/middlewared/etc_files/ctdb.conf.mako
@@ -1,0 +1,37 @@
+<%
+    from pathlib import Path
+    from middlewared.plugins.cluster_linux.utils import CTDBLocal, CTDBCluster
+    from middlewared.plugins.smb import SMBHAMODE
+
+    clustered = SMBHAMODE[middleware.call_sync('smb.get_smb_ha_mode')] == SMBHAMODE.CLUSTERED
+    if not clustered:
+        return
+
+    r_file = CTDBCluster.RECOVERY_FILE.value
+    v_dir = CTDBLocal.SMB_VOLATILE_DB_DIR.value
+    p_dir = CTDBLocal.SMB_PERSISTENT_DB_DIR.value
+    s_dir = CTDBLocal.SMB_STATE_DB_DIR.value
+
+    try:
+        for i in (v_dir, p_dir, s_dir):
+            p = Path(i)
+            p.mkdir(parents=True, exist_ok=True)
+    except Exception as e:
+        middleware.logger.error('Failed creating %s with error %r', i, e)
+        return
+
+%>\
+[logging]
+
+    location = syslog:nonblocking
+    log level = NOTICE
+
+[cluster]
+
+    recovery lock = ${r_file}
+
+[database]
+
+    volatile database directory = ${v_dir}
+    persistent database directory = ${p_dir}
+    state database directory = ${s_dir}

--- a/src/middlewared/middlewared/etc_files/ctdb_private.conf.mako
+++ b/src/middlewared/middlewared/etc_files/ctdb_private.conf.mako
@@ -1,0 +1,15 @@
+<%
+    from middlewared.plugins.smb import SMBHAMODE
+
+    clustered = SMBHAMODE[middleware.call_sync('smb.get_smb_ha_mode')] == SMBHAMODE.CLUSTERED
+    if not clustered:
+        return
+
+    data = middleware.call_sync('datastore.query', 'ctdb.private.ips')
+    if not data:
+        raise FileShouldNotExist()
+
+%>\
+% for i in data:
+${i['ip']}
+% endfor

--- a/src/middlewared/middlewared/etc_files/ctdb_private.conf.mako
+++ b/src/middlewared/middlewared/etc_files/ctdb_private.conf.mako
@@ -5,7 +5,7 @@
     if not clustered:
         return
 
-    data = middleware.call_sync('datastore.query', 'ctdb.private.ips')
+    data = middleware.call_sync('ctdb.private.ips.query')
     if not data:
         raise FileShouldNotExist()
 

--- a/src/middlewared/middlewared/etc_files/ctdb_public.conf.mako
+++ b/src/middlewared/middlewared/etc_files/ctdb_public.conf.mako
@@ -5,7 +5,7 @@
     if not clustered:
         return
 
-    data = middleware.call_sync('datastore.query', 'ctdb.public.ips')
+    data = middleware.call_sync('ctdb.public.ips.query')
     if not data:
         raise FileShouldNotExist()
 

--- a/src/middlewared/middlewared/etc_files/ctdb_public.conf.mako
+++ b/src/middlewared/middlewared/etc_files/ctdb_public.conf.mako
@@ -1,0 +1,15 @@
+<%
+    from middlewared.plugins.smb import SMBHAMODE
+
+    clustered = SMBHAMODE[middleware.call_sync('smb.get_smb_ha_mode')] == SMBHAMODE.CLUSTERED
+    if not clustered:
+        return
+
+    data = middleware.call_sync('datastore.query', 'ctdb.public.ips')
+    if not data:
+        raise FileShouldNotExist()
+
+%>\
+% for i in data:
+${i['ip']}/${i['netmask']} ${i['interface']}
+% endfor

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_general.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_general.py
@@ -1,0 +1,62 @@
+from middlewared.service import accepts, job, CallError, CRUDService
+from .utils import JOB_LOCK
+
+import subprocess
+import json
+
+
+class CtdbGeneralService(CRUDService):
+
+    class Config:
+        namespace = 'ctdb.general'
+
+    def __ctdb_wrapper(self, command):
+
+        command = command.insert(0, 'ctdb')
+        command = command.insert(1, '-j')
+
+        result = {}
+        sp = subprocess.run(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            encoding='utf8',
+            errors='ignore',
+        )
+
+        if not sp.returncode:
+            try:
+                result = json.loads(sp.stdout)
+            except Exception as e:
+                raise CallError(
+                    'Failed parsing ctdb information with error: %s', e
+                )
+        else:
+            raise CallError(
+                'Failed running ctdb command with error %s',
+                result.stderr.decode()
+            )
+
+        return result
+
+    @accepts()
+    @job(lock=JOB_LOCK)
+    async def listnodes(self, job):
+
+        """
+        List the nodes in the ctdb cluster.
+        """
+
+        command = ['listnodes']
+        return self.__ctdb_wrapper(command)
+
+    @accepts()
+    @job(lock=JOB_LOCK)
+    def status(self, job):
+
+        """
+        Query for the status of the ctdb cluster.
+        """
+
+        command = ['status']
+        return self.__ctdb_wrapper(command)

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_private.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_private.py
@@ -1,0 +1,138 @@
+from middlewared.schema import List, Dict, IPAddr, Int
+from middlewared.service import accepts, private, job, CRUDService, ValidationErrors
+import middlewared.sqlalchemy as sa
+from .utils import CTDBConfig, JOB_LOCK
+
+
+PRIVATE_IP_FILE = CTDBConfig.PRIVATE_IP_FILE.value
+
+
+class CtdbPrivateIpModel(sa.Model):
+    __tablename__ = 'ctdb_private_ips'
+
+    id = sa.Column(sa.Integer(), primary_key=True)
+    ip = sa.Column(sa.String(45), nullable=True)
+
+
+class CtdbPrivateIpService(CRUDService):
+
+    class Config:
+        namespace = datastore = 'ctdb.private.ips'
+
+    @private
+    async def common_validation(self, data, schema_name, verrors):
+
+        # make sure something was given to us
+        if not data['private_ips']:
+            verrors.add(
+                f'{schema_name}.no_ips',
+                'Private IP(s) must be specified.',
+            )
+
+        verrors.check()
+
+        # normalize the data and remove netmask info (if its given to us)
+        # from `ip` keys since it's not used
+        for i in data['private_ips']:
+            i['ip'] = i['ip'].split('/')[0]
+
+        if schema_name == 'node_create':
+            # get the current ips in the cluster
+            cur_data = {'private_ips': [], 'public_ips': []}
+            cur_data['private_ips'] = await self.query()
+            cur_data['public_ips'] = await self.middleware.call('datastore.query', 'ctdb.public.ips')
+
+            # need to make sure the new private ip(s) don't already exist in the cluster
+            if m := list(set(i['ip'] for i in data['private_ips']).intersection(set(i['ip'] for i in cur_data['private_ips']))):
+                verrors.add(
+                    f'{schema_name}.private_ip_exists',
+                    f'Private IP address(es): {m} already in the cluster.',
+                )
+
+            # need to make sure the new private ip(s) don't already exist in the cluster as public ip(s)
+            if m := list(set(i['ip'] for i in data['private_ips']).intersection(set(i['ip'] for i in cur_data['public_ips']))):
+                verrors.add(
+                    f'{schema_name}.public_ip_exists',
+                    f'Private IP address(es): {m} have already been added to the cluster as public IP(s).',
+                )
+
+        verrors.check()
+
+        return data
+
+    @private
+    async def write_private_ips_to_ctdb(self):
+
+        data = {'private_ips': []}
+        data['private_ips'] = await self.query()
+
+        with open(PRIVATE_IP_FILE, 'w') as f:
+            for i in map(lambda i: i['ip'], data['private_ips']):
+                f.write(f'{i}\n')
+
+        return data
+
+    @accepts(Dict(
+        'node_create',
+        List('private_ips', unique=True, items=[
+            Dict('private_ip', IPAddr('ip'))
+        ], default=[]),
+    ))
+    @job(lock=JOB_LOCK)
+    async def do_create(self, job, data):
+
+        """
+        Create private IPs to be used in the ctdb cluster.
+
+        `private_ips` is a list of `ip` addresses that will be used
+            for the intra-cluster communication between nodes.
+            These ip addresses should be on a phyically separate
+            network and should be non-routable.
+        """
+
+        schema_name = 'node_create'
+        verrors = ValidationErrors()
+
+        data = await self.common_validation(data, schema_name, verrors)
+
+        for i in data['private_ips']:
+            await self.middleware.call(
+                'datastore.insert', 'ctdb.private.ips', i,
+            )
+
+        return await self.write_private_ips_to_ctdb()
+
+    @accepts(Dict(
+        'node_update',
+        List('private_ips', items=[IPAddr('ip', network=False)], default=[]),
+    ))
+    @job(lock=JOB_LOCK)
+    async def do_update(self, job, data):
+
+        """
+        Add nodes to the ctdb cluster.
+
+        `private_ips` is a list of `ip` addresses that will be used
+            for the intra-cluster communication between nodes.
+            These ip addresses should be on a phyically separate
+            network and should be non-routable.
+        """
+
+        schema_name = 'node_update'
+        data = await self.common_validation(data, schema_name)
+
+        return await self.write_private_ips_to_ctdb()
+
+    @accepts(Int('id'))
+    @job(lock=JOB_LOCK)
+    async def do_delete(self, job, id):
+
+        """
+        Delete private IP with `id` from ctdb cluster.
+        """
+
+        result = await self.middleware.call('datastore.delete', self._config.datastore, id)
+
+        await self.write_private_ips_to_ctdb()
+
+        return result

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_private.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_private.py
@@ -68,11 +68,11 @@ class CtdbPrivateIpService(CRUDService):
 
         self.common_validation(data, schema_name, verrors)
 
-        self.middleware.call_sync('datastore.insert', 'ctdb.private.ips', data)
+        id = self.middleware.call_sync('datastore.insert', 'ctdb.private.ips', data)
 
         self.write_private_ips_to_ctdb()
 
-        return data
+        return self.middleware.call_sync('ctdb.private.ips.get_instance', id)
 
     @accepts(Int('id'))
     @job(lock=JOB_LOCK)

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_public.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_public.py
@@ -1,0 +1,156 @@
+from middlewared.schema import List, Dict, Str, IPAddr, Int
+from middlewared.service import accepts, private, job, CRUDService, ValidationErrors
+import middlewared.sqlalchemy as sa
+from .utils import CTDBConfig, JOB_LOCK
+
+
+PUBLIC_IP_FILE = CTDBConfig.PUBLIC_IP_FILE.value
+
+
+class CtdbPublicIpModel(sa.Model):
+    __tablename__ = 'ctdb_public_ips'
+
+    id = sa.Column(sa.Integer(), primary_key=True)
+    ip = sa.Column(sa.String(45), nullable=True)
+    netmask = sa.Column(sa.String(3), nullable=True)
+    interface = sa.Column(sa.String(256), nullable=True)
+
+
+class CtdbPublicIpService(CRUDService):
+
+    class Config:
+        namespace = datastore = 'ctdb.public.ips'
+
+    @private
+    async def common_validation(self, data, schema_name, verrors):
+
+        # make sure something was given to us
+        if not data['public_ips']:
+            verrors.add(
+                f'{schema_name}.no_ips',
+                'Public IP(s) must be specified.',
+            )
+
+        verrors.check()
+
+        # normalize the data and remove netmask info (if its given to us)
+        # from `ip` keys since it's not used
+        for i in data['public_ips']:
+            i['ip'] = i['ip'].split('/')[0]
+
+        if schema_name == 'node_create':
+            # get copy of current data
+            cur_data = {'public_ips': [], 'private_ips': []}
+            cur_data['public_ips'] = await self.query()
+            cur_data['private_ips'] = await self.middleware.call('datastore.query', 'ctdb.private.ips')
+
+            # need to make sure the new public ip(s) don't already exist in the cluster
+            if m := list(set(i['ip'] for i in data['public_ips']).intersection(set(i['ip'] for i in cur_data['public_ips']))):
+                verrors.add(
+                    f'{schema_name}.public_ip_exists',
+                    f'Public IP address(es): {m} already in the cluster.',
+                )
+
+            # need to make sure the new public ip(s) don't already exist in the cluster as private ip(s)
+            if m := list(set(i['ip'] for i in data['public_ips']).intersection(set(i['ip'] for i in cur_data['private_ips']))):
+                verrors.add(
+                    f'{schema_name}.public_ip_exists',
+                    f'Public IP address(es): {m} have already been added to the cluster as private IP(s).',
+                )
+
+        # need to make sure that the interface specified for the public IP exists
+        ints = [i['name'] for i in await self.middleware.call('interface.query')]
+        if m := list(set(i['interface'] for i in data['public_ips']) - set(ints)):
+            verrors.add(
+                f'{schema_name}.invalid_interface',
+                f'Invalid interface(s) specified {m}.',
+            )
+
+        verrors.check()
+
+        return data
+
+    @private
+    async def write_public_ips_to_ctdb(self):
+
+        data = {'public_ips': []}
+        data['public_ips'] = await self.query()
+
+        with open(PUBLIC_IP_FILE, 'w') as f:
+            for i in data['public_ips']:
+                f.write(f'{i["ip"]}/{i["netmask"]} {i["interface"]}\n')
+
+        return data
+
+    @accepts(Dict(
+        'node_create',
+        List('public_ips', unique=True, items=[
+            Dict('public_ip', IPAddr('ip'), Int('netmask', required=True), Str('interface', required=True))
+        ], default=[]),
+    ))
+    @job(lock=JOB_LOCK)
+    async def do_create(self, job, data):
+
+        """
+        Create public IPs to be used in the ctdb cluster.
+
+        `public_ips` is a list of:
+            `ip` address
+            `netmask` CIDR representation of netmask
+            `interface` which interface to assign the `ip` to
+        """
+
+        schema_name = 'node_create'
+        verrors = ValidationErrors()
+
+        data = await self.common_validation(data, schema_name, verrors)
+
+        for i in data['public_ips']:
+            await self.middleware.call(
+                'datastore.insert', self._config.datastore, i,
+            )
+
+        return await self.write_public_ips_to_ctdb()
+
+    @accepts(Dict(
+        'node_update',
+        List('public_ips', unique=True, items=[
+            Dict('public_ip', IPAddr('ip'), Int('netmask', required=True), Str('interface', required=True))
+        ], default=[]),
+    ))
+    @job(lock=JOB_LOCK)
+    async def do_update(self, job, data):
+
+        """
+        Update public IPs in the ctdb cluster.
+
+        `public_ips` is a list of:
+            `ip` ip v4/v6 address
+            `netmask` CIDR representation of netmask
+            `interface` which interface to assign the `ip` to
+        """
+
+        old = await self.config()
+        new = old.copy()
+        new.update(data)
+
+        schema_name = 'node_update'
+        new = await self.common_validation(new, schema_name)
+
+        await self.middleware.call('datastore.update', self._config.datastore, id, new)
+
+        return await self.write_public_ips_to_ctdb()
+
+    @accepts(Int('id'))
+    @job(lock=JOB_LOCK)
+    async def do_delete(self, job, id):
+
+        """
+        Delete public IP with `id` from ctdb cluster.
+        """
+
+        result = await self.middleware.call('datastore.delete', self._config.datastore, id)
+
+        await self.write_public_ips_to_ctdb()
+
+        return result

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_public.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_public.py
@@ -83,7 +83,7 @@ class CtdbPublicIpService(CRUDService):
 
         self.write_public_ips_to_ctdb()
 
-        return data
+        return self.middleware.call_sync('ctdb.public.ips.get_instance', id)
 
     @accepts(Int('id'))
     @job(lock=JOB_LOCK)

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_public.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_public.py
@@ -1,4 +1,4 @@
-from middlewared.schema import List, Dict, Str, IPAddr, Int
+from middlewared.schema import Dict, Str, IPAddr, Int
 from middlewared.service import accepts, private, job, CRUDService, ValidationErrors
 import middlewared.sqlalchemy as sa
 from .utils import CTDBConfig, JOB_LOCK
@@ -22,135 +22,79 @@ class CtdbPublicIpService(CRUDService):
         namespace = datastore = 'ctdb.public.ips'
 
     @private
-    async def common_validation(self, data, schema_name, verrors):
+    def common_validation(self, data, schema_name, verrors):
 
-        # make sure something was given to us
-        if not data['public_ips']:
+        # get copy of current data
+        cur_data = {'public_ips': [], 'private_ips': []}
+        cur_data['public_ips'] = self.middleware.call_sync('ctdb.public.ips.query')
+        cur_data['private_ips'] = self.middleware.call_sync('ctdb.private.ips.query')
+
+        # need to make sure the new public ip(s) don't already exist in the cluster
+        if data['ip'] in set(i['ip'] for i in cur_data['public_ips'] + cur_data['private_ips']):
             verrors.add(
-                f'{schema_name}.no_ips',
-                'Public IP(s) must be specified.',
+                f'{schema_name}.ip',
+                f'Public IP address: {data["ip"]} already in the cluster.',
             )
-
-        verrors.check()
-
-        # normalize the data and remove netmask info (if its given to us)
-        # from `ip` keys since it's not used
-        for i in data['public_ips']:
-            i['ip'] = i['ip'].split('/')[0]
-
-        if schema_name == 'node_create':
-            # get copy of current data
-            cur_data = {'public_ips': [], 'private_ips': []}
-            cur_data['public_ips'] = await self.query()
-            cur_data['private_ips'] = await self.middleware.call('datastore.query', 'ctdb.private.ips')
-
-            # need to make sure the new public ip(s) don't already exist in the cluster
-            if m := list(set(i['ip'] for i in data['public_ips']).intersection(set(i['ip'] for i in cur_data['public_ips']))):
-                verrors.add(
-                    f'{schema_name}.public_ip_exists',
-                    f'Public IP address(es): {m} already in the cluster.',
-                )
-
-            # need to make sure the new public ip(s) don't already exist in the cluster as private ip(s)
-            if m := list(set(i['ip'] for i in data['public_ips']).intersection(set(i['ip'] for i in cur_data['private_ips']))):
-                verrors.add(
-                    f'{schema_name}.public_ip_exists',
-                    f'Public IP address(es): {m} have already been added to the cluster as private IP(s).',
-                )
 
         # need to make sure that the interface specified for the public IP exists
-        ints = [i['name'] for i in await self.middleware.call('interface.query')]
-        if m := list(set(i['interface'] for i in data['public_ips']) - set(ints)):
+        ints = [i['name'] for i in self.middleware.call_sync('interface.query')]
+        if data['interface'] not in ints:
             verrors.add(
-                f'{schema_name}.invalid_interface',
-                f'Invalid interface(s) specified {m}.',
+                f'{schema_name}.interface',
+                f'Invalid interface specified {data["interface"]}.',
             )
 
         verrors.check()
 
-        return data
-
     @private
-    async def write_public_ips_to_ctdb(self):
-
-        data = {'public_ips': []}
-        data['public_ips'] = await self.query()
+    def write_public_ips_to_ctdb(self):
 
         with open(PUBLIC_IP_FILE, 'w') as f:
-            for i in data['public_ips']:
+            for i in self.middleware.call_sync('ctdb.public.ips.query'):
                 f.write(f'{i["ip"]}/{i["netmask"]} {i["interface"]}\n')
-
-        return data
 
     @accepts(Dict(
         'node_create',
-        List('public_ips', unique=True, items=[
-            Dict('public_ip', IPAddr('ip'), Int('netmask', required=True), Str('interface', required=True))
-        ], default=[]),
+        IPAddr('ip'),
+        Int('netmask', required=True),
+        Str('interface', required=True)
     ))
     @job(lock=JOB_LOCK)
-    async def do_create(self, job, data):
+    def do_create(self, job, data):
 
         """
-        Create public IPs to be used in the ctdb cluster.
+        Create public IP to be used in the ctdb cluster.
 
-        `public_ips` is a list of:
-            `ip` address
-            `netmask` CIDR representation of netmask
-            `interface` which interface to assign the `ip` to
+        `ip` address
+        `netmask` CIDR representation of netmask
+        `interface` which interface to assign the `ip` to
         """
 
         schema_name = 'node_create'
         verrors = ValidationErrors()
 
-        data = await self.common_validation(data, schema_name, verrors)
+        # normalize the data and remove netmask info (if its given to us)
+        # from `ip` keys since it's not used
+        data['ip'] = data['ip'].split('/')[0]
 
-        for i in data['public_ips']:
-            await self.middleware.call(
-                'datastore.insert', self._config.datastore, i,
-            )
+        self.common_validation(data, schema_name, verrors)
 
-        return await self.write_public_ips_to_ctdb()
+        self.middleware.call_sync('datastore.insert', self._config.datastore, data)
 
-    @accepts(Dict(
-        'node_update',
-        List('public_ips', unique=True, items=[
-            Dict('public_ip', IPAddr('ip'), Int('netmask', required=True), Str('interface', required=True))
-        ], default=[]),
-    ))
-    @job(lock=JOB_LOCK)
-    async def do_update(self, job, data):
+        self.write_public_ips_to_ctdb()
 
-        """
-        Update public IPs in the ctdb cluster.
-
-        `public_ips` is a list of:
-            `ip` ip v4/v6 address
-            `netmask` CIDR representation of netmask
-            `interface` which interface to assign the `ip` to
-        """
-
-        old = await self.config()
-        new = old.copy()
-        new.update(data)
-
-        schema_name = 'node_update'
-        new = await self.common_validation(new, schema_name)
-
-        await self.middleware.call('datastore.update', self._config.datastore, id, new)
-
-        return await self.write_public_ips_to_ctdb()
+        return data
 
     @accepts(Int('id'))
     @job(lock=JOB_LOCK)
-    async def do_delete(self, job, id):
+    def do_delete(self, job, id):
 
         """
         Delete public IP with `id` from ctdb cluster.
         """
 
-        result = await self.middleware.call('datastore.delete', self._config.datastore, id)
+        result = self.middleware.call_sync('datastore.delete', self._config.datastore, id)
 
-        await self.write_public_ips_to_ctdb()
+        self.write_public_ips_to_ctdb()
 
         return result

--- a/src/middlewared/middlewared/plugins/cluster_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/utils.py
@@ -1,0 +1,44 @@
+import os
+import enum
+
+from middlewared.plugins.smb import SMBPath
+
+
+BASE = SMBPath.STATEDIR.platform()
+JOB_LOCK = 'ctdb_job_lock'
+
+
+class CTDBConfig(enum.Enum):
+
+    PRIVATE_IP_FILE = '/etc/ctdb/nodes'
+    PUBLIC_IP_FILE = '/etc/ctdb/public_addresses'
+
+
+class CTDBCluster(enum.Enum):
+
+    """
+    Represents the clustered locations
+    to store various files used by ctdb.
+    It's expected that any file/dir listed
+    in this class will be stored on the
+    clustered filesystem.
+    """
+
+    RECOVERY_FILE = '/cluster/ctdb/.CTDB-lockfile'
+
+
+class CTDBLocal(enum.Enum):
+
+    """
+    Represents the _LOCAL_ directories
+    to store various files used by ctdb. These
+    do NOT need to be stored on the clusterd
+    filesystem.
+    """
+
+    # volatile database
+    SMB_VOLATILE_DB_DIR = '/var/run/ctdb/volatile/'
+    # persistent database
+    SMB_PERSISTENT_DB_DIR = os.path.join(BASE, 'ctdb_persistent')
+    # state database
+    SMB_STATE_DB_DIR = os.path.join(BASE, 'ctdb_state')

--- a/src/middlewared/middlewared/plugins/etc.py
+++ b/src/middlewared/middlewared/plugins/etc.py
@@ -256,6 +256,33 @@ class EtcService(Service):
         'smb_share': [
             {'type': 'mako', 'path': 'local/smb4_share.conf', 'checkpoint': 'pool_import'},
         ],
+        'ctdb_private': [
+            {
+                'type': 'mako',
+                'path': 'ctdb/nodes',
+                'checkpoint': 'interface_sync',
+                'local_path': 'ctdb_private.conf',
+                'platform': 'Linux',
+            },
+        ],
+        'ctdb_public': [
+            {
+                'type': 'mako',
+                'path': 'ctdb/public_addresses',
+                'checkpoint': 'interface_sync',
+                'local_path': 'ctdb_public.conf',
+                'platform': 'Linux',
+            },
+        ],
+        'ctdb': [
+            {
+                'type': 'mako',
+                'path': 'ctdb/ctdb.conf',
+                'checkpoint': 'pool_import',
+                'local_path': 'ctdb.conf',
+                'platform': 'Linux',
+            },
+        ],
         'snmpd': [
             {'type': 'mako', 'path': 'local/snmpd.conf' if osc.IS_FREEBSD else 'snmp/snmpd.conf',
              'local_path': 'local/snmpd.conf'},

--- a/src/middlewared/middlewared/plugins/service_/services/all.py
+++ b/src/middlewared/middlewared/plugins/service_/services/all.py
@@ -27,6 +27,7 @@ from .wsd import WSDService
 from .keepalived import KeepalivedService
 from .glusterd import GlusterdService
 from .glustereventsd import GlusterEventsdService
+from .ctdb import CtdbService
 
 from .pseudo.ad import ActiveDirectoryService, LdapService, NisService
 from .pseudo.collectd import CollectDService, RRDCacheDService
@@ -113,6 +114,7 @@ all_services = [
 ]
 if osc.IS_LINUX:
     all_services.extend([
+        CtdbService,
         KeepalivedService,
         GlusterdService,
         GlusterEventsdService,

--- a/src/middlewared/middlewared/plugins/service_/services/ctdb.py
+++ b/src/middlewared/middlewared/plugins/service_/services/ctdb.py
@@ -1,0 +1,9 @@
+from .base import SimpleService
+
+
+class CtdbService(SimpleService):
+
+    name = 'ctdb'
+    systemd_unit = 'ctdb'
+    restartable = True
+    etc = ['ctdb', 'ctdb_public', 'ctdb_private']


### PR DESCRIPTION
Implement ctdb clustering plugin. I've tried to keep this as modular as possible since ctdb can be used with NFS (it's unknown if this is feasible right now but this is needed for SMB nonetheless).

- override ctdb service and make it start after gluster service
- create 3 sections for ctdb config generation (`ctdb.conf`, `/etc/ctdb/nodes` (private ips), `/etc/ctdb/public_addresses` (public ips))
- create 2 new CRUD APIs for ctdb config (for adding/deleting private/public IPs respectively)
- create 1 new public API for querying status information from the ctdb daemon
- create ctdb service