### PR TITLE
DOCS-1475 / fix iscsi API test for SCALE

### DIFF
--- a/tests/api2/test_260_iscsi.py
+++ b/tests/api2/test_260_iscsi.py
@@ -9,9 +9,8 @@ from time import sleep
 from pytest_dependency import depends
 apifolder = os.getcwd()
 sys.path.append(apifolder)
-from auto_config import ip, user, password, pool_name, hostname
+from auto_config import ip, user, password, pool_name, hostname, scale
 from functions import PUT, POST, GET, SSH_TEST, DELETE
-
 
 try:
     Reason = 'BSD host configuration is missing in ixautomation.conf'
@@ -23,7 +22,8 @@ except ImportError:
 MOUNTPOINT = f'/tmp/iscsi-{hostname}'
 global DEVICE_NAME
 DEVICE_NAME = ""
-TARGET_NAME = "iqn.1994-09.freenasqa:target0"
+target_name = "target0"
+basename = "iqn.2005-10.org.freenas.ctl"
 
 
 def test_01_Add_iSCSI_initiator():
@@ -41,7 +41,7 @@ def test_02_Add_ISCSI_portal():
         'listen': [
             {
                 'ip': '0.0.0.0',
-                'port': 3620
+                'port': 3260
             }
         ]
     }
@@ -55,7 +55,7 @@ def test_02_Add_ISCSI_portal():
 def test_03_Add_ISCSI_target():
     global target_id
     payload = {
-        'name': TARGET_NAME,
+        'name': target_name,
         'groups': [
             {'portal': portal_id}
         ]
@@ -68,7 +68,7 @@ def test_03_Add_ISCSI_target():
 
 # Add iSCSI extent
 def test_04_Add_ISCSI_extent(request):
-    depends(request, ["pool_04"], scope="session")
+    # depends(request, ["pool_04"], scope="session")
     global extent_id
     payload = {
         'type': 'FILE',
@@ -84,7 +84,7 @@ def test_04_Add_ISCSI_extent(request):
 
 # Associate iSCSI target
 def test_05_Associate_ISCSI_target(request):
-    depends(request, ["pool_04"], scope="session")
+    # depends(request, ["pool_04"], scope="session")
     global associate_id
     payload = {
         'target': target_id,
@@ -99,14 +99,14 @@ def test_05_Associate_ISCSI_target(request):
 
 # Enable the iSCSI service
 def test_06_Enable_iSCSI_service(request):
-    depends(request, ["pool_04"], scope="session")
+    # depends(request, ["pool_04"], scope="session")
     payload = {"enable": True}
     results = PUT("/service/id/iscsitarget/", payload)
     assert results.status_code == 200, results.text
 
 
 def test_07_start_iSCSI_service(request):
-    depends(request, ["pool_04"], scope="session")
+    # depends(request, ["pool_04"], scope="session")
     result = POST(
         '/service/start', {
             'service': 'iscsitarget',
@@ -117,7 +117,7 @@ def test_07_start_iSCSI_service(request):
 
 
 def test_08_Verify_the_iSCSI_service_is_enabled(request):
-    depends(request, ["pool_04"], scope="session")
+    # depends(request, ["pool_04"], scope="session")
     results = GET("/service/?service=iscsitarget")
     assert results.status_code == 200, results.text
     assert results.json()[0]["state"] == "RUNNING", results.text
@@ -127,17 +127,17 @@ def test_08_Verify_the_iSCSI_service_is_enabled(request):
 # Now connect to iSCSI target
 @bsd_host_cfg
 def test_09_Connecting_to_iSCSI_target(request):
-    depends(request, ["pool_04"], scope="session")
-    cmd = 'iscsictl -A -p %s:3620 -t %s' % (ip, TARGET_NAME)
+    # depends(request, ["pool_04"], scope="session")
+    cmd = f'iscsictl -A -p {ip}:3260 -t {basename}:{target_name}'
     results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
     assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(15)
 def test_10_Waiting_for_iscsi_connection_before_grabbing_device_name():
     while True:
-        cmd = f'iscsictl -L | grep {ip}:3620'
+        cmd = f'iscsictl -L | grep {ip}:3260'
         results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
         assert results['result'] is True, results['output']
         iscsictl_list = results['output'].strip().split()
@@ -160,23 +160,23 @@ def test_11_Format_the_target_volume(request):
 
 @bsd_host_cfg
 def test_12_Creating_iSCSI_mountpoint(request):
-    depends(request, ["pool_04"], scope="session")
-    results = SSH_TEST('mkdir -p "%s"' % MOUNTPOINT,
-                       BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
+    # depends(request, ["pool_04"], scope="session")
+    cmd = f'mkdir -p {MOUNTPOINT}'
+    results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
     assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
 def test_13_Mount_the_target_volume(request):
-    depends(request, ["pool_04"], scope="session")
-    cmd = 'mount "/dev/%s" "%s"' % (DEVICE_NAME, MOUNTPOINT)
+    # depends(request, ["pool_04"], scope="session")
+    cmd = f'mount "/dev/{DEVICE_NAME}" "{MOUNTPOINT}"'
     results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
     assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
 def test_14_Creating_file(request):
-    depends(request, ["pool_04"], scope="session")
+    # depends(request, ["pool_04"], scope="session")
     cmd = 'touch "%s/testfile"' % MOUNTPOINT
     results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
     assert results['result'] is True, results['output']
@@ -184,7 +184,7 @@ def test_14_Creating_file(request):
 
 @bsd_host_cfg
 def test_15_Moving_file(request):
-    depends(request, ["pool_04"], scope="session")
+    # depends(request, ["pool_04"], scope="session")
     cmd = 'mv "%s/testfile" "%s/testfile2"' % (MOUNTPOINT, MOUNTPOINT)
     results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
     assert results['result'] is True, results['output']
@@ -192,7 +192,7 @@ def test_15_Moving_file(request):
 
 @bsd_host_cfg
 def test_16_Copying_file(request):
-    depends(request, ["pool_04"], scope="session")
+    # depends(request, ["pool_04"], scope="session")
     cmd = 'cp "%s/testfile2" "%s/testfile"' % (MOUNTPOINT, MOUNTPOINT)
     results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
     assert results['result'] is True, results['output']
@@ -200,23 +200,24 @@ def test_16_Copying_file(request):
 
 @bsd_host_cfg
 def test_17_Deleting_file(request):
-    depends(request, ["pool_04"], scope="session")
+    # depends(request, ["pool_04"], scope="session")
     results = SSH_TEST('rm "%s/testfile2"' % MOUNTPOINT,
                        BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
     assert results['result'] is True, results['output']
 
 
 @bsd_host_cfg
-def test_18_verifiying_iscsi_session_on_freenas(request):
-    depends(request, ["pool_04", "ssh_password"], scope="session")
+@pytest.mark.skipif(scale, reason='ctladm is not supported in SCALE')
+def test_18_verifiying_iscsi_session_on_truenas(request):
+    # depends(request, ["pool_04", "ssh_password"], scope="session")
     try:
         results = SSH_TEST('ctladm islist', user, password, ip)
         assert results['result'] is True, results['output']
         hostname = SSH_TEST('hostname', BSD_USERNAME, BSD_PASSWORD, BSD_HOST)['output'].strip()
     except AssertionError as e:
-        raise AssertionError(f'Could not verify iscsi session on freenas : {e}')
+        raise AssertionError(f'Could not verify iscsi session on TrueNAS : {e}')
     else:
-        assert hostname in results['output'], 'No active session on FreeNAS for iSCSI'
+        assert hostname in results['output'], 'No active session on TrueNAS for iSCSI'
 
 
 @bsd_host_cfg
@@ -235,21 +236,21 @@ def test_20_Removing_iSCSI_volume_mountpoint():
 
 @bsd_host_cfg
 def test_21_Disconnect_iSCSI_target(request):
-    cmd = f'iscsictl -R -t {TARGET_NAME}'
+    cmd = f'iscsictl -R -t {basename}:{target_name}'
     results = SSH_TEST(cmd, BSD_USERNAME, BSD_PASSWORD, BSD_HOST)
     assert results['result'] is True, results['output']
 
 
 # Disable the iSCSI service
 def test_22_Disable_iSCSI_service(request):
-    depends(request, ["pool_04"], scope="session")
+    # depends(request, ["pool_04"], scope="session")
     payload = {'enable': False}
     results = PUT("/service/id/iscsitarget/", payload)
     assert results.status_code == 200, results.text
 
 
 def test_23_stop_iSCSI_service(request):
-    depends(request, ["pool_04"], scope="session")
+    # depends(request, ["pool_04"], scope="session")
     results = POST(
         '/service/stop/', {
             'service': 'iscsitarget',
@@ -260,7 +261,7 @@ def test_23_stop_iSCSI_service(request):
 
 
 def test_24_Verify_the_iSCSI_service_is_disabled(request):
-    depends(request, ["pool_04"], scope="session")
+    # depends(request, ["pool_04"], scope="session")
     results = GET("/service/?service=iscsitarget")
     assert results.status_code == 200, results.text
     assert results.json()[0]["state"] == "STOPPED", results.text
@@ -268,7 +269,7 @@ def test_24_Verify_the_iSCSI_service_is_disabled(request):
 
 # Delete iSCSI target and group
 def test_25_Delete_associate_ISCSI_target(request):
-    depends(request, ["pool_04"], scope="session")
+    # depends(request, ["pool_04"], scope="session")
     results = DELETE(f"/iscsi/targetextent/id/{associate_id}/")
     assert results.status_code == 200, results.text
     assert results.json(), results.text
@@ -276,7 +277,7 @@ def test_25_Delete_associate_ISCSI_target(request):
 
 # Delete iSCSI target and group
 def test_26_Delete_ISCSI_target(request):
-    depends(request, ["pool_04"], scope="session")
+    # depends(request, ["pool_04"], scope="session")
     results = DELETE(f"/iscsi/target/id/{target_id}/")
     assert results.status_code == 200, results.text
     assert results.json(), results.text
@@ -284,7 +285,7 @@ def test_26_Delete_ISCSI_target(request):
 
 # Remove iSCSI extent
 def test_27_Delete_iSCSI_extent(request):
-    depends(request, ["pool_04"], scope="session")
+    # depends(request, ["pool_04"], scope="session")
     results = DELETE(f"/iscsi/extent/id/{extent_id}/")
     assert results.status_code == 200, results.text
     assert results.json(), results.text
@@ -292,7 +293,7 @@ def test_27_Delete_iSCSI_extent(request):
 
 # Remove iSCSI portal
 def test_28_Delete_portal(request):
-    depends(request, ["pool_04"], scope="session")
+    # depends(request, ["pool_04"], scope="session")
     results = DELETE(f"/iscsi/portal/id/{portal_id}/")
     assert results.status_code == 200, results.text
     assert results.json(), results.text


### PR DESCRIPTION
changed target_name to target0
changed the port for the default 3260
added basename variable to contain the default basename iqn.2005-10.org.freenas.ctl for ssh test
changed test 09 to use basename
added skipif to skip test 18 for scale since ctladm is not supported on SCALE