### PR TITLE
NAS-108834 / 21.02 / Fix race condition for shell acess

### DIFF
--- a/src/middlewared/middlewared/main.py
+++ b/src/middlewared/middlewared/main.py
@@ -729,10 +729,6 @@ class ShellApplication(object):
                     continue
 
                 authenticated = True
-                await ws.send_json({
-                    'msg': 'connected',
-                    'id': conndata.id,
-                })
 
                 options = data.get('options', {})
                 options['jail'] = data.get('jail') or options.get('jail')
@@ -752,6 +748,11 @@ class ShellApplication(object):
                 conndata.t_worker.start()
 
                 self.shells[conndata.id] = conndata.t_worker
+
+                await ws.send_json({
+                    'msg': 'connected',
+                    'id': conndata.id,
+                })
 
         # If connection was not authenticated, return earlier
         if not authenticated:


### PR DESCRIPTION
This commit fixes an issue where we return shell id back and a subsequent call to resize shell can fail as middleware has not yet stored / initialized the shell thread.