### PR TITLE
NAS-108883 / 21.02 / Allow some grace period for docker to properly start

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/docker.py
+++ b/src/middlewared/middlewared/plugins/service_/services/docker.py
@@ -5,3 +5,8 @@ class DockerService(SimpleService):
     name = 'docker'
     etc = ['docker']
     systemd_unit = 'docker'
+
+    async def _start_linux(self):
+        # https://jira.ixsystems.com/browse/NAS-108883 we see that docker did not start right away
+        # and takes 17 seconds to initialize.
+        await self._unit_action('Start', timeout=30)


### PR DESCRIPTION
There has been a report where we see that docker did not start in time and the results in kubernetes bootstrap process to fail. This PR adds changes to allow some grace period for docker to properly initialize