### PR TITLE
NAS-108503 / 20.12 / Handle docker images specially which are being used by the system

### DIFF
--- a/src/middlewared/middlewared/plugins/docker_linux/images.py
+++ b/src/middlewared/middlewared/plugins/docker_linux/images.py
@@ -97,6 +97,9 @@ class DockerImagesService(CRUDService):
         """
         await self.docker_checks()
         image = await self.get_instance(id)
+        if image['system_image']:
+            raise CallError(f'{id} is being used by system and cannot be deleted.')
+
         async with aiodocker.Docker() as docker:
             await docker.images.delete(name=id, force=options['force'])
 

--- a/src/middlewared/middlewared/plugins/docker_linux/update_alerts.py
+++ b/src/middlewared/middlewared/plugins/docker_linux/update_alerts.py
@@ -20,7 +20,7 @@ class DockerImagesService(Service, DockerClientMixin):
     @private
     async def check_update(self):
         images = await self.middleware.call('docker.images.query')
-        for image in images:
+        for image in filter(lambda i: not i['system_image'], images):
             for tag in image['repo_tags']:
                 try:
                     await self.get_digest_of_image(tag, image)

--- a/src/middlewared/middlewared/plugins/docker_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/docker_linux/utils.py
@@ -1,3 +1,4 @@
+DEFAULT_DOCKER_IMAGES_LIST_PATH = '/usr/local/share/docker_images/image-list.txt'
 DEFAULT_DOCKER_REGISTRY = 'registry-1.docker.io'
 DEFAULT_DOCKER_REPO = 'library'
 DEFAULT_DOCKER_TAG = 'latest'


### PR DESCRIPTION
This PR introduces changes to ensure that we mark docker images being used by the system as system images and do not check for updates for those and neither allow user to delete those.