### PR TITLE
NAS-108538 / 12.0 / Re-initialize libvirt connection if it closes

### DIFF
--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -1637,7 +1637,7 @@ class VMService(CRUDService, LibvirtConnectionMixin):
             # We don't want vm.query to fail at any cost, so let's catch the exception
             self.middleware.logger.debug('Failed to setup libvirt connection', exc_info=True)
 
-        if self.LIBVIRT_CONNECTION and vm['name'] in self.vms:
+        if LibvirtConnectionMixin.LIBVIRT_CONNECTION and vm['name'] in self.vms:
             try:
                 # Whatever happens, query shouldn't fail
                 return self.vms[vm['name']].status()
@@ -1807,8 +1807,7 @@ class VMService(CRUDService, LibvirtConnectionMixin):
     def close_libvirt_connection(self):
         if self.LIBVIRT_CONNECTION:
             with contextlib.suppress(libvirt.libvirtError):
-                self.LIBVIRT_CONNECTION.close()
-            self.LIBVIRT_CONNECTION = None
+                self._close()
 
     @private
     async def terminate(self):
@@ -1844,7 +1843,7 @@ class VMService(CRUDService, LibvirtConnectionMixin):
 
         # We use datastore.query specifically here to avoid a recursive case where vm.datastore_extend calls
         # status method which in turn needs a vm object to retrieve the libvirt status for the specified VM
-        if self.LIBVIRT_CONNECTION:
+        if LibvirtConnectionMixin.LIBVIRT_CONNECTION:
             for vm_data in self.middleware.call_sync('datastore.query', 'vm.vm'):
                 vm_data['devices'] = self.middleware.call_sync('vm.device.query', [['vm', '=', vm_data['id']]])
                 try:

--- a/src/middlewared/middlewared/plugins/vm.py
+++ b/src/middlewared/middlewared/plugins/vm.py
@@ -1220,9 +1220,7 @@ class VMService(CRUDService, LibvirtConnectionMixin):
         `shutdown_timeout` seconds, system initiates poweroff for the VM to stop it.
         """
         async with LIBVIRT_LOCK:
-            if not self.LIBVIRT_CONNECTION:
-                await self.wait_for_libvirtd(10)
-        await self.middleware.run_in_thread(self._check_setup_connection)
+            await self.middleware.run_in_thread(self._check_setup_connection)
 
         verrors = ValidationErrors()
         await self.__common_validation(verrors, 'vm_create', data)

--- a/src/middlewared/middlewared/plugins/vm_/connection.py
+++ b/src/middlewared/middlewared/plugins/vm_/connection.py
@@ -20,14 +20,14 @@ class LibvirtConnectionMixin:
 
     def _close(self):
         try:
-            self.LIBVIRT_CONNECTION.close()
+            LibvirtConnectionMixin.LIBVIRT_CONNECTION.close()
         except libvirt.libvirtError as e:
             raise CallError(f'Failed to close libvirt connection: {e}')
         else:
-            self.LIBVIRT_CONNECTION = None
+            LibvirtConnectionMixin.LIBVIRT_CONNECTION = None
 
     def _is_connection_alive(self):
-        return self.LIBVIRT_CONNECTION and self.LIBVIRT_CONNECTION.isAlive()
+        return LibvirtConnectionMixin.LIBVIRT_CONNECTION and LibvirtConnectionMixin.LIBVIRT_CONNECTION.isAlive()
 
     def _check_connection_alive(self):
         if not self._is_connection_alive():

--- a/src/middlewared/middlewared/plugins/vm_/connection.py
+++ b/src/middlewared/middlewared/plugins/vm_/connection.py
@@ -1,0 +1,39 @@
+import libvirt
+
+from middlewared.service import CallError
+
+
+LIBVIRT_URI = 'bhyve+unix:///system'
+
+
+class LibvirtConnectionMixin:
+
+    LIBVIRT_CONNECTION = None
+
+    def _open(self):
+        try:
+            # We want to do this before initializing libvirt connection
+            libvirt.virEventRegisterDefaultImpl()
+            LibvirtConnectionMixin.LIBVIRT_CONNECTION = libvirt.open(LIBVIRT_URI)
+        except libvirt.libvirtError as e:
+            raise CallError(f'Failed to open libvirt connection: {e}')
+
+    def _close(self):
+        try:
+            self.LIBVIRT_CONNECTION.close()
+        except libvirt.libvirtError as e:
+            raise CallError(f'Failed to close libvirt connection: {e}')
+        else:
+            self.LIBVIRT_CONNECTION = None
+
+    def _is_connection_alive(self):
+        return self.LIBVIRT_CONNECTION and self.LIBVIRT_CONNECTION.isAlive()
+
+    def _check_connection_alive(self):
+        if not self._is_connection_alive():
+            raise CallError('Failed to connect to libvirt')
+
+    def _check_setup_connection(self):
+        if not self._is_connection_alive():
+            self.middleware.call_sync('vm.wait_for_libvirtd', 10)
+        self._check_connection_alive()

--- a/src/middlewared/middlewared/plugins/vm_/events.py
+++ b/src/middlewared/middlewared/plugins/vm_/events.py
@@ -1,10 +1,11 @@
 import libvirt
 import threading
 
+from middlewared.plugins.vm import LibvirtConnectionMixin
 from middlewared.service import private, Service
 
 
-class VMService(Service):
+class VMService(Service, LibvirtConnectionMixin):
 
     @private
     def setup_libvirt_events(self, libvirt_connection):
@@ -58,11 +59,11 @@ class VMService(Service):
                 self.middleware.logger.debug('Received libvirtd event with unknown domain name %s', dom.name())
 
         def event_loop_execution():
-            while libvirt_connection._o and libvirt_connection.isAlive():
+            while self.LIBVIRT_CONNECTION._o and self.LIBVIRT_CONNECTION.isAlive():
                 libvirt.virEventRunDefaultImpl()
 
         event_thread = threading.Thread(target=event_loop_execution, name='libvirt_event_loop')
         event_thread.setDaemon(True)
         event_thread.start()
-        libvirt_connection.domainEventRegister(callback, None)
-        libvirt_connection.setKeepAlive(5, 3)
+        self.LIBVIRT_CONNECTION.domainEventRegister(callback, None)
+        self.LIBVIRT_CONNECTION.setKeepAlive(5, 3)

--- a/src/middlewared/middlewared/plugins/vm_/events.py
+++ b/src/middlewared/middlewared/plugins/vm_/events.py
@@ -1,14 +1,15 @@
 import libvirt
 import threading
 
-from middlewared.plugins.vm import LibvirtConnectionMixin
 from middlewared.service import private, Service
+
+from .connection import LibvirtConnectionMixin
 
 
 class VMService(Service, LibvirtConnectionMixin):
 
     @private
-    def setup_libvirt_events(self, libvirt_connection):
+    def setup_libvirt_events(self):
         def callback(conn, dom, event, detail, opaque):
             """
             0: 'DEFINED',


### PR DESCRIPTION
Libvirt is not very stable in freebsd with bhyve and thus we are seeing occurrences where libvirt connection closes for some reason. This PR introduces changes to re-initialize the libvirt connection if it closes.