### PR TITLE
NAS-108979 / 21.02 / Properly setup k3s agent

### DIFF
--- a/src/middlewared/middlewared/etc_files/rancher/node/node_passwd.py
+++ b/src/middlewared/middlewared/etc_files/rancher/node/node_passwd.py
@@ -6,16 +6,6 @@ def render(service, middleware):
     if not k8s_config['dataset']:
         return
 
-    k3s_node_passwd_file = os.path.join('/mnt', k8s_config['dataset'], 'k3s/server/cred/node-passwd')
-    if not os.path.exists(k3s_node_passwd_file):
-        # The only time this will happen is the first time k8s is configured and at that time it's okay
-        # as k3s will populate the correct password under /etc but on subsequent upgrades of the system
-        # that will be lost
-        return
-
-    with open(k3s_node_passwd_file, 'r') as f:
-        passwd = f.read().strip().split(',')[0].strip()
-
     os.makedirs('/etc/rancher/node', exist_ok=True)
     with open('/etc/rancher/node/password', 'w') as f:
-        f.write(passwd)
+        f.write(middleware.call_sync('k8s.node.worker_node_password'))

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -133,7 +133,7 @@ class KubernetesService(Service):
         await self.validate_k8s_fs_setup()
         await self.middleware.call('service.start', 'docker')
         await self.middleware.call('container.image.load_default_images')
-        asyncio.ensure_future(self.middleware.call('service.start', 'kubernetes'))
+        await self.middleware.call('service.start', 'kubernetes')
 
     @private
     async def setup_pool(self):

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -9,12 +9,19 @@ from datetime import datetime
 
 from middlewared.service import CallError, private, Service
 
+START_LOCK = asyncio.Lock()
+
 
 class KubernetesService(Service):
 
     @private
     async def post_start(self):
         # TODO: Add support for migrations
+        async with START_LOCK:
+            return await self.post_start_impl()
+
+    @private
+    async def post_start_impl(self):
         try:
             timeout = 60
             while timeout > 0:
@@ -33,11 +40,8 @@ class KubernetesService(Service):
             raise
         else:
             asyncio.ensure_future(self.middleware.call('k8s.event.setup_k8s_events'))
-            asyncio.ensure_future(self.middleware.call('chart.release.refresh_events_state'))
+            await self.middleware.call('chart.release.refresh_events_state')
             await self.middleware.call('alert.oneshot_delete', 'ApplicationsStartFailed', None)
-            # We only want to start checking for release updates once we have started k8s
-            asyncio.ensure_future(self.middleware.call('chart.release.chart_releases_update_checks_internal'))
-            await self.middleware.call('catalog.sync_all')
 
     @private
     async def post_start_internal(self):
@@ -126,6 +130,7 @@ class KubernetesService(Service):
             with open(config_path, 'w') as f:
                 f.write(json.dumps(config))
 
+            self.middleware.call_sync('catalog.sync_all')
             self.middleware.call_sync('alert.oneshot_delete', 'ApplicationsConfigurationFailed', None)
 
     @private
@@ -159,11 +164,24 @@ class KubernetesService(Service):
             os.path.join(k8s_ds, d) for d in ('docker', 'k3s', 'releases', 'default_volumes', 'catalogs')
         ]
 
+    @private
+    async def start_kubernetes(self):
+        # TODO: Remove this wrapper after 21.02 where we will moving on assume that all agent nodes are now using
+        #  our constant worker node password
+        if not (await self.middleware.call('kubernetes.config'))['pool']:
+            return
+
+        await self.middleware.call('service.start', 'kubernetes')
+        async with START_LOCK:
+            await self.middleware.call('k8s.node.delete_node')
+            await self.middleware.call('service.restart', 'kubernetes')
+            await self.middleware.call('catalog.sync_all')
+
 
 async def _event_system(middleware, event_type, args):
 
-    if args['id'] == 'ready' and (await middleware.call('kubernetes.config'))['pool']:
-        asyncio.ensure_future(middleware.call('service.start', 'kubernetes'))
+    if args['id'] == 'ready':
+        asyncio.ensure_future(middleware.call('kubernetes.start_kubernetes'))
     elif args['id'] == 'shutdown' and await middleware.call('service.started', 'kubernetes'):
         asyncio.ensure_future(middleware.call('service.stop', 'kubernetes'))
 

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/nodes.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/nodes.py
@@ -48,3 +48,8 @@ class KubernetesNodeService(ConfigService):
         async with api_client({'node': True}) as (api, context):
             for taint_key in taint_keys:
                 await nodes.remove_taint(context['core_api'], taint_key, context['node'])
+
+    @accepts()
+    async def delete_node(self):
+        async with api_client({'node': True}) as (api, context):
+            await context['core_api'].delete_node(NODE_NAME)

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/nodes.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/nodes.py
@@ -2,7 +2,7 @@ from middlewared.schema import Dict, List, Str
 from middlewared.service import accepts, ConfigService
 
 from .k8s import api_client, nodes
-from .utils import NODE_NAME
+from .utils import NODE_NAME, KUBERNETES_WORKER_NODE_PASSWORD
 
 
 class KubernetesNodeService(ConfigService):
@@ -53,3 +53,7 @@ class KubernetesNodeService(ConfigService):
     async def delete_node(self):
         async with api_client({'node': True}) as (api, context):
             await context['core_api'].delete_node(NODE_NAME)
+
+    @accepts()
+    async def worker_node_password(self):
+        return KUBERNETES_WORKER_NODE_PASSWORD

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/utils.py
@@ -1,4 +1,5 @@
 BACKUP_NAME_PREFIX = 'ix-applications-backup-'
 KUBECONFIG_FILE = '/etc/rancher/k3s/k3s.yaml'
+KUBERNETES_WORKER_NODE_PASSWORD = 'e3d26cefbdf2f81eff5181e68a02372f'
 NODE_NAME = 'ix-truenas'
 UPDATE_BACKUP_PREFIX = 'system-update-'


### PR DESCRIPTION
This PR adds changes accounting for upstream k3s changes where registered worker nodes passwords are not available in a file anymore and they are only available now on worker node's `/etc/rancher/node/password` path. However this is lost on system upgrades, so in order to have it persist, we use a static constant value for the node worker password. ( https://github.com/k3s-io/k3s/issues/2813 )

For existing users already using k8s, we delete the worker node which forces k3s to re-register the node and that works nicely without us losing data.