### PR TITLE
NAS-108636 / 20.12 / Add context to helm values

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
@@ -122,9 +122,11 @@ class ChartReleaseService(Service):
         # chart versions during helm upgrade in the helm template, hence the requirement for a context object.
         config[CONTEXT_KEY_NAME].update({
             'operation': 'UPGRADE',
+            'isUpgrade': True,
             'upgradeMetadata': {
                 'oldChartVersion': current_chart['version'],
                 'newChartVersion': new_version,
+                'preUpgradeRevision': release['version'],
             }
         })
 

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
@@ -11,7 +11,7 @@ from middlewared.schema import Dict, Str
 from middlewared.service import accepts, CallError, job, periodic, private, Service, ValidationErrors
 
 from .schema import clean_values_for_upgrade
-from .utils import get_namespace, run
+from .utils import CONTEXT_KEY_NAME, get_namespace, run
 
 
 class ChartReleaseService(Service):
@@ -115,6 +115,18 @@ class ChartReleaseService(Service):
         job.set_progress(40, 'Created snapshot for upgrade')
 
         await self.middleware.call('chart.release.perform_actions', context)
+
+        # Let's update context options to reflect that an upgrade is taking place and from which version to which
+        # version it's happening.
+        # Helm considers simple config change as an upgrade as well, and we have no way of determining the old/new
+        # chart versions during helm upgrade in the helm template, hence the requirement for a context object.
+        config[CONTEXT_KEY_NAME].update({
+            'operation': 'UPGRADE',
+            'upgradeMetadata': {
+                'oldChartVersion': current_chart['version'],
+                'newChartVersion': new_version,
+            }
+        })
 
         with tempfile.NamedTemporaryFile(mode='w+') as f:
             f.write(yaml.dump(config))

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
@@ -5,10 +5,12 @@ from middlewared.utils import run as _run
 
 
 CHART_NAMESPACE_PREFIX = 'ix-'
+CONTEXT_KEY_NAME = 'ixChartContext'
 RESERVED_NAMES = [
     ('ixExternalInterfacesConfiguration', list),
     ('ixExternalInterfacesConfigurationNames', list),
     ('ixVolumes', list),
+    (CONTEXT_KEY_NAME, dict),
 ]
 
 


### PR DESCRIPTION
Helm does not offer us to differentiate between versions during upgrade. To clarify, we cannot determine what version we are upgrading from and to which version we are upgrading to. We add a context which will help us determine this and perform any relevant operation as desired with this information.