### PR TITLE
NAS-109136 / 21.02 / Isolate kubernetes cluster

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/kubernetes.py
+++ b/src/middlewared/middlewared/plugins/service_/services/kubernetes.py
@@ -39,3 +39,4 @@ class KubernetesService(SimpleService):
         # This is necessary to ensure that docker umounts datasets and shuts down cleanly
         await asyncio.sleep(5)
         await self.middleware.call('k8s.cni.cleanup_cni')
+        await self.middleware.call('kubernetes.remove_iptables_rules')


### PR DESCRIPTION
This PR adds changes to isolate kubernetes cluster so that new nodes cannot be joined. This prevents anyone accessing kubernetes api from outside the TN host.