### PR TITLE
NAS-109088 / 21.02 / Make GPU label more descriptive

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -126,7 +126,8 @@ class CatalogService(Service):
                 for gpu, quantity in self.middleware.call_sync('k8s.gpu.available_gpus').items():
                     data['attrs'].append({
                         'variable': gpu,
-                        'label': 'GPU Resource',
+                        'label': f'GPU Resource ({gpu})',
+                        'description': 'Please specify number of GPU\'s to allocate',
                         'schema': {
                             'type': 'int',
                             'max': int(quantity),

--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -127,7 +127,7 @@ class CatalogService(Service):
                     data['attrs'].append({
                         'variable': gpu,
                         'label': f'GPU Resource ({gpu})',
-                        'description': 'Please specify number of GPU\'s to allocate',
+                        'description': 'Please enter the number of GPUs to allocate',
                         'schema': {
                             'type': 'int',
                             'max': int(quantity),


### PR DESCRIPTION
This commit adds changes to make GPU label more descriptive showing which type of GPU in question is being added and also adds a description.

![Screenshot 2021-01-22 at 6 31 50 PM](https://user-images.githubusercontent.com/17968138/105497053-277f0e80-5ce0-11eb-8a74-341e276e9bdb.png)
