### PR TITLE
NAS-108678 / 20.12 / Partially revert "Fix possibility for middleware plugin to leak passw… (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/vmware.py
+++ b/src/middlewared/middlewared/plugins/vmware.py
@@ -6,7 +6,7 @@ import ssl
 import uuid
 
 from middlewared.async_validators import resolve_hostname
-from middlewared.schema import accepts, Bool, Dict, Int, Str, Patch
+from middlewared.schema import accepts, Any, Bool, Dict, Int, Str, Patch
 from middlewared.service import CallError, CRUDService, job, private, ValidationErrors
 import middlewared.sqlalchemy as sa
 
@@ -143,7 +143,7 @@ class VMWareService(CRUDService):
         'vmware-creds',
         Str('hostname', required=True),
         Str('username', required=True),
-        Str('password', required=True),
+        Str('password', private=True, required=True),
     ))
     def get_datastores(self, data):
         """
@@ -155,7 +155,7 @@ class VMWareService(CRUDService):
         'vmware-creds',
         Str('hostname', required=True),
         Str('username', required=True),
-        Str('password', required=True),
+        Str('password', private=True, required=True),
     ))
     def match_datastores_with_datasets(self, data):
         """
@@ -559,6 +559,7 @@ class VMWareService(CRUDService):
         return self.snapshot_begin(task["dataset"], task["recursive"])
 
     @private
+    @accepts(Any("context", private=True))
     @job()
     def periodic_snapshot_task_end(self, job, context):
         return self.snapshot_end(context)


### PR DESCRIPTION
Automatic cherry-pick failed. Please resolve conflicts by running:

    git reset --hard HEAD~1
    git cherry-pick -x 46333c5a16bfb3fccad1033fbdc60309c2f07d4a

diff HEAD~2
```
diff --git a/src/middlewared/middlewared/plugins/vmware.py b/src/middlewared/middlewared/plugins/vmware.py
index b3f41fe506..5ac6af8a31 100644
--- a/src/middlewared/middlewared/plugins/vmware.py
+++ b/src/middlewared/middlewared/plugins/vmware.py
@@ -6,7 +6,7 @@ import ssl
 import uuid
 
 from middlewared.async_validators import resolve_hostname
-from middlewared.schema import accepts, Bool, Dict, Int, Str, Patch
+from middlewared.schema import accepts, Any, Bool, Dict, Int, Str, Patch
 from middlewared.service import CallError, CRUDService, job, private, ValidationErrors
 import middlewared.sqlalchemy as sa
 
@@ -143,7 +143,7 @@ class VMWareService(CRUDService):
         'vmware-creds',
         Str('hostname', required=True),
         Str('username', required=True),
-        Str('password', required=True),
+        Str('password', private=True, required=True),
     ))
     def get_datastores(self, data):
         """
@@ -155,7 +155,7 @@ class VMWareService(CRUDService):
         'vmware-creds',
         Str('hostname', required=True),
         Str('username', required=True),
-        Str('password', required=True),
+        Str('password', private=True, required=True),
     ))
     def match_datastores_with_datasets(self, data):
         """
@@ -552,6 +552,7 @@ class VMWareService(CRUDService):
         return self.snapshot_begin(task["dataset"], task["recursive"])
 
     @private
+    @accepts(Any("context", private=True))
     @job()
     def periodic_snapshot_task_end(self, job, context):
         return self.snapshot_end(context)
```

Original PR: https://github.com/freenas/freenas/pull/6168