### PR TITLE
fix traceback when rotation rate fails inside qemu/kvm vms

### DIFF
--- a/src/middlewared/middlewared/plugins/device_/device_info_linux.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info_linux.py
@@ -125,6 +125,10 @@ class DeviceService(Service, DeviceInfoBase):
         try:
             disk = libsgio.SCSIDevice(device_path)
             rotation_rate = disk.rotation_rate()
+        except RuntimeError:
+            # this means the ioctl failed which is
+            # expected on qemu/kvm guests
+            return
         except Exception as e:
             self.logger.error(
                 'Failed to retrieve rotational rate '


### PR DESCRIPTION
https://github.com/truenas/py-sgio/pull/6 was merged which properly raises a `RuntimeError` when the `ioctl()` fails. This is expected behavior in qemu/kvm guest vms.

When I changed this code to use `libsgio`, I forgot to account for this fact when the previous code did.