### PR TITLE
NAS-108719 / 21.02 / dont restart services when unlocking zfs datasets on failover

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
@@ -619,7 +619,7 @@ class FailoverService(ConfigService):
         # Unnlock all (if any) zfs datasets for `pool_name`
         # that we have keys for in the cache or the database.
         # `restart_services` will cause any services that are
-        # depedant on the datasets to be restarted after the
+        # dependent on the datasets to be restarted after the
         # datasets are unlocked.
         zfs_keys = (await self.encryption_keys())['zfs']
         unlock_job = await self.middleware.call(

--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover.py
@@ -607,14 +607,26 @@ class FailoverService(ConfigService):
         return await self.middleware.call('failover.force_master')
 
     @private
+    @accepts(
+        Str('pool_name'),
+        Dict(
+            'unlock_zfs_datasets',
+            Bool('restart_services', default=True),
+        )
+    )
     @job(lock=lambda args: f'failover_dataset_unlock_{args[0]}')
-    async def unlock_zfs_datasets(self, job, pool_name):
-        # We are going to unlock all zfs datasets we have keys in cache/database for the pool in question
+    async def unlock_zfs_datasets(self, job, pool_name, data):
+        # Unnlock all (if any) zfs datasets for `pool_name`
+        # that we have keys for in the cache or the database.
+        # `restart_services` will cause any services that are
+        # depedant on the datasets to be restarted after the
+        # datasets are unlocked.
         zfs_keys = (await self.encryption_keys())['zfs']
         unlock_job = await self.middleware.call(
             'pool.dataset.unlock', pool_name, {
                 'recursive': True,
-                'datasets': [{'name': name, 'passphrase': passphrase} for name, passphrase in zfs_keys.items()]
+                'datasets': [{'name': name, 'passphrase': passphrase} for name, passphrase in zfs_keys.items()],
+                'toggle_attachments': data['restart_services'],
             }
         )
         return await job.wrap(unlock_job)

--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/event_linux.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/event_linux.py
@@ -426,7 +426,11 @@ class FailoverService(Service):
                 continue
 
             # try to unlock the zfs datasets (if any)
-            unlock_job = self.run_call('failover.unlock_zfs_datasets', vol["name"])
+            unlock_job = self.run_call(
+                'failover.unlock_zfs_datasets', vol["name"], {
+                    'restart_services': False,
+                }
+            )
             unlock_job.wait_sync()
             if unlock_job.error:
                 logger.error(f'Error unlocking ZFS encrypted datasets: {unlock_job.error}')


### PR DESCRIPTION
On a failover event, we unlock any encrypted datasets on zpool import. By default, the unlocking of the datasets will also try and restart the associated services that depend on that dataset.

This causes a failure because we don't setup the system dataset by the time this is called. Since the failover logic will restart all associated services as necessary, I've added a `restart_services` boolean to `failover.unlock_zfs_datasets` that will prevent this behavior. I've defaulted to `True` to not cause POLA violation with the `pool.dataset.unlock` API.