### PR TITLE
NAS-108948 / 21.02 / Do not convert app-readme to html

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -80,7 +80,7 @@ class CatalogService(Service):
         for key, filename, parser in (
             ('values', 'values.yaml', yaml.safe_load),
             ('schema', 'questions.yaml', yaml.safe_load),
-            ('app_readme', 'app-readme.md', markdown.markdown),
+            ('app_readme', 'app-readme.md', str.strip),
             ('detailed_readme', 'README.md', markdown.markdown),
         ):
             with open(os.path.join(version_path, filename), 'r') as f:


### PR DESCRIPTION
For UI, do not convert app-readme to html and have it as plain text so it can be used for catalog item tooltip directly on UI end