### PR TITLE
NAS-108206 / 21.02 / netcli: only show login banner if we are a child of init (by themylogin)

### DIFF
--- a/src/freenas/etc/netcli
+++ b/src/freenas/etc/netcli
@@ -1633,11 +1633,13 @@ if __name__ == '__main__':
 
     while True:
         try:
-            try:
-                with Client() as c:
-                    console = c.call('system.advanced.config')['consolemenu']
-            except Exception:
-                console = True
+            console = True
+            if os.getppid() == 1:
+                try:
+                    with Client() as c:
+                        console = c.call('system.advanced.config')['consolemenu']
+                except Exception:
+                    pass
             if console:
                 main_menu()
             else:


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 501cc0cf300304a73417ebebbce081f1f379b8af



Original PR: https://github.com/freenas/freenas/pull/6100