### PR TITLE
NAS-108806 / 21.02 / Explicitly disallow password authentication for SSH

### DIFF
--- a/src/middlewared/middlewared/etc_files/local/ssh/sshd_config.mako
+++ b/src/middlewared/middlewared/etc_files/local/ssh/sshd_config.mako
@@ -73,9 +73,7 @@ Compression delayed
 % else:
 Compression no
 % endif
-% if ssh_config['passwordauth']:
-PasswordAuthentication yes
-% endif
+PasswordAuthentication ${"yes" if ssh_config['passwordauth'] else "no"}
 % if ssh_config['kerberosauth']:
 GSSAPIAuthentication yes
 % endif


### PR DESCRIPTION
If password authentication is not desired, we don't explicitly disable it which results it in ssh using a default for it which is true.