### PR TITLE
NAS-108724 / 21.02 / if serial input is enabled, read the input buffer to clear any garbage

### DIFF
--- a/src/freenas/etc/grub.d/10_truenas_linux
+++ b/src/freenas/etc/grub.d/10_truenas_linux
@@ -34,6 +34,10 @@ export TEXTDOMAINDIR="${datarootdir}/locale"
 CLASS="--class gnu-linux --class gnu --class os"
 SUPPORTED_INITS="sysvinit:/lib/sysvinit/init systemd:/lib/systemd/systemd upstart:/sbin/upstart"
 
+if echo ${GRUB_TERMINAL_OUTPUT} | grep -q serial; then
+  echo "sleep -i 1 # serial input enabled, let's consume buffered input"
+fi
+
 if [ "x${GRUB_DISTRIBUTOR}" = "x" ] ; then
   OS=GNU/Linux
 else


### PR DESCRIPTION
On my hardware, `serial` *always* has some garbage after initialization.

Grub reads that garbage input and disables the timeout.

If we wait 1 second with `--interruptible` set, grub reads the buffer (`ESC` early aborts the sleep). 

In order for this to *not* be sufficient, ESC (`10`(STOP/START)+`00011011`+`1`(STOP)) would have to be read on the byte boundary. This is possible, but it seems very unlikely.