### PR TITLE
NAS-108999 / 21.02 / Use cgroups v1 for k8s

### DIFF
--- a/src/freenas/usr/local/bin/truenas-grub.py
+++ b/src/freenas/usr/local/bin/truenas-grub.py
@@ -22,9 +22,10 @@ if __name__ == "__main__":
     advanced = {k.replace("adv_", ""): v for k, v in c.fetchone().items()}
 
     # We need to allow tpm in grub as sedutil-cli requires it
+    # TODO: Please remove kernel flag to use cgroups v1 when upstream k3s has support for cgroups v2
     config = [
         'GRUB_DISTRIBUTOR="TrueNAS Scale"',
-        'GRUB_CMDLINE_LINUX_DEFAULT="libata.allow_tpm=1"',
+        'GRUB_CMDLINE_LINUX_DEFAULT="libata.allow_tpm=1 systemd.unified_cgroup_hierarchy=0"',
     ]
 
     terminal = ["console"]


### PR DESCRIPTION
With newer kernel, we are getting cgroups v2 by default which does not work well with k8s/k3s resulting in k3s not working at all. This PR specifies a kernel flag to switch to cgroups v1 until upstream has added support for cgroups v2 which should be soon.