### PR TITLE
NAS-108441 / 12.0 /  Do not include system dataset into quota alerts

### DIFF
--- a/src/middlewared/middlewared/alert/source/cores.py
+++ b/src/middlewared/middlewared/alert/source/cores.py
@@ -1,22 +1,45 @@
 import os
+import time
 
 from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, ThreadedAlertSource
+from middlewared.utils.osc import IS_FREEBSD
 
 
 class CoreFilesArePresentAlertClass(AlertClass):
     category = AlertCategory.SYSTEM
     level = AlertLevel.WARNING
     title = "Core Files Found in System Database"
-    text = ("System core files were found in /var/db/system/cores: %s. Please create a ticket at https://jira.ixsystems.com/ "
-            "and remove these files.")
+    text = ("System core files were found in /var/db/system/cores. Please create a ticket at "
+            "https://jira.ixsystems.com/ and remove these files.")
 
 
 class CoreFilesArePresentAlertSource(ThreadedAlertSource):
     def check_sync(self):
+        cores = "/var/db/system/cores"
         try:
-            files = sorted(os.listdir("/var/db/system/cores"))
+            listdir = os.listdir(cores)
         except Exception:
-            files = []
+            return
 
-        if files:
-            return Alert(CoreFilesArePresentAlertClass, ", ".join(files))
+        has_core_file = False
+        for file in listdir:
+            if not file.endswith(".core"):
+                continue
+
+            path = os.path.join(cores, file)
+            if not os.path.isfile(path):
+                continue
+
+            unlink = False
+            if IS_FREEBSD and file == "syslog-ng.core":
+                unlink = True
+            elif os.stat(path).st_mtime < time.time() - 86400 * 5:
+                unlink = True
+            else:
+                has_core_file = True
+
+            if unlink:
+                os.unlink(path)
+
+        if has_core_file:
+            return Alert(CoreFilesArePresentAlertClass)

--- a/src/middlewared/middlewared/alert/source/cores.py
+++ b/src/middlewared/middlewared/alert/source/cores.py
@@ -6,9 +6,9 @@ from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert,
 class CoreFilesArePresentAlertClass(AlertClass):
     category = AlertCategory.SYSTEM
     level = AlertLevel.WARNING
-    title = "Core Files Are Present"
-    text = ("Core files are present in /var/db/system/cores: %s. Please, file a ticket at https://jira.ixsystems.com/ "
-            "and then remove them.")
+    title = "Core Files Found in System Database"
+    text = ("System core files were found in /var/db/system/cores: %s. Please create a ticket at https://jira.ixsystems.com/ "
+            "and remove these files.")
 
 
 class CoreFilesArePresentAlertSource(ThreadedAlertSource):

--- a/src/middlewared/middlewared/alert/source/cores.py
+++ b/src/middlewared/middlewared/alert/source/cores.py
@@ -1,0 +1,22 @@
+import os
+
+from middlewared.alert.base import AlertClass, AlertCategory, AlertLevel, Alert, ThreadedAlertSource
+
+
+class CoreFilesArePresentAlertClass(AlertClass):
+    category = AlertCategory.SYSTEM
+    level = AlertLevel.WARNING
+    title = "Core Files Are Present"
+    text = ("Core files are present in /var/db/system/cores: %s. Please, file a ticket at https://jira.ixsystems.com/ "
+            "and then remove them.")
+
+
+class CoreFilesArePresentAlertSource(ThreadedAlertSource):
+    def check_sync(self):
+        try:
+            files = sorted(os.listdir("/var/db/system/cores"))
+        except Exception:
+            files = []
+
+        if files:
+            return Alert(CoreFilesArePresentAlertClass, ", ".join(files))

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -496,6 +496,11 @@ class ZFSDatasetService(CRUDService):
         return filter_list(datasets, filters, options)
 
     def query_for_quota_alert(self):
+        filters = []
+        config = self.middleware.call_sync("systemdataset.config")
+        if config["basename"]:
+            filters = [["name", "!=", config["basename"]], ["name", "!^", f"{config['basename']}/"]]
+
         return [
             {
                 k: v for k, v in dataset['properties'].items()
@@ -505,7 +510,7 @@ class ZFSDatasetService(CRUDService):
                     "org.freenas:refquota_warning", "org.freenas:refquota_critical"
                 ]
             }
-            for dataset in self.query()
+            for dataset in self.query(filters)
         ]
 
     def common_load_dataset_checks(self, ds):


### PR DESCRIPTION
I am not sure we should have a new alert in 12.0. What if an average system has a core file there? (I had one for syslog-ng for example) We'll have a ton of tickets!