### PR TITLE
NAS-108659 / 21.02 / fix loader.conf.local being lost on upgrade (by yocalebo)

### DIFF
--- a/src/freenas/etc/ix.rc.d/ix-update
+++ b/src/freenas/etc/ix.rc.d/ix-update
@@ -4,6 +4,7 @@
 #
 
 # PROVIDE: ix-update
+# REQUIRE: ix-update-scripts
 # BEFORE: middlewared earlykld
 
 . /etc/rc.freenas
@@ -88,9 +89,21 @@ db_update()
 		if [ -f /usr/local/sbin/firmware_update.py ]; then
 			LD_LIBRARY_PATH=/usr/local/lib /usr/local/bin/python /usr/local/sbin/firmware_update.py
 			if [ $? -eq 0 ]; then
-				# A reboot will be required, but we'll hold off
-				# on that and do database upgrades if they need
-				# to be done as well to avoid a double reboot.
+				# Users often wonder why a 3rd reboot occurs on their system
+				# when they upgrade their box. This is the reason why.
+				# To keep the long, drawn out story as short as possible
+				# and to maintain the fickle state that my mind is in
+				# after troubleshooting upgrade code for an entire day,
+				# /update-scripts gets created on upgrade by default
+				# in the Installer.py code (freenas-update).
+				# ix-update-scripts runs before this script and reboots
+				# the box before this rc script gets called.
+				# So a 2nd reboot occurs, and if the system that is being
+				# upgraded also has a SAS HBA card that received a
+				# firmware upgrade, then we set this variable to 1. As
+				# you may already guess, a 3rd reboot occurs. This will
+				# make you drink, if you don't already and/or step away
+				# from the computer and make you question your life choices.
 				REBOOT_REQUIRED=1
 			fi
 		else
@@ -143,8 +156,6 @@ db_update()
 
 	rm -f $NEED_UPDATE_SENTINEL
 	rm -f $CD_UPGRADE_SENTINEL
-
-	/usr/local/bin/midclt call etc.generate loader > /dev/null
 
 	echo "Database upgrade complete.  Rebooting."
 	cd /

--- a/src/middlewared/middlewared/etc_files/loader.py
+++ b/src/middlewared/middlewared/etc_files/loader.py
@@ -1,6 +1,7 @@
 import logging
 import subprocess
 import sysctl
+import os
 from packaging import version
 
 from middlewared.utils.io import write_if_changed
@@ -10,7 +11,16 @@ logger = logging.getLogger(__name__)
 
 def loader_config(middleware):
     config = generate_loader_config(middleware)
-    write_if_changed("/boot/loader.conf.local", "\n".join(config) + "\n")
+    path = "/boot/loader.conf.local"
+    write_if_changed(path, "\n".join(config) + "\n")
+
+    # write_if_changed creates the file with
+    # the execute bit so remove it
+    try:
+        os.chmod(path, 0o644)
+    except Exception:
+        # dont crash here
+        pass
 
 
 def generate_loader_config(middleware):


### PR DESCRIPTION
There was a singular issue. `/boot/loader.conf.local` was being "lost" on upgrades....kind of. `kenv` didn't report the values set by us but the file had the correct contents. I spun up a local VM and delved into the problem. Slowly but inexorably crawling upon my consciousness and rising above every other impression, came a dizzying dissonance between the upgrade code and my personal fear. I stared into the abyss, and it stared back. I've barely made it out alive (thankful to the ones that helped me through this trying time 😄 )

I've found a few issues that I've tried to address with this PR.

- `freenas-update` creates `/update-scritps` every time which means `ix-update-scripts` runs and as far as I can comprehend, `ix-update` needs to run after `ix-update-scripts`
- `ix-update` runs `BEFORE: middlewared` which means the `midclt` call will fail
- partially revert 7d5f773ffa4338ebab1bc11ef605b1ee12eb046e because it introduced the fact that we were creating a `/boot/loader.conf.local` file at _BUILD_ time so when an upgrade occurred it would overwrite the current `/boot/loader.conf.local` file.
- etc config and loader files are executable

Original PR: https://github.com/freenas/freenas/pull/6170