### PR TITLE
NAS-108790 / 21.02 / fix sysdataset setup by moving cluster calls to glusterd service

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_shared_volume.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_shared_volume.py
@@ -158,24 +158,11 @@ class CtdbSharedVolumeService(Service):
         Mount the ctdb shared volume locally.
         """
 
-        # We call this method on startup so if we were
-        # to add a call to the `create` method then all
-        # nodes in the cluster would try to create the
-        # shared volume which is unnecessary and will
-        # cause lots of errors since only 1 node in the
-        # cluster needs to create the volume and it gets
-        # propagated to the peers that were specified
-        # during the creation of the shared volume.
-        #
-        # In summary....dont try to be fancy and call the
-        # create method in here or it's going to cause
-        # headaches.
+        # if the volume hasn't been created or started then we obviously
+        # can't mount it
         exists, started = await self.shared_volume_exists_and_started()
         if not exists or not started:
-            raise CallError(
-                'The ctdb shared volume does not exist or '
-                'is not started.'
-            )
+            return
 
         path = pathlib.Path(CTDBConfig.CTDB_LOCAL_MOUNT.value)
         try:

--- a/src/middlewared/middlewared/plugins/gluster_linux/eventsd.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/eventsd.py
@@ -169,17 +169,8 @@ class GlusterEventsdService(Service):
     def init(self, job):
         """
         Initializes the webhook directory and config file
-        if it doesn't exist and then starts the service.
+        if it doesn't exist.
         """
-
-        service = self.middleware.call_sync(
-            'datastore.query', 'services.services',
-            [('srv_service', '=', 'glusterd')],
-            {'prefix': 'srv_'},
-        )
-        if not service[0]['enable']:
-            # glusterd isn't enabled so return
-            return
 
         webhook_file = pathlib.Path(WEBHOOKS_FILE)
 
@@ -226,11 +217,5 @@ class GlusterEventsdService(Service):
             raise CallError(
                 f'Failed writing to {webhook_file} with error: {e}'
             )
-
-        # glustereventsd service doesn't have an entry in
-        # the db so we start it based on whether or not the
-        # glusterd service is set to start on boot so if we
-        # get here, then restart it
-        self.middleware.call_sync('service.restart', 'glustereventsd')
 
         return init_data

--- a/src/middlewared/middlewared/plugins/gluster_linux/volume.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/volume.py
@@ -136,7 +136,9 @@ class GlusterVolumeService(Service):
 
         # before we create the gluster volume, we need to ensure
         # the ctdb shared volume is setup
-        self.middleware.call_sync('ctdb.shared.volume.create')
+        self.middleware.call_sync(
+            'ctdb.shared.volume.create'
+        ).wait_sync(raise_error=True)
 
         bricks = []
         for i in temp:


### PR DESCRIPTION
- `ctdb.shared.volume.{mount/umount}` now no longer raise `CallError` if the ctdb volume doesn't exist
- Remove all gluster related calls (that depend on `glusterd` to be started) from the `sysdataset.setup` plugin since it's running before the `glusterd` service is started
- On all gluster creation requests, we run and wait on `ctdb.shared.volume.create` raising any errors if necessary.
- `glustereventsd` and FUSE mounting the `ctdb_shared_vol` is now all run on any `glusterd` service action.