### PR TITLE
NAS-108612 / 21.02 / reduce max log file size generated by lib/debug (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/smb4.conf.mako
+++ b/src/middlewared/middlewared/etc_files/local/smb4.conf.mako
@@ -116,7 +116,7 @@
             """
             pc.update({
                 'dns proxy': 'No',
-                'max log size': '51200',
+                'max log size': '5120',
                 'load printers': 'No',
                 'printing': 'bsd',
                 'printcap name': '/dev/null',


### PR DESCRIPTION
Drop log file rollover size from 50MiB to 5MiB.

Original PR: https://github.com/freenas/freenas/pull/6134