### PR TITLE
NAS-108895 / 21.02 / Bug fix for generating debug

### DIFF
--- a/src/freenas/usr/local/bin/ixdiagnose
+++ b/src/freenas/usr/local/bin/ixdiagnose
@@ -147,7 +147,7 @@ fi
 if [ -d "/tmp/middlewared/jobs" ]; then
 	tar -chf - -C /tmp/middlewared jobs | tar -C $dir -xf -
 fi
-tar -chf - -C /var log --exclude=log/journal --exclude=log/faillog --exclude=log/lastlog --exclude=log/sysstat | tar -C $dir -xf -
+tar -chf - -C /var --exclude=log/journal --exclude=log/faillog --exclude=log/lastlog --exclude=log/sysstat log | tar -C $dir -xf -
 tar -chf - -C /var/tmp fndebug | tar -C $dir -xf -
 if [ "${limit}" != "-1" ] ; then
 	truncate_files "${limit}"


### PR DESCRIPTION
Right now generating debug leads to the following error
```
+--------------------------------------------------------------------------------+
debug finished in 0 seconds for kstat
tar: The following options were used after any non-optional arguments in archive create or update mode.  These options are positional and affect only arguments that follow them.  Please, rearrange them properly.
tar: --exclude 'log/journal' has no effect
tar: --exclude 'log/faillog' has no effect
tar: --exclude 'log/lastlog' has no effect
tar: --exclude 'log/sysstat' has no effect
tar: Exiting with failure status due to previous errors
```

This PR fixes the above issue.