### PR TITLE
NAS-108524 / 12.0 / Bump up AIO values for Samba

### DIFF
--- a/src/freenas/etc/sysctl.conf.local
+++ b/src/freenas/etc/sysctl.conf.local
@@ -30,3 +30,8 @@ net.inet.carp.allow=0
 # we handle that in the application layer
 net.inet.carp.senderr_demotion_factor=0
 net.inet.carp.ifdown_demotion_factor=0
+
+# AIO tuning for SMB
+vfs.aio.max_aio_procs=128
+vfs.aio.target_aio_procs=16
+kern.kq_calloutmax=150000


### PR DESCRIPTION
The defaults are somewhat low for high iops workloads.

This goes along with additional changes to samba to improve error handling and simplify async code path in vfs_aio_fbsd. Increase kq_calloutmax for busy servers (high numbers of users) to avoid hitting resource limits.