### PR TITLE
NAS-108575 / 21.02 / Make checking container image updates optional

### DIFF
--- a/src/middlewared/middlewared/alembic/versions/12.1/2020-12-14_05-11_container_image_updates.py
+++ b/src/middlewared/middlewared/alembic/versions/12.1/2020-12-14_05-11_container_image_updates.py
@@ -1,0 +1,24 @@
+"""
+Allow container image updates to be configurable
+
+Revision ID: 920a1a135ef7
+Revises: 3d611f8cc676
+Create Date: 2020-12-14 05:11:26.058680+00:00
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '920a1a135ef7'
+down_revision = '3d611f8cc676'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'services_container',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('enable_image_updates', sa.Boolean(), default=True),
+        sa.PrimaryKeyConstraint('id', name=op.f('pk_services_container')),
+    )

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
@@ -175,7 +175,9 @@ class ChartReleaseService(Service):
 
             await self.chart_release_update_check(catalog_item, application)
 
-        asyncio.ensure_future(self.middleware.call('container.image.check_update'))
+        container_config = await self.middleware.call('container.config')
+        if container_config['enable_image_updates']:
+            asyncio.ensure_future(self.middleware.call('container.image.check_update'))
 
     @private
     async def chart_release_update_check(self, catalog_item, application):

--- a/src/middlewared/middlewared/plugins/docker_linux/client.py
+++ b/src/middlewared/middlewared/plugins/docker_linux/client.py
@@ -62,14 +62,14 @@ class DockerClientMixin:
 
         return response
 
-    def get_manifest_call_headers(self, registry, image, headers):
+    async def get_manifest_call_headers(self, registry, image, headers):
         if registry == DEFAULT_DOCKER_REGISTRY:
             headers['Authorization'] = f'Bearer {await self._get_token(image)}'
         return headers
 
     async def _get_latest_digest(self, registry, image, tag):
         response = await self._get_manifest_response(
-            registry, image, tag, self.get_manifest_call_headers(registry, image, {
+            registry, image, tag, await self.get_manifest_call_headers(registry, image, {
                 'Accept': 'application/vnd.docker.distribution.manifest.v2+json',
             }), 'get', True
         )
@@ -78,7 +78,7 @@ class DockerClientMixin:
 
     async def _get_repo_digest(self, registry, image, tag):
         response = await self._get_manifest_response(
-            registry, image, tag, self.get_manifest_call_headers(registry, image, {
+            registry, image, tag, await self.get_manifest_call_headers(registry, image, {
                 'Accept': 'application/vnd.docker.distribution.manifest.v2+json, '
                           'application/vnd.docker.distribution.manifest.list.v2+json, '
                           'application/vnd.docker.distribution.manifest.v1+json',

--- a/src/middlewared/middlewared/plugins/docker_linux/client.py
+++ b/src/middlewared/middlewared/plugins/docker_linux/client.py
@@ -5,7 +5,7 @@ import asyncio
 
 from middlewared.service import CallError
 
-from .utils import DEFAULT_DOCKER_REGISTRY
+from .utils import DEFAULT_DOCKER_REGISTRY, DOCKER_CONTENT_DIGEST_HEADER
 
 
 DOCKER_REGISTRY_AUTH_BASE = 'https://auth.docker.io'
@@ -14,16 +14,17 @@ DOCKER_AUTH_SERVICE = 'registry.docker.io'
 
 class DockerClientMixin:
 
-    async def _get_call(self, url, options=None, headers=None):
+    async def _api_call(self, url, options=None, headers=None, mode='get'):
         options = options or {}
         timeout = options.get('timeout', 15)
+        assert mode in ('get', 'head')
         response = {'error': None, 'response': {}, 'response_obj': None}
         try:
             async with async_timeout.timeout(timeout):
                 async with aiohttp.ClientSession(
                     raise_for_status=True, trust_env=True,
                 ) as session:
-                    req = await session.get(url, headers=headers)
+                    req = await getattr(session, mode)(url, headers=headers)
         except asyncio.TimeoutError:
             response['error'] = f'Unable to connect with {url} in {timeout} seconds.'
         except aiohttp.ClientResponseError as e:
@@ -44,7 +45,7 @@ class DockerClientMixin:
         return response
 
     async def _get_token(self, image):
-        response = await self._get_call(
+        response = await self._api_call(
             f'{DOCKER_REGISTRY_AUTH_BASE}/token?service={DOCKER_AUTH_SERVICE}&scope=repository:{image}:pull'
         )
         if response['error']:
@@ -52,15 +53,36 @@ class DockerClientMixin:
 
         return response['response']['token']
 
-    async def _get_latest_digest(self, registry, image, tag):
-        headers = {'Accept': 'application/vnd.docker.distribution.manifest.v2+json'}
-        if registry == DEFAULT_DOCKER_REGISTRY:
-            headers['Authorization'] = f'Bearer {await self._get_token(image)}'
-
-        response = await self._get_call(
-            f'https://{registry}/v2/{image}/manifests/{tag}', headers=headers
+    async def _get_manifest_response(self, registry, image, tag, headers, mode, raise_error):
+        response = await self._api_call(
+            f'https://{registry}/v2/{image}/manifests/{tag}', headers=headers, mode=mode
         )
-        if response['error']:
+        if raise_error and response['error']:
             raise CallError(f'Unable to retrieve latest image digest for {f"{image}:{tag}"!r}: {response["error"]}')
 
+        return response
+
+    def get_manifest_call_headers(self, registry, image, headers):
+        if registry == DEFAULT_DOCKER_REGISTRY:
+            headers['Authorization'] = f'Bearer {await self._get_token(image)}'
+        return headers
+
+    async def _get_latest_digest(self, registry, image, tag):
+        response = await self._get_manifest_response(
+            registry, image, tag, self.get_manifest_call_headers(registry, image, {
+                'Accept': 'application/vnd.docker.distribution.manifest.v2+json',
+            }), 'get', True
+        )
+
         return response['response']['config']['digest']
+
+    async def _get_repo_digest(self, registry, image, tag):
+        response = await self._get_manifest_response(
+            registry, image, tag, self.get_manifest_call_headers(registry, image, {
+                'Accept': 'application/vnd.docker.distribution.manifest.v2+json, '
+                          'application/vnd.docker.distribution.manifest.list.v2+json, '
+                          'application/vnd.docker.distribution.manifest.v1+json',
+            }), 'head', False
+        )
+        if not response['error']:
+            return response['response_obj'].headers.get(DOCKER_CONTENT_DIGEST_HEADER)

--- a/src/middlewared/middlewared/plugins/docker_linux/images.py
+++ b/src/middlewared/middlewared/plugins/docker_linux/images.py
@@ -38,6 +38,7 @@ class DockerImagesService(CRUDService):
                     'id': image['Id'],
                     'labels': image['Labels'],
                     'repo_tags': repo_tags,
+                    'repo_digests': image.get('RepoDigests') or [],
                     'size': image['Size'],
                     'created': datetime.fromtimestamp(int(image['Created'])),
                     'dangling': len(repo_tags) == 1 and repo_tags[0] == '<none>:<none>',

--- a/src/middlewared/middlewared/plugins/docker_linux/update.py
+++ b/src/middlewared/middlewared/plugins/docker_linux/update.py
@@ -1,0 +1,33 @@
+import middlewared.sqlalchemy as sa
+
+from middlewared.schema import Bool, Dict
+from middlewared.service import accepts, ConfigService
+
+
+class ContainerModel(sa.Model):
+    __tablename__ = 'services_container'
+
+    id = sa.Column(sa.Integer(), primary_key=True)
+    enable_image_updates = sa.Column(sa.Boolean(), default=True)
+
+
+class ContainerService(ConfigService):
+
+    class Config:
+        datastore = 'services.kubernetes'
+
+    @accepts(
+        Dict(
+            'container_update',
+            Bool('enable_image_updates'),
+            update=True,
+        )
+    )
+    async def do_update(self, data):
+        old_config = await self.config()
+        config = old_config.copy()
+        config.update(data)
+
+        await self.middleware.call('datastore.update', self._config.datastore, old_config['id'], config)
+
+        return await self.config()

--- a/src/middlewared/middlewared/plugins/docker_linux/update.py
+++ b/src/middlewared/middlewared/plugins/docker_linux/update.py
@@ -14,7 +14,7 @@ class ContainerModel(sa.Model):
 class ContainerService(ConfigService):
 
     class Config:
-        datastore = 'services.kubernetes'
+        datastore = 'services.container'
 
     @accepts(
         Dict(
@@ -24,6 +24,14 @@ class ContainerService(ConfigService):
         )
     )
     async def do_update(self, data):
+        """
+        When `enable_image_updates` is set, system will check if existing container images need to be updated. System
+        will basically check if we have an updated image hash available for the same tag available and if we do,
+        user is alerted to update the image.
+        A use case for unsetting this variable can be rate limits for docker registries, as each time we check if a
+        single image needs update, we consume the rate limit and eventually it can hinder operations if the number
+        of images to be checked is a lot.
+        """
         old_config = await self.config()
         config = old_config.copy()
         config.update(data)

--- a/src/middlewared/middlewared/plugins/docker_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/docker_linux/utils.py
@@ -1,5 +1,5 @@
-DOCKER_CONTENT_DIGEST_HEADER = 'Docker-Content-Digest'
 DEFAULT_DOCKER_IMAGES_LIST_PATH = '/usr/local/share/docker_images/image-list.txt'
 DEFAULT_DOCKER_REGISTRY = 'registry-1.docker.io'
 DEFAULT_DOCKER_REPO = 'library'
 DEFAULT_DOCKER_TAG = 'latest'
+DOCKER_CONTENT_DIGEST_HEADER = 'Docker-Content-Digest'

--- a/src/middlewared/middlewared/plugins/docker_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/docker_linux/utils.py
@@ -1,3 +1,4 @@
+DOCKER_CONTENT_DIGEST_HEADER = 'Docker-Content-Digest'
 DEFAULT_DOCKER_IMAGES_LIST_PATH = '/usr/local/share/docker_images/image-list.txt'
 DEFAULT_DOCKER_REGISTRY = 'registry-1.docker.io'
 DEFAULT_DOCKER_REPO = 'library'


### PR DESCRIPTION
Dockerhub has recently introduced rate limits and we are affected by the rate limit. How it happens is that each time when we check if we have an update for an image available, we consume the rate limit which can potentially hinder operations involving docker/k8s, so this PR makes checking container image updates optional.