### PR TITLE
NAS-108814 / 21.02 / Adjust Samba's lockdir path

### DIFF
--- a/src/middlewared/middlewared/plugins/smb.py
+++ b/src/middlewared/middlewared/plugins/smb.py
@@ -81,7 +81,7 @@ class SMBPath(enum.Enum):
     LEGACYPRIVATE = ('/root/samba/private', '/root/samba/private', 0o700, True)
     MSG_SOCK = ('/var/db/system/samba4/private/msg.sock', '/var/db/system/samba4/private/msg.sock', 0o700, False)
     RUNDIR = ('/var/run/samba4', '/var/run/samba', 0o755, True)
-    LOCKDIR = ('/var/lock', '/var/lock/samba4', 0o755, True)
+    LOCKDIR = ('/var/lock', '/var/run/samba-lock', 0o755, True)
     LOGDIR = ('/var/log/samba4', '/var/log/samba4', 0o755, True)
     IPCSHARE = ('/var/tmp', '/tmp', 0o1777, True)
 


### PR DESCRIPTION
This synchronizes middleware's path for samba's lockdir with the new defaults in the samba package.