### PR TITLE
NAS-108970 / 21.02 / fix 2 issues with ganesha mako template

### DIFF
--- a/src/middlewared/middlewared/etc_files/ganesha/ganesha.conf.mako
+++ b/src/middlewared/middlewared/etc_files/ganesha/ganesha.conf.mako
@@ -15,8 +15,7 @@
     # n times (n being the number of shares in db)
     peers = []
     if middleware.call_sync("service.started", "glusterd"):
-        peer_job = middleware.call_sync("gluster.peer.status")
-        peers = peer_job.wait_sync()
+        peers = middleware.call_sync("gluster.peer.status")
 
     bindip = middleware.call_sync("nfs.bindip", config)
     sec = middleware.call_sync("nfs.sec", config, kerberos_keytabs)

--- a/src/middlewared/middlewared/etc_files/ganesha/ganesha.conf.mako
+++ b/src/middlewared/middlewared/etc_files/ganesha/ganesha.conf.mako
@@ -4,6 +4,8 @@
     config = middleware.call_sync("nfs.config")
 
     shares = middleware.call_sync("sharing.nfs.query", [["enabled", "=", True]])
+    if not shares:
+        raise FileShouldNotExist()
 
     kerberos_keytabs = middleware.call_sync("kerberos.keytab.query")
 
@@ -11,8 +13,10 @@
 
     # call this here so that we don't have to call this
     # n times (n being the number of shares in db)
-    peer_job = middleware.call_sync("gluster.peer.status")
-    peers = peer_job.wait_sync()
+    peers = []
+    if middleware.call_sync("service.started", "glusterd"):
+        peer_job = middleware.call_sync("gluster.peer.status")
+        peers = peer_job.wait_sync()
 
     bindip = middleware.call_sync("nfs.bindip", config)
     sec = middleware.call_sync("nfs.sec", config, kerberos_keytabs)


### PR DESCRIPTION
Fixes 2 issues:

- running `gluster.peer.status` will traceback if glusterd isn't started which is guaranteed to be the case when the system is freshly booting
- if there are no NFS shares that are enabled, then don't continue and bail out early