### PR TITLE
NAS-109081 / 21.02 / Make retrieving single chart release faster

### DIFF
--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -507,7 +507,7 @@ class CRUDService(ServiceChangeMixin, Service):
         """
         Helper method to get an instance from a collection given the `id`.
         """
-        instance = await self.middleware.call(f'{self._config.namespace}.query', [('id', '=', id)])
+        instance = await self.middleware.call(f'{self._config.namespace}.query', [['id', '=', id]])
         if not instance:
             raise ValidationError(None, f'{self._config.verbose_name} {id} does not exist', errno.ENOENT)
         return instance[0]


### PR DESCRIPTION
This commit introduces changes to make retrieving single chart release considerably faster. With these changes we get chart release details in about 0.7 seconds and without this we get it in around 2 seconds for about 25 chart releases. And when chart release chart schema is required, it is 0.85 secs and the latter around 4.8 seconds.