### PR TITLE
NAS-108658 / 20.12 / Fix logging when failing to add SMB share

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -1353,7 +1353,7 @@ class SharingSMBService(SharingService):
             try:
                 await self.middleware.call('sharing.smb.reg_addshare', share_conf[0])
             except Exception:
-                self.logger.warning("Failed to add SMB share [%] while synchronizing registry config",
+                self.logger.warning("Failed to add SMB share [%s] while synchronizing registry config",
                                     share, exc_info=True)
 
         for share in to_del:


### PR DESCRIPTION
@anodos325 the underlying exception is:
```
[2020/10/27 20:14:25] (DEBUG) SharingSMBService.netconf():59 - netconf failure for command [['net', 'conf', 'addshare', 'Tools', '/mnt/akira_p01/Tools', 'writeable=y', 'guest_ok=y']] stdout: 
--- Logging error ---
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/middlewared/plugins/smb.py", line 1220, in sync_registry
    await self.middleware.call('sharing.smb.reg_addshare', share_conf[0])
  File "/usr/local/lib/python3.8/site-packages/middlewared/main.py", line 1233, in call
    return await self._call(
  File "/usr/local/lib/python3.8/site-packages/middlewared/main.py", line 1191, in _call
    return await methodobj(*prepared_call.args)
  File "/usr/local/lib/python3.8/site-packages/middlewared/plugins/smb_/registry.py", line 76, in reg_addshare
    await self.netconf(
  File "/usr/local/lib/python3.8/site-packages/middlewared/plugins/smb_/registry.py", line 61, in netconf
    raise CallError(
middlewared.service_exception.CallError: [EFAULT] net conf addshare [Tools] failed with error: ERROR: share Tools already exists.
```
If you think that should not be happening, the debug is here https://jira.ixsystems.com/browse/NAS-108613 (this message is at the very top of `middlewared.log`)