### PR TITLE
NAS-108720 / 12.0 / Do not background Samba path creation during sysdataset setup (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/plugins/sysdataset.py
+++ b/src/middlewared/middlewared/plugins/sysdataset.py
@@ -290,7 +290,10 @@ class SystemDatasetService(ConfigService):
                 os.chmod(corepath, 0o775)
 
             await self.__nfsv4link(config)
-            await self.middleware.call('smb.configure')
+            await self.middleware.call('smb.setup_directories')
+            # The following should be backgrounded since they may be quite
+            # long-running.
+            await self.middleware.call('smb.configure', False)
             await self.middleware.call('dscache.initialize')
 
         return config


### PR DESCRIPTION
Other tasks may be dependent on these paths actually existing
because samba libraries may not be able to generate a messaging
context.