### PR TITLE
NAS-108689 / 21.02 / Add events to accommodate changes in chart release status

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -353,6 +353,7 @@ class ChartReleaseService(CRUDService):
 
             raise
         else:
+            await self.middleware.call('chart.release.refresh_events_state', data['release_name'])
             job.set_progress(100, 'Chart release created')
             return await self.get_instance(data['release_name'])
 
@@ -430,6 +431,8 @@ class ChartReleaseService(CRUDService):
         await self.middleware.call('chart.release.wait_for_pods_to_terminate', get_namespace(release_name))
 
         await self.post_remove_tasks(release_name, job)
+
+        await self.middleware.call('chart.release.remove_chart_release_from_events_state', release_name)
 
         job.set_progress(100, f'{release_name!r} chart release deleted')
         return True

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/events.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/events.py
@@ -54,3 +54,9 @@ async def chart_release_event(middleware, event_type, args):
 
 async def setup(middleware):
     middleware.event_subscribe('kubernetes.events', chart_release_event)
+    if await middleware.call('service.started', 'kubernetes'):
+        try:
+            await middleware.call('chart.release.refresh_events_state')
+        except Exception:
+            # Let's not make this fatal for middleware boot
+            middleware.logger.error('Failed to refresh chart release events state', exc_info=True)

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/events.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/events.py
@@ -1,0 +1,46 @@
+from middlewared.service import private, Service
+
+from .utils import get_chart_release_from_namespace, is_ix_namespace
+
+
+class ChartReleaseService(Service):
+
+    CHART_RELEASES = {}
+
+    class Config:
+        namespace = 'chart.release'
+
+    @private
+    async def refresh_events_state(self):
+        ChartReleaseService.CHART_RELEASES = {
+            app['name']: app for app in await self.middleware.call('chart.release.query')
+        }
+
+    @private
+    async def handle_k8s_event(self, k8s_event):
+        name = get_chart_release_from_namespace(k8s_event['involved_object']['namespace'])
+        chart_release = await self.middleware.call('chart.release.query', [['id', '=', name]])
+        if not chart_release:
+            # It's possible the chart release got deleted
+            return
+        else:
+            chart_release = chart_release[0]
+
+        if chart_release['status'] != self.CHART_RELEASES.get(name, {}).get('status'):
+            # raise event
+            self.middleware.send_event('chart.release.events', 'CHANGED', id=name, fields=chart_release)
+
+        ChartReleaseService.CHART_RELEASES[name] = chart_release
+
+
+async def chart_release_event(middleware, event_type, args):
+    args = args['fields']
+    if args['involved_object']['kind'] != 'Pod' or not is_ix_namespace(args['involved_object']['namespace']):
+        return
+
+    await middleware.call('chart.release.handle_k8s_event', args)
+
+
+async def setup(middleware):
+    middleware.event_subscribe('kubernetes.events', chart_release_event)
+    middleware.event_register('chart.release.events', 'Chart Releases events')

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/utils.py
@@ -27,6 +27,14 @@ def get_namespace(release_name):
     return f'{CHART_NAMESPACE_PREFIX}{release_name}'
 
 
+def get_chart_release_from_namespace(namespace):
+    return namespace.split(CHART_NAMESPACE_PREFIX, 1)[-1]
+
+
+def is_ix_namespace(namespace):
+    return namespace.startswith(CHART_NAMESPACE_PREFIX)
+
+
 async def run(*args, **kwargs):
     kwargs['env'] = dict(os.environ, KUBECONFIG='/etc/rancher/k3s/k3s.yaml')
     return await _run(*args, **kwargs)

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -33,6 +33,7 @@ class KubernetesService(Service):
             raise
         else:
             asyncio.ensure_future(self.middleware.call('k8s.event.setup_k8s_events'))
+            asyncio.ensure_future(self.middleware.call('chart.release.refresh_events_state'))
             await self.middleware.call('alert.oneshot_delete', 'ApplicationsStartFailed', None)
             # We only want to start checking for release updates once we have started k8s
             asyncio.ensure_future(self.middleware.call('chart.release.chart_releases_update_checks_internal'))


### PR DESCRIPTION
When pods in a chart release are started / stopped / removed / added, we do not send events for those changes. This PR adds changes to accommodate this.