### PR TITLE
NAS-108913 / 21.02 / fix gluster volume create deadlock and refactor code

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/utils.py
@@ -2,15 +2,18 @@ import os
 import enum
 
 
-JOB_LOCK = 'ctdb_lock'
-CRE_OR_DEL_LOCK = 'ctdb_create_or_delete_lock'
-
-
 class CTDBConfig(enum.Enum):
 
     """
     Various configuration settings used to configure ctdb.
     """
+
+    # create/delete or mount/umount requests can
+    # take awhile and obviously don't need to be
+    # run at the same time
+    BASE_LOCK = 'ctdb_'
+    MOUNT_UMOUNT_LOCK = BASE_LOCK + 'mount_or_umount_lock'
+    CRE_OR_DEL_LOCK = BASE_LOCK + 'ctdb_create_or_delete_lock'
 
     # ctdb smb related config
     VOL_DB_DIR = '/var/run/ctdb/volatile'

--- a/src/middlewared/middlewared/plugins/gluster_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/utils.py
@@ -1,6 +1,9 @@
 import enum
 import os
 
+from middlewared.service import CallError
+from glustercli.cli.utils import GlusterCmdException
+
 
 class GlusterConfig(enum.Enum):
 
@@ -31,3 +34,26 @@ class GlusterConfig(enum.Enum):
     # they automatically get written to a json formatted
     # file here
     WEBHOOKS_FILE = os.path.join(WORKDIR, 'events/webhooks.json')
+
+
+def run_method(func, *args, **kwargs):
+
+    result = b''
+
+    try:
+        result = func(*args, **kwargs)
+    except GlusterCmdException as e:
+        # gluster cli binary will return stderr to stdout
+        # and vice versa depending on the failure.
+        rc, out, err = e.args[0]
+        err = err if err else out
+        if isinstance(err, bytes):
+            err = err.decode()
+        raise CallError(f'{err.strip()}')
+    except Exception:
+        raise
+
+    if isinstance(result, bytes):
+        return result.decode().strip()
+
+    return result


### PR DESCRIPTION
- primarily this changes fixes a deadlock when trying to create a gluster volume
- `gluster.volume` and `gluster.peer` were each using their own "_wrapper" method which is unnecessary
- create global wrapper method `run_method` that is called by any of the `gluster.volume.` `gluser.peer` or `ctdb.shared.volume` API endpoints
- refactor the code to use the new wrapper method
- remove `@job` decorator from all methods except `create`, `delete`, `mount`, `umount` endpoints