### PR TITLE
reduce max log file size generated by lib/debug

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4.conf
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf
@@ -116,7 +116,7 @@
             pc.update({
                 'dns proxy': 'No',
                 'aio max threads': '2',
-                'max log size': '51200',
+                'max log size': '5120',
                 'load printers': 'No',
                 'printing': 'bsd',
                 'disable spoolss': 'Yes',


### PR DESCRIPTION
Drop log file rollover size from 50MiB to 5MiB.