### PR TITLE
NAS-108611 / 12.0 / Move aio_fbsd to end of list of VFS modules

### DIFF
--- a/src/middlewared/middlewared/plugins/smb_/registry.py
+++ b/src/middlewared/middlewared/plugins/smb_/registry.py
@@ -156,7 +156,7 @@ class SharingSMBService(Service):
     @private
     async def order_vfs_objects(self, vfs_objects):
         vfs_objects_special = ('catia', 'zfs_space', 'fruit', 'streams_xattr', 'shadow_copy_zfs',
-                               'noacl', 'ixnas', 'zfsacl', 'crossrename', 'recycle')
+                               'noacl', 'ixnas', 'zfsacl', 'crossrename', 'recycle', 'aio_fbsd')
 
         vfs_objects_ordered = []
 


### PR DESCRIPTION
Certain VFS modules may alter targets of vfs_pread_send() / vfs_pwrite_send() requests depending on the target file type. For instance, in a non-default configuration (for us) configuration, vfs_fruit will intercept stream reads / writes for afp_info and afp_resource streams and convert them to writes to special adouble files. This needs to happen before the async pread / pwrite hits vfs_aio_fbsd, which means vfs_aio_fbsd needs to be at the end of the module list.