### PR TITLE
NAS-108562 / 20.12 / Remove root from /etc/ftpusers when root login is enabled

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/proftpd.py
+++ b/src/middlewared/middlewared/etc_files/local/proftpd.py
@@ -1,7 +1,11 @@
 import os
 
+from middlewared.utils import osc
+
 
 def setup(middleware):
+    ftp = middleware.call_sync("ftp.config")
+
     os.makedirs("/var/log/proftpd", exist_ok=True)
     os.makedirs("/var/run/proftpd", exist_ok=True)
 
@@ -9,10 +13,19 @@ def setup(middleware):
     open("/etc/hosts.allow", "w+").close()
     open("/etc/hosts.deny", "w+").close()
 
+    if osc.IS_LINUX:
+        filters = [["builtin", "=", True]]
+        if ftp["rootlogin"]:
+            filters.append(["username", "!=", "root"])
+
+        ftpusers = [user["username"] for user in middleware.call_sync("user.query", filters)]
+
+        with open("/etc/ftpusers", "w") as f:
+            f.write("\n".join(ftpusers) + "\n")
+
     open("/var/log/wtmp", "w+").close()
     os.chmod("/var/log/wtmp", 0o644)
 
-    ftp = middleware.call_sync("ftp.config")
     with open("/var/run/proftpd/proftpd.motd", "w") as f:
         if ftp["banner"]:
             f.write(ftp["banner"] + "\n")


### PR DESCRIPTION
@william-gr this is a blacklist for ftp users, by default it contains some of the system built-in users