### PR TITLE
NAS-108662 / 21.02 / Bug fix for ip_in_use endpoint

### DIFF
--- a/src/middlewared/middlewared/plugins/network.py
+++ b/src/middlewared/middlewared/plugins/network.py
@@ -2025,9 +2025,10 @@ class InterfaceService(CRUDService):
 
         """
         list_of_ip = []
-        ignore_nics = ['tap', 'epair', 'pflog']
-        if not choices['loopback']:
-            ignore_nics.append('lo')
+        ignore_nics = self.middleware.call_sync('interface.internal_interfaces')
+        if choices['loopback']:
+            ignore_nics.remove('lo')
+
         ignore_nics = tuple(ignore_nics)
         static_ips = {}
         if choices['static']:


### PR DESCRIPTION
This commit fixes an issue where we only filtered out internal interfaces of freebsd and for linux we were getting ips of those internal interfaces as well when consuming this endpoint.