### PR TITLE
NAS-108620 / 20.12 / samba - add zfs_core to vfs objects in SCALE

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -121,9 +121,8 @@ class SMBSharePreset(enum.Enum):
         'path_suffix': '%U',
         'timemachine': True,
         'auxsmbconf': '\n'.join([
-            'tmprotect:auto_rollback=powerloss',
-            'ixnas:zfs_auto_homedir=true',
-            'ixnas:default_user_quota=1T',
+            'ixnas:zfs_auto_homedir=true' if osc.IS_FREEBSD else 'zfs_core:zfs_auto_create=true',
+            'ixnas:default_user_quota=1T' if osc.IS_FREEBSD else 'zfs_core:base_user_quota=1T',
         ])
     }}
     MULTI_PROTOCOL_AFP = {"verbose_name": "Multi-protocol (AFP/SMB) shares", "params": {
@@ -155,7 +154,7 @@ class SMBSharePreset(enum.Enum):
     PRIVATE_DATASETS = {"verbose_name": "Private SMB Datasets and Shares", "params": {
         'path_suffix': '%U',
         'auxsmbconf': '\n'.join([
-            'ixnas:zfs_auto_homedir=true'
+            'ixnas:zfs_auto_homedir=true' if osc.IS_FREEBSD else 'zfs_core:zfs_auto_create=true'
         ])
     }}
     WORM_DROPBOX = {"verbose_name": "SMB WORM. Files become readonly via SMB after 5 minutes", "params": {

--- a/src/middlewared/middlewared/plugins/smb_/registry.py
+++ b/src/middlewared/middlewared/plugins/smb_/registry.py
@@ -156,7 +156,8 @@ class SharingSMBService(Service):
     @private
     async def order_vfs_objects(self, vfs_objects):
         vfs_objects_special = ('catia', 'zfs_space', 'fruit', 'streams_xattr', 'shadow_copy_zfs',
-                               'noacl', 'ixnas', 'acl_xattr', 'zfsacl', 'crossrename', 'recycle')
+                               'noacl', 'ixnas', 'acl_xattr', 'zfsacl', 'crossrename', 'recycle',
+                               'zfs_core', 'aio_fbsd', 'io_uring')
 
         vfs_objects_ordered = []
 
@@ -343,7 +344,7 @@ class SharingSMBService(Service):
         if osc.IS_FREEBSD:
             data['vfsobjects'] = ['aio_fbsd']
         else:
-            data['vfsobjects'] = ['io_uring']
+            data['vfsobjects'] = ['zfs_core', 'io_uring']
 
         if data['comment']:
             conf["comment"] = data['comment']


### PR DESCRIPTION
This fixes zfs dataset auto-creation for multi-user time machine shares
and private home datasets. In addition to this change, ensure that Linux
specific configuration is applied to shares.