### PR TITLE
NAS-108678 / 12.0 / Partially revert "Fix possibility for middleware plugin to leak passw…

### DIFF
--- a/src/freenas/usr/local/libexec/freenas-debug/system/system.sh
+++ b/src/freenas/usr/local/libexec/freenas-debug/system/system.sh
@@ -133,7 +133,7 @@ system_func()
 	section_footer
 
 	section_header "Middleware Jobs - 'midclt call core.get_jobs'"
-	midclt call core.get_jobs '[["state", "!=", "SUCCESS"]]' '{"extra": {"public": true}}' | jq .
+	midclt call core.get_jobs '[["state", "!=", "SUCCESS"]]' | jq .
 	section_footer
 
 	if [ -f /data/license ]; then

--- a/src/middlewared/middlewared/job.py
+++ b/src/middlewared/middlewared/job.py
@@ -438,7 +438,7 @@ class Job(object):
 
         await self.middleware.run_in_thread(close_pipes)
 
-    def __encode__(self, public=False):
+    def __encode__(self):
         exc_info = None
         if self.exc_info:
             etype = self.exc_info[0]
@@ -466,7 +466,7 @@ class Job(object):
             'logs_path': self.logs_path,
             'logs_excerpt': self.logs_excerpt,
             'progress': self.progress,
-            'result': '********' if public and self.options['result_private'] else self.result,
+            'result': self.result,
             'error': self.error,
             'exception': self.exception,
             'exc_info': exc_info,

--- a/src/middlewared/middlewared/plugins/vmware.py
+++ b/src/middlewared/middlewared/plugins/vmware.py
@@ -543,7 +543,7 @@ class VMWareService(CRUDService):
             connect.Disconnect(si)
 
     @private
-    @job(result_private=True)
+    @job()
     def periodic_snapshot_task_begin(self, job, task_id):
         task = self.middleware.call_sync("pool.snapshottask.query",
                                          [["id", "=", task_id]],

--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -52,8 +52,7 @@ def item_method(fn):
     return fn
 
 
-def job(lock=None, lock_queue_size=None, logs=False, process=False, pipes=None, check_pipes=True, transient=False,
-        result_private=False):
+def job(lock=None, lock_queue_size=None, logs=False, process=False, pipes=None, check_pipes=True, transient=False):
     """Flag method as a long running job."""
     def check_job(fn):
         fn._job = {
@@ -64,7 +63,6 @@ def job(lock=None, lock_queue_size=None, logs=False, process=False, pipes=None, 
             'pipes': pipes or [],
             'check_pipes': check_pipes,
             'transient': transient,
-            'result_private': result_private,
         }
         return fn
     return check_job
@@ -774,8 +772,7 @@ class CoreService(Service):
     def get_jobs(self, filters=None, options=None):
         """Get the long running jobs."""
         jobs = filter_list([
-            i.__encode__(public=options['extra'].get('public', False))
-            for i in list(self.middleware.jobs.all().values())
+            i.__encode__() for i in list(self.middleware.jobs.all().values())
         ], filters, options)
         return jobs
 


### PR DESCRIPTION
diff HEAD~2
```
diff --git a/src/middlewared/middlewared/plugins/vmware.py b/src/middlewared/middlewared/plugins/vmware.py
index b3f41fe506..5ac6af8a31 100644
--- a/src/middlewared/middlewared/plugins/vmware.py
+++ b/src/middlewared/middlewared/plugins/vmware.py
@@ -6,7 +6,7 @@ import ssl
 import uuid
 
 from middlewared.async_validators import resolve_hostname
-from middlewared.schema import accepts, Bool, Dict, Int, Str, Patch
+from middlewared.schema import accepts, Any, Bool, Dict, Int, Str, Patch
 from middlewared.service import CallError, CRUDService, job, private, ValidationErrors
 import middlewared.sqlalchemy as sa
 
@@ -143,7 +143,7 @@ class VMWareService(CRUDService):
         'vmware-creds',
         Str('hostname', required=True),
         Str('username', required=True),
-        Str('password', required=True),
+        Str('password', private=True, required=True),
     ))
     def get_datastores(self, data):
         """
@@ -155,7 +155,7 @@ class VMWareService(CRUDService):
         'vmware-creds',
         Str('hostname', required=True),
         Str('username', required=True),
-        Str('password', required=True),
+        Str('password', private=True, required=True),
     ))
     def match_datastores_with_datasets(self, data):
         """
@@ -552,6 +552,7 @@ class VMWareService(CRUDService):
         return self.snapshot_begin(task["dataset"], task["recursive"])
 
     @private
+    @accepts(Any("context", private=True))
     @job()
     def periodic_snapshot_task_end(self, job, context):
         return self.snapshot_end(context)
```