### PR TITLE
NAS-108666 / 21.02 / prevent netcli from hanging on sockstat calls by redoing get_ui_urls

### DIFF
--- a/src/freenas/etc/netcli
+++ b/src/freenas/etc/netcli
@@ -1482,8 +1482,7 @@ def show_ip():
         print()
         print(_("The web user interface is at:"))
         print()
-
-        for url in sorted(urls):
+        for url in urls:
             print(url)
     else:
         print()

--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -1414,101 +1414,86 @@ class SystemGeneralService(ConfigService):
 
         raise CallError('Unable to connect to any of the specified UI addresses:\n' + '\n'.join(errors))
 
-    def __get_urls(self, aliases, addrs, ipv6=False):
-
-        skip_internal = False
-        if self.middleware.call_sync('system.product_type') == 'ENTERPRISE':
-            skip_internal = True
-
-        urls = []
-        for addr in addrs:
-            ip, port = addr.split(':')
-
-            if ip == '*':
-                ips = [
-                    i["address"]
-                    for i in aliases
-                    if i['type'] == ('INET6' if ipv6 else 'INET')
-                ]
-            else:
-                ips = [ip]
-
-            for o in ips:
-                if skip_internal and o in (
-                    '169.254.10.1',
-                    '169.254.10.2',
-                    '169.254.10.20',
-                    '169.254.10.80',
-                ):
-                    continue
-
-                if ipv6 and '%' in o:
-                    o = o.split('%')[0]
-
-                if ipv6:
-                    url = f'http://[{o}]'
-                else:
-                    url = f'http://{o}'
-                if port != '80':
-                    url = f'{url}:{port}'
-                try:
-                    r = requests.head(url, timeout=10)
-                    assert r.status_code in (200, 302, 301)
-                    urls.append(url)
-                    continue
-                except Exception:
-                    pass
-
-                if ipv6:
-                    url = f'https://[{o}]'
-                else:
-                    url = f'https://{o}'
-                if port != '443':
-                    url = f'{url}:{port}'
-                try:
-                    r = requests.head(url, timeout=15, verify=False)
-                    assert r.status_code in (200, 302)
-                    urls.append(url)
-                    continue
-                except Exception:
-                    pass
-        return urls
-
     @private
-    def get_ui_urls(self):
-        addrsv4 = []
-        addrsv6 = []
-        aliases = []
-        for i in self.middleware.call_sync('interface.query'):
-            if not i['state'] or not i['state']['aliases']:
-                continue
-            aliases += list(filter(lambda x: x['type'].startswith('INET'), i['state']['aliases']))
+    async def get_ui_urls(self):
 
-        cp = subprocess.run(
-            'sockstat -46{} tcp |awk \'{{ if ($2 == "nginx" && ${} == "*:*") print ${}","${} }}\' | '
-            'sort | uniq'.format(
-                # Linux sockstat uses -R for protocol selection
-                # FreeBSD uses -P instead.
-                *(('R', '6', '4', '5') if osc.IS_LINUX else ('P', '7', '5', '6'))
-            ),
-            shell=True, capture_output=True, text=True,
-        )
-        for line in cp.stdout.strip('\n').split('\n'):
-            if not line:
-                continue
-            _type, addr = line.split(',', 1)
+        config = await self.middleware.call('system.general.config')
+        kwargs = {'static': True} if (await self.middleware.call('failover.licensed')) else {}
 
-            if _type == 'tcp4':
-                addrsv4.append(addr)
-            else:
-                addrsv6.append(addr)
+        # http is always used
+        http_proto = 'http://'
+        http_port = config['ui_port']
+        http_default_port = config['ui_port'] == 80
+
+        # populate https data if necessary
+        https_proto = https_port = https_default_port = None
+        if config['ui_certificate']:
+            https_proto = 'https://'
+            https_port = config['ui_httpsport']
+            https_default_port = config['ui_httpsport'] == 443
+
+        nginx_ips = {}
+        for i in psutil.net_connections():
+            if i.laddr.port in (http_port, https_port):
+                nginx_ips.update({i.laddr.ip: i.family.name})
+
+        all_ip4 = '0.0.0.0' in nginx_ips
+        all_ip6 = '::' in nginx_ips
 
         urls = []
-        if addrsv4:
-            urls += self.__get_urls(aliases, addrsv4)
-        if addrsv6:
-            urls += self.__get_urls(aliases, addrsv6, ipv6=True)
-        return sorted(urls)
+        if all_ip4 or all_ip6:
+            for i in await self.middleware.call('interface.ip_in_use', kwargs):
+
+                # nginx could be listening to all IPv4 IPs but not all IPv6 IPs
+                # or vice versa
+                if i['type'] == 'INET' and all_ip4:
+                    http_url = f'{http_proto}{i["address"]}'
+                    if not http_default_port:
+                        http_url += f':{http_port}'
+                    urls.append(http_url)
+                    if https_proto is not None:
+                        https_url = f'{https_proto}{i["address"]}'
+                        if not https_default_port:
+                            https_url += f':{https_port}'
+                        urls.append(https_url)
+
+                elif i['type'] == 'INET6' and all_ip6:
+                    http_url = f'{http_proto}[{i["address"]}]'
+                    if not https_default_port:
+                        http_url += f':{https_port}'
+                    urls.append(http_url)
+                    if https_proto is not None:
+                        https_url = f'{https_proto}[{i["address"]}]'
+                        if not https_default_port:
+                            https_url += f':{https_port}'
+                        urls.append(https_url)
+
+        for k, v in nginx_ips.items():
+            # 0.0.0.0 and/or :: is handled above
+            if k not in ('0.0.0.0', '::'):
+                if v == 'AF_INET':
+                    http_url = f'{http_proto}{k}'
+                    if not http_default_port:
+                        http_url += f':{http_port}'
+                    urls.append(http_url)
+                    if https_proto is not None:
+                        https_url = f'{https_proto}{k}'
+                        if not https_default_port:
+                            https_url += f':{https_port}'
+                        urls.append(https_url)
+
+                elif v == 'AF_INET6':
+                    http_url = f'{http_proto}[{k}]'
+                    if not http_default_port:
+                        http_url += f':{http_port}'
+                    urls.append(http_url)
+                    if https_proto is not None:
+                        https_url = f'{https_proto}[{k}]'
+                        if not https_default_port:
+                            https_url += f':{https_port}'
+                        urls.append(https_url)
+
+        return sorted(set(urls))
 
     @private
     def set_language(self):


### PR DESCRIPTION
This fixes a few issues.

- `sockstat` can block on FreeBSD `getpwuid()` calls if joined to a directory service and the connection to said service is not "healthy". I've since patched `sockstat` to actually ignore trying to resolve numeric UIDs to user names here: [freenas/os repo](https://github.com/freenas/os/pull/235/commits/447470473e51597ff6c028d3435ffff34a628be4) which was pushed upstream here: [upstream commit](https://cgit.freebsd.org/src/commit/?id=ccdd2b2b3cc2f86cd08a355be2fb58e435ec8ff8)
- However, I've removed the call to `sockstat` since we can get the same information by running `psutil.net_connections()`
- Furthermore, (based on a previous discussion in this PR) there is absolutely no reason to run `requests.head()` for each IP address that returned from the `psutil.net_connections()` and/or `interface.ip_in_use`. There is only 1 consumer of this method (`netcli`) and all this function does is return a list of formatted URLs to be displayed on the console.
- Running `requests.head()` doesn't scale either since we have customer systems with 50+ IP addresses on their system so this could potentially do a HEAD request for each http IP and https IP with timeouts for each set at 10 and 15 seconds respectively. This is unacceptable. Furthermore, trying to run all these requests in parallel would solve 1 problem but would introduce another one altogether. I.E. what happens if the total time given to run all the HEAD requests expires? Do we take only the completed parallel tasks or do we not include any of them? What if a system has 50+ IPs on their system? Do we increase the total time for all parallel tasks 3*total_ips? Do we have to increase the total timeout if the system has above a certain threshold of IPs? 100? 200? An unnecessary problem to give ourselves when this is simply returning formatted URLs to the console.
- before changes, the method didn't account for HA systems (VIPs are the only functioning IP that can be used when accessing the webUI)

To summarize:
- remove `sockstat` call
- no longer perform any type of HTTP HEAD request on the IPs dramatically speeding up the time it takes for this method to run
- make it work with HA VIPs