### PR TITLE
NAS-108666 / 12.0 / prevent netcli from hanging on sockstat calls by redoing get_ui_urls (by yocalebo)

### DIFF
--- a/src/freenas/etc/netcli
+++ b/src/freenas/etc/netcli
@@ -1467,8 +1467,7 @@ def show_ip():
         print()
         print(_("The web user interface is at:"))
         print()
-
-        for url in sorted(urls):
+        for url in urls:
             print(url)
     else:
         print()


### PR DESCRIPTION
This fixes a few issues.

- `sockstat` can block on FreeBSD `getpwuid()` calls if joined to a directory service and the connection to said service is not "healthy". I've since patched `sockstat` to actually ignore trying to resolve numeric UIDs to user names here: [freenas/os repo](https://github.com/freenas/os/pull/235/commits/447470473e51597ff6c028d3435ffff34a628be4) which was pushed upstream here: [upstream commit](https://cgit.freebsd.org/src/commit/?id=ccdd2b2b3cc2f86cd08a355be2fb58e435ec8ff8)
- However, I've removed the call to `sockstat` since we can get the same information by running `psutil.net_connections()`
- Furthermore, (based on a previous discussion in this PR) there is absolutely no reason to run `requests.head()` for each IP address that returned from the `psutil.net_connections()` and/or `interface.ip_in_use`. There is only 1 consumer of this method (`netcli`) and all this function does is return a list of formatted URLs to be displayed on the console.
- Running `requests.head()` doesn't scale either since we have customer systems with 50+ IP addresses on their system so this could potentially do a HEAD request for each http IP and https IP with timeouts for each set at 10 and 15 seconds respectively. This is unacceptable. Furthermore, trying to run all these requests in parallel would solve 1 problem but would introduce another one altogether. I.E. what happens if the total time given to run all the HEAD requests expires? Do we take only the completed parallel tasks or do we not include any of them? What if a system has 50+ IPs on their system? Do we increase the total time for all parallel tasks 3*total_ips? Do we have to increase the total timeout if the system has above a certain threshold of IPs? 100? 200? An unnecessary problem to give ourselves when this is simply returning formatted URLs to the console.
- before changes, the method didn't account for HA systems (VIPs are the only functioning IP that can be used when accessing the webUI)

To summarize:
- remove `sockstat` call
- no longer perform any type of HTTP HEAD request on the IPs dramatically speeding up the time it takes for this method to run
- make it work with HA VIPs

Original PR: https://github.com/freenas/freenas/pull/6209