### PR TITLE
NAS-109138 / 21.02 / fix up gluster.volume/peer and ctdb.shared.volume plugins

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_shared_volume.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_shared_volume.py
@@ -1,11 +1,10 @@
-from middlewared.service import Service, CallError, accepts, private, job
-from middlewared.plugins.cluster_linux.utils import CTDBConfig
-from middlewared.plugins.gluster_linux.utils import run_method
-from glustercli.cli import volume
-
 import os
 import pathlib
-import subprocess
+from glustercli.cli import volume
+
+from middlewared.utils import run
+from middlewared.service import Service, CallError, job
+from middlewared.plugins.cluster_linux.utils import CTDBConfig
 
 
 MOUNT_UMOUNT_LOCK = CTDBConfig.MOUNT_UMOUNT_LOCK.value
@@ -18,37 +17,14 @@ class CtdbSharedVolumeService(Service):
 
     class Config:
         namespace = 'ctdb.shared.volume'
+        private = True
 
-    @private
-    def construct_gluster_volume_create_data(self, peers):
-
-        payload = {}
-
-        # get the system dataset location
-        ctdb_sysds_path = self.middleware.call_sync('systemdataset.config')['path']
-        ctdb_sysds_path = os.path.join(ctdb_sysds_path, CTDB_VOL_NAME)
-
-        bricks = []
-        for i in peers:
-            peer = i
-            path = ctdb_sysds_path
-            brick = peer + ':' + path
-            bricks.append(brick)
-
-        payload = {
-            'bricks': bricks,
-            'replica': len(peers),
-            'force': True,
-        }
-
-        return payload
-
-    @private
-    def shared_volume_exists_and_started(self):
+    async def exists_and_started(self):
 
         exists = started = False
 
-        vol = run_method(volume.status_detail, volname=CTDB_VOL_NAME)
+        filters = [('id', '=', CTDB_VOL_NAME)]
+        vol = await self.middleware.call('gluster.volume.query', filters)
         if vol:
             if vol[0]['type'] != 'REPLICATE':
                 raise CallError(
@@ -64,27 +40,24 @@ class CtdbSharedVolumeService(Service):
                 )
             elif vol[0]['status'] != 'Started':
                 exists = True
-                run_method(volume.start, CTDB_VOL_NAME)
-                started = True
             else:
                 exists = started = True
 
         return exists, started
 
-    @accepts()
     @job(lock=CRE_OR_DEL_LOCK)
-    def create(self, job):
+    async def create(self, job):
         """
         Create and mount the shared volume to be used
         by ctdb daemon.
         """
 
         # check if ctdb shared volume already exists and started
-        exists, started = self.shared_volume_exists_and_started()
+        exists, started = await self.middleware.call('ctdb.shared.volume.exists_and_started')
 
         if not exists:
             # get the peers in the TSP
-            peers = self.middleware.call_sync('gluster.peer.pool')
+            peers = await self.middleware.call('gluster.peer.query')
             if not peers:
                 raise CallError('No peers detected')
 
@@ -97,51 +70,56 @@ class CtdbSharedVolumeService(Service):
                     'shared volume can be created.'
                 )
 
-            # create the ctdb shared volume
-            req = self.construct_gluster_volume_create_data(con_peers)
-            run_method(volume.create, CTDB_VOL_NAME, req.pop('bricks'), **req)
+            # get the system dataset location
+            ctdb_sysds_path = (await self.middleware.call('systemdataset.config'))['path']
+            ctdb_sysds_path = os.path.join(ctdb_sysds_path, CTDB_VOL_NAME)
+
+            bricks = []
+            for i in con_peers:
+                bricks.append(i + ':' + ctdb_sysds_path)
+
+            options = {'args': (CTDB_VOL_NAME, bricks,)}
+            options['kwargs'] = {'replica': len(con_peers), 'force': True}
+            await self.middleware.call('gluster.method.run', volume.create, options)
 
         if not started:
             # start it if we get here
-            run_method(volume.start, CTDB_VOL_NAME)
+            options = {'args': (CTDB_VOL_NAME,)}
+            await self.middleware.call('gluster.method.run', volume.start, options)
 
         # try to mount it locally
-        mount_job = self.middleware.call_sync('ctdb.shared.volume.mount')
-        mount_job.wait_sync(raise_error=True)
+        mount_job = await self.middleware.call('ctdb.shared.volume.mount')
+        await mount_job.wait(raise_error=True)
 
-        return 'SUCCESS'
+        return await self.middleware.call('gluster.volume.query', [('id', '=', CTDB_VOL_NAME)])
 
-    @accepts()
     @job(lock=CRE_OR_DEL_LOCK)
-    def delete(self, job):
+    async def delete(self, job):
         """
         Delete and unmount the shared volume used by ctdb daemon.
         """
 
         # nothing to delete if it doesn't exist
-        exists, started = self.shared_volume_exists_and_started()
+        exists, started = await self.middleware.call('ctdb.shared.volume.exists_and_started')
         if not exists:
             return
 
         # umount it first
-        umount_job = self.middleware.call_sync('ctdb.shared.volume.umount')
-        umount_job.wait_sync(raise_error=True)
+        umount_job = await self.middleware.call('ctdb.shared.volume.umount')
+        await umount_job.wait(raise_error=True)
 
         if started:
             # stop the volume
-            force = {'force': True}
-            run_method(volume.stop, CTDB_VOL_NAME, **force)
+            options = {'args': (CTDB_VOL_NAME,), 'kwargs': {'force': True}}
+            await self.middleware.call('gluster.method.run', volume.stop, options)
 
         # now delete it
-        run_method(volume.delete, CTDB_VOL_NAME)
+        await self.middleware.call('gluster.method.run', volume.delete, {'args': (CTDB_VOL_NAME,)})
 
-        return 'SUCCESS'
-
-    @accepts()
     @job(lock=MOUNT_UMOUNT_LOCK)
-    def mount(self, job):
+    async def mount(self, job):
         """
-        Mount the ctdb shared volume locally.
+        FUSE mount the ctdb shared volume locally.
         """
 
         mounted = False
@@ -150,11 +128,11 @@ class CtdbSharedVolumeService(Service):
         # the mount utility simply returns a msg to stderr stating
         # "Mounting glusterfs on /cluster/ctdb_shared_vol failed" which is
         # expected since the service isn't running
-        if not self.middleware.call_sync('service.started', 'glusterd'):
+        if not await self.middleware.call('service.started', 'glusterd'):
             self.logger.warning('The "glusterd" service is not running. Not mounting.')
             return mounted
 
-        exists, started = self.shared_volume_exists_and_started()
+        exists, started = await self.middleware.call('ctdb.shared.volume.exists_and_started')
         if not exists or not started:
             return mounted
 
@@ -181,10 +159,10 @@ class CtdbSharedVolumeService(Service):
         # generates another SUBVOL_UP event........This causes a mount/umount loop.
         # So, as an easy work-around we stop the glusterevevntsd service which prevents
         # any more events from being triggered while we mount/umount the volume.
-        self.middleware.call_sync('service.stop', 'glustereventsd')
+        await self.middleware.call('service.stop', 'glustereventsd')
         try:
             cmd = ['mount', '-t', 'glusterfs', 'localhost:/' + CTDB_VOL_NAME, CTDB_LOCAL_MOUNT]
-            cp = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            cp = await run(cmd, check=False)
             if cp.returncode:
                 if b'is already mounted' in cp.stderr:
                     mounted = True
@@ -198,25 +176,24 @@ class CtdbSharedVolumeService(Service):
                 'Unhandled exception when trying to mount ctdb shared volume', exc_info=True
             )
         finally:
-            self.middleware.call_sync('service.start', 'glustereventsd')
+            await self.middleware.call('service.start', 'glustereventsd')
 
         return mounted
 
-    @accepts()
     @job(lock=MOUNT_UMOUNT_LOCK)
-    def umount(self, job):
+    async def umount(self, job):
         """
-        Unmount the locally mounted ctdb shared volume.
+        Unmount the locally FUSE mounted ctdb shared volume.
         """
 
         umounted = False
 
         # read the above comment in the `def mount` method on why we stop and
         # start this service before we umount the volume
-        self.middleware.call_sync('service.stop', 'glustereventsd')
+        await self.middleware.call('service.stop', 'glustereventsd')
         try:
             cmd = ['umount', '-R', CTDB_LOCAL_MOUNT]
-            cp = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            cp = await run(cmd, check=False)
             if cp.returncode:
                 errmsg = cp.stderr.decode().strip()
                 if 'not mounted' in errmsg or 'ctdb_shared_vol: not found' in errmsg:
@@ -230,6 +207,6 @@ class CtdbSharedVolumeService(Service):
                 'Unhandled exception when trying to umount ctdb shared volume', exc_info=True
             )
         finally:
-            self.middleware.call_sync('service.start', 'glustereventsd')
+            await self.middleware.call('service.start', 'glustereventsd')
 
         return umounted

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_shared_volume.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_shared_volume.py
@@ -91,7 +91,7 @@ class CtdbSharedVolumeService(Service):
         mount_job = await self.middleware.call('ctdb.shared.volume.mount')
         await mount_job.wait(raise_error=True)
 
-        return await self.middleware.call('gluster.volume.query', [('id', '=', CTDB_VOL_NAME)])
+        return await self.get_instance(CTDB_VOL_NAME)
 
     @job(lock=CRE_OR_DEL_LOCK)
     async def delete(self, job):

--- a/src/middlewared/middlewared/plugins/gluster_linux/peer.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/peer.py
@@ -1,26 +1,32 @@
-from glustercli.cli import peer
-from middlewared.async_validators import resolve_hostname
-from middlewared.schema import Dict, Str
-from middlewared.service import (accepts, private, job,
-                                 CallError, Service,
-                                 ValidationErrors)
-from .utils import GlusterConfig, run_method
-
-import subprocess
 import xml.etree.ElementTree as ET
+from glustercli.cli import peer
+
+from middlewared.utils import filter_list, run
+from middlewared.schema import Dict, Str, Bool
+from middlewared.service import (accepts, private, job, filterable,
+                                 CallError, CRUDService)
+from .utils import GlusterConfig
 
 
 GLUSTER_JOB_LOCK = GlusterConfig.CLI_LOCK.value
 
 
-class GlusterPeerService(Service):
+class GlusterPeerService(CRUDService):
 
     class Config:
         namespace = 'gluster.peer'
 
-    @private
-    def _parse_peer(self, p):
+    @filterable
+    async def query(self, filters=None, options=None):
+        peers = []
+        if await self.middleware.call('service.started', 'glusterd'):
+            peers = await self.middleware.call('gluster.peer.status')
+            peers = list(map(lambda i: dict(i, id=i['uuid']), peers))
 
+        return filter_list(peers, filters, options)
+
+    @private
+    async def _parse_peer(self, p):
         data = {
             'uuid': p.find('uuid').text,
             'hostname': p.find('hostname').text,
@@ -35,12 +41,11 @@ class GlusterPeerService(Service):
         return data
 
     @private
-    def _parse_peer_status_xml(self, data):
-
+    async def _parse_peer_status_xml(self, data):
         peers = []
         for _ in data.findall('peerStatus/peer'):
             try:
-                peers.append(self._parse_peer(_))
+                peers.append(await self._parse_peer(_))
             except Exception as e:
                 raise CallError(
                     f'Failed parsing peer information with error: {e}'
@@ -48,148 +53,90 @@ class GlusterPeerService(Service):
 
         return peers
 
-    @private
-    async def resolve_host_or_ip(self, hostname, verrors):
-
-        args = (self.middleware, verrors, 'resolve_host_or_ip', hostname)
-        return await resolve_hostname(*args)
-
-    @private
-    def common_validation(self, hostname=None):
-
-        verrors = ValidationErrors()
-
-        if hostname:
-            self.middleware.call_sync(
-                'gluster.peer.resolve_host_or_ip', hostname, verrors)
-
-        verrors.check()
-
-    @accepts(
-        Dict(
-            'probe_peer_create',
-            Str('hostname', required=True, max_length=253)
-        )
-    )
+    @accepts(Dict(
+        'peer_create',
+        Str('hostname', required=True, max_length=253)
+    ))
     @job(lock=GLUSTER_JOB_LOCK)
-    def create(self, job, data):
+    async def do_create(self, job, data):
         """
         Add peer to the Trusted Storage Pool.
 
-        `hostname` can be an IP(v4/v6) address or DNS name.
+        `hostname` String representing an IP(v4/v6) address or DNS name
         """
 
-        hostname = data.get('hostname')
+        await self.middleware.call('gluster.method.run', peer.attach, {'args': (data['hostname'],)})
+        return await self.middleware.call('gluster.peer.query', [('hostname', '=', data['hostname'])])
 
-        self.common_validation(hostname=hostname)
-
-        return run_method(peer.attach, hostname)
-
-    @accepts(
-        Dict(
-            'probe_peer_delete',
-            Str('hostname', required=True, max_length=253)
-        )
-    )
+    @accepts(Str('id'))
     @job(lock=GLUSTER_JOB_LOCK)
-    def delete(self, job, data):
+    async def do_delete(self, job, id):
         """
-        Remove peer of `hostname` from the Trusted Storage Pool.
-        """
+        Remove peer of `id` from the Trusted Storage Pool.
 
-        hostname = data.get('hostname')
-
-        self.common_validation(hostname=hostname)
-
-        return run_method(peer.detach, hostname)
-
-    @accepts()
-    def status(self):
-        """
-        List the status of peers in the Trusted Storage Pool
-        excluding localhost.
+        `id` String representing the uuid of the peer
         """
 
-        return run_method(peer.status)
+        await self.middleware.call(
+            'gluster.method.run', peer.detach, {'args': ((await self.get_instance(id))['hostname'],)})
 
-    @accepts()
-    def pool(self):
+    @accepts(Dict(
+        'peer_status',
+        Bool('localhost', default=True),
+    ))
+    async def status(self, data):
         """
-        List the status of peers in the Trusted Storage Pool
-        including localhost.
+        List the status of peers in the Trusted Storage Pool.
+
+        `localhost` Boolean if True, include localhost else exclude localhost
         """
 
-        final = None
+        peers = await self.middleware.call('gluster.method.run', peer.status)
+        if not data['localhost']:
+            return peers
 
-        # get the local viewpoint of the remote peers in the TSP
-        if local_view := run_method(peer.status):
-            remote_node = None
-            # need to pull out a remote peer (that's connected)
-            for i in local_view:
-                if i['connected'] == 'Connected' and i['hostname'] != 'localhost':
-                    remote_node = i['hostname']
-                    break
+        try:
+            remote_node = next(i['hostname'] for i in peers if i['connected'] == 'Connected')
+        except StopIteration:
+            raise CallError('All remote peers are disconnected.')
 
-            if remote_node is None:
-                raise CallError('All remote peers are disconnected.')
-
-            # now we need to run the same command as `run_method(peer.status)`
-            # but specifying a remote peer to get the "remote_local_view"
-            command = [
-                'gluster',
-                f'--remote-host={remote_node}',
-                'peer', 'status', '--xml'
-            ]
-            cp = subprocess.run(
-                command,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                universal_newlines=True,
+        # this is the same as running `gluster.method.run, peer.status` but
+        # running it on the `remote_node` so that we can get 2 different
+        # "views" of the peers in the TSP.
+        command = ['gluster', f'--remote-host={remote_node}', 'peer', 'status', '--xml']
+        cp = await run(command, check=False)
+        if cp.returncode:
+            # the gluster cli utility will return stderr
+            # to stdout and vice versa on certain failures.
+            # account for this and decode appropriately
+            err = cp.stderr if cp.stderr else cp.stdout
+            if isinstance(err, bytes):
+                err = err.decode()
+            raise CallError(
+                f'Failed running remote peer status with error: {err.strip()}'
             )
-            if cp.returncode:
-                # the gluster cli utility will return stderr
-                # to stdout and vice versa on certain failures.
-                # account for this and decode appropriately
-                err = cp.stderr if cp.stderr else cp.stdout
-                if isinstance(err, bytes):
-                    err = err.decode()
-                raise CallError(
-                    f'Failed running remote peer status with error: {err.strip()}'
-                )
 
-            # build our data structure by parsing the xml
-            remote_local_view = ET.fromstring(cp.stdout)
-            remote_local_view = self._parse_peer_status_xml(remote_local_view)
+        # build our data structure by parsing the xml
+        remote_local_view = ET.fromstring(cp.stdout.decode())
+        remote_local_view = await self._parse_peer_status_xml(remote_local_view)
 
-            # now we compare the 2 "viewpoints" and deduce which IP address
-            # is our own
-            final = local_view.copy()
+        # this should only ever produce 1 entry
+        our_ip = [i for i in remote_local_view if i not in peers]
+        if len(our_ip) != 1:
+            raise CallError(
+                f'Remote peer: {remote_node} sees these peers: {remote_local_view}'
+                f'The local peer sees these peers: {peers}.'
+                'The local and remote peers should be the same quantity.'
+            )
 
-            # this should only ever produce 1 entry
-            our_ip = [i for i in remote_local_view if i not in local_view]
-            if len(our_ip) != 1:
-                raise CallError(
-                    f'Remote peer: {remote_node} sees these peers: '
-                    f'{remote_local_view}'
-                    f'The local peer sees these peers: {local_view}.'
-                    'The local and remote peers should be the same quantity.'
-                )
+        peers.append(our_ip[0])
 
-            final.append(our_ip[0])
-
-        return list(final)
+        return peers
 
     @accepts()
     async def ips_available(self):
         """
-        List of IPv4/v6 addresses available that can be used
-        as the `peer_name` when creating a gluster volume.
-
-        NOTE:
-            This will only return statically assigned IPs.
-            If this is an HA system, this will only return
-            the VIP addresses that have been configured on
-            the system.
+        Return list of VIP(v4/v6) addresses available on the system
         """
 
         return [

--- a/src/middlewared/middlewared/plugins/gluster_linux/run.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/run.py
@@ -29,7 +29,7 @@ class GlusterMethodService(Service):
             err = err if err else out
             if isinstance(err, bytes):
                 err = err.decode()
-            raise CallError(f'{err.strip()}')
+            raise CallError(err.strip())
         except Exception:
             raise
 

--- a/src/middlewared/middlewared/plugins/gluster_linux/run.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/run.py
@@ -1,0 +1,39 @@
+from glustercli.cli.utils import GlusterCmdException
+
+from middlewared.service import CallError, Service
+
+
+class GlusterMethodService(Service):
+
+    class Config:
+        namespace = 'gluster.method'
+        private = True
+
+    def run(self, func, options=None):
+
+        result = b''
+
+        if options is not None:
+            args = options.get('args', ())
+            kwargs = options.get('kwargs', {})
+        else:
+            args = ()
+            kwargs = {}
+
+        try:
+            result = func(*args, **kwargs)
+        except GlusterCmdException as e:
+            # gluster cli binary will return stderr to stdout
+            # and vice versa depending on the failure.
+            rc, out, err = e.args[0]
+            err = err if err else out
+            if isinstance(err, bytes):
+                err = err.decode()
+            raise CallError(f'{err.strip()}')
+        except Exception:
+            raise
+
+        if isinstance(result, bytes):
+            return result.decode().strip()
+
+        return result

--- a/src/middlewared/middlewared/plugins/gluster_linux/utils.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/utils.py
@@ -1,10 +1,6 @@
 import enum
 import os
 
-from middlewared.service import CallError
-from glustercli.cli.utils import GlusterCmdException
-
-
 class GlusterConfig(enum.Enum):
 
     """
@@ -34,26 +30,3 @@ class GlusterConfig(enum.Enum):
     # they automatically get written to a json formatted
     # file here
     WEBHOOKS_FILE = os.path.join(WORKDIR, 'events/webhooks.json')
-
-
-def run_method(func, *args, **kwargs):
-
-    result = b''
-
-    try:
-        result = func(*args, **kwargs)
-    except GlusterCmdException as e:
-        # gluster cli binary will return stderr to stdout
-        # and vice versa depending on the failure.
-        rc, out, err = e.args[0]
-        err = err if err else out
-        if isinstance(err, bytes):
-            err = err.decode()
-        raise CallError(f'{err.strip()}')
-    except Exception:
-        raise
-
-    if isinstance(result, bytes):
-        return result.decode().strip()
-
-    return result

--- a/src/middlewared/middlewared/plugins/gluster_linux/volume.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/volume.py
@@ -1,73 +1,30 @@
 from glustercli.cli import volume, quota
-from middlewared.service import (Service, accepts, job,
-                                 private, item_method)
+
+from middlewared.utils import filter_list
+from middlewared.service import (CRUDService, accepts, job,
+                                 item_method, filterable)
 from middlewared.schema import Dict, Str, Int, Bool, List
-from .utils import GlusterConfig, run_method
+from .utils import GlusterConfig
 
 
 GLUSTER_JOB_LOCK = GlusterConfig.CLI_LOCK.value
 
 
-class GlusterVolumeService(Service):
+class GlusterVolumeService(CRUDService):
 
     class Config:
         namespace = 'gluster.volume'
 
-    @private
-    def removebrick_volume(self, name, data):
+    @filterable
+    async def query(self, filters=None, options=None):
+        vols = []
+        if await self.middleware.call('service.started', 'glusterd'):
+            method = volume.status_detail
+            options = {'kwargs': {'group_subvols': True}}
+            vols = await self.middleware.call('gluster.method.run', method, options['kwargs'])
+            vols = list(map(lambda i: dict(i, id=i['name']), vols))
 
-        temp = data.pop('bricks')
-        op = data.pop('operation')
-
-        bricks = []
-        for i in temp:
-            peer = i['peer_name']
-            path = i['peer_path']
-            brick = peer + ':' + path
-            bricks.append(brick)
-        # TODO
-        # glustercli-python has a bug where if provided the "force"
-        # option, it will concatenate it with the "start" option
-        # This is wrong, you can choose "start" or "force" exclusively
-        # (i.e. gluster volume name remove-brick peer:path start OR force)
-        if op.lower() == 'start':
-            result = run_method(
-                volume.bricks.remove_start, name, bricks, **data)
-
-        if op.lower() == 'stop':
-            result = run_method(
-                volume.bricks.remove_stop, name, bricks, **data)
-
-        if op.lower() == 'commit':
-            result = run_method(
-                volume.bricks.remove_commit, name, bricks, **data)
-
-        if op.lower() == 'status':
-            result = run_method(
-                volume.bricks.remove_status, name, bricks, **data)
-
-        return result
-
-    @private
-    def replacebrick_volume(self, name, data):
-
-        src = data.pop('src_brick')
-        new = data.pop('new_brick')
-
-        src_peer = src['peer_name']
-        src_path = src['peer_path']
-        src_brick = src_peer + ':' + src_path
-
-        new_peer = new['peer_name']
-        new_path = new['peer_path']
-        new_brick = new_peer + ':' + new_path
-
-        return run_method(
-            volume.bricks.replace_commit,
-            name,
-            src_brick,
-            new_brick,
-            **data)
+        return filter_list(vols, filters, options)
 
     @accepts(Dict(
         'glustervolume_create',
@@ -87,331 +44,333 @@ class GlusterVolumeService(Service):
         Bool('force'),
     ))
     @job(lock=GLUSTER_JOB_LOCK)
-    def create(self, job, data):
+    async def do_create(self, job, data):
         """
         Create a gluster volume.
 
-        `name` Name to be given to the gluster volume
-        `bricks` List of brick paths
-            `peer_name` IP or DNS name of the peer.
-            `peer_path` The full path of the brick
+        `name` String representing name to be given to the volume
+        `bricks` List representing the brick paths
+            `peer_name` String representing IP or DNS name of the peer
+            `peer_path` String representing the full path of the brick
 
-        `replica` Number of replica bricks
-        `arbiter` Number of arbiter bricks
-        `disperse` Number of disperse bricks
-        `disperse_data` Number of disperse data bricks
-        `redundancy` Number of redundancy bricks
-        `force` Create volume forcefully, ignoring potential warnings
+        `replica` Integer representing number of replica bricks
+        `arbiter` Integer representing number of arbiter bricks
+        `disperse` Integer representing number of disperse bricks
+        `disperse_data` Integer representing number of disperse data bricks
+        `redundancy` Integer representing number of redundancy bricks
+        `force` Boolean, if True ignore potential warnings
         """
 
         # before we create the gluster volume, we need to ensure
         # the ctdb shared volume is setup
-        ctdb_job = self.middleware.call_sync('ctdb.shared.volume.create')
-        ctdb_job.wait_sync(raise_error=True)
+        ctdb_job = await self.middleware.call('ctdb.shared.volume.create')
+        await ctdb_job.wait(raise_error=True)
 
         name = data.pop('name')
-        temp = data.pop('bricks')
 
         bricks = []
-        for i in temp:
-            peer = i['peer_name']
-            path = i['peer_path']
-            brick = peer + ':' + path
-            bricks.append(brick)
+        for i in data.pop('bricks'):
+            bricks.append(i['peer_name'] + ':' + i['peer_path'])
 
-        return run_method(volume.create, name, bricks, **data)
+        options = {'args': (name, bricks,), 'kwargs': data}
+        await self.middleware.call('gluster.method.run', volume.create, options)
+        await self.middleware.call('gluster.volume.start', {'name': name})
+
+        return await self.middleware.call('gluster.volume.query', [('id', '=', name)])
 
     @item_method
-    @accepts(
+    @accepts(Dict(
+        'volume_start',
         Str('name', required=True),
-        Dict(
-            'data',
-            Bool('force')
-        ),
-    )
-    def start(self, name, data):
+        Bool('force', default=True)
+    ))
+    async def start(self, data):
         """
         Start a gluster volume.
 
-        `name` Name of gluster volume
-        `force` Forcefully start the gluster volume
+        `name` String representing name of gluster volume
+        `force` Boolean, if True forcefully start the gluster volume
         """
 
-        return run_method(volume.start, name, **data)
+        options = {'args': (data.pop('name'),), 'kwargs': data}
+        return await self.middleware.call('gluster.method.run', volume.start, options)
 
     @item_method
-    @accepts(
+    @accepts(Dict(
+        'volume_restart',
         Str('name', required=True),
-        Dict(
-            'data',
-            Bool('force')
-        ),
-    )
-    def restart(self, name, data):
+        Bool('force', default=True)
+    ))
+    async def restart(self, data):
         """
         Restart a gluster volume.
 
-        `name` Name of gluster volume
-        `force` Forcefully restart the gluster volume
+        `name` String representing name of gluster volume
+        `force` Boolean, if True forcefully restart the gluster volume
         """
 
-        return run_method(volume.restart, name, **data)
+        options = {'args': (data.pop('name'),), 'kwargs': data}
+        return await self.middleware.call('gluster.method.run', volume.restart, options)
 
     @item_method
-    @accepts(
+    @accepts(Dict(
+        'volume_stop',
         Str('name', required=True),
-        Dict(
-            'data',
-            Bool('force')
-        ),
-    )
-    def stop(self, name, data):
+        Bool('force', default=False)
+    ))
+    async def stop(self, data):
         """
         Stop a gluster volume.
 
-        `name` Name of gluster volume
-        `force` Forcefully stop the gluster volume
+        `name` String representing name of gluster volume
+        `force` Boolean, if True forcefully stop the gluster volume
         """
 
-        return run_method(volume.stop, name, **data)
+        options = {'args': (data.pop('name'),), 'kwargs': data}
+        return await self.middleware.call('gluster.method.run', volume.stop, options)
 
-    @accepts(Dict(
-        'glustervolume_delete',
-        Str('name', required=True),
-    ))
+    @accepts(Str('id'))
     @job(lock=GLUSTER_JOB_LOCK)
-    def delete(self, job, data):
+    async def do_delete(self, job, id):
         """
         Delete a gluster volume.
 
-        `name` Name of the volume to be deleted
+        `id` String representing name of gluster volume
+                to be deleted
         """
 
-        return run_method(volume.delete, data['name'])
+        await self.middleware.call(
+            'gluster.method.run', volume.delete, {'args': ((await self.get_instance(id))['name'],)})
 
     @item_method
-    @accepts(Str('name'))
-    def info(self, name):
+    @accepts(Dict(
+        'volume_info',
+        Str('name', required=True),
+    ))
+    async def info(self, data):
         """
         Return information about gluster volume(s).
 
-        `name` Name of the gluster volume
+        `name` String representing name of gluster volume
         """
 
-        rv = {}
-        rv['volname'] = name
-
-        return run_method(volume.info, **rv)
+        options = {'kwargs': {'volname': data['name']}}
+        return await self.middleware.call('gluster.method.run', volume.info, options)
 
     @item_method
-    @accepts(
+    @accepts(Dict(
+        'volume_status',
         Str('name', required=True),
-        Dict(
-            'data',
-            Bool('verbose', default=True),
-        )
-    )
-    def status(self, name, data):
+        Bool('verbose', default=True),
+    ))
+    async def status(self, data):
         """
-        Return detailed information about gluster volume(s).
+        Return detailed information about gluster volume.
 
-        `name` Name of the gluster volume
-        `verbose` If False, only return brick information
-            for gluster volume with `name`.
+        `name` String representing name of gluster volume
+        `verbose` Boolean, If False, only return brick information
         """
 
-        rv = {}
-        rv['volname'] = name
-        rv['group_subvols'] = data.pop('verbose')
-
-        return run_method(volume.status_detail, **rv)
+        options = {'kwargs': {'volname': data['name'], 'group_subvols': data['verbose']}}
+        return await self.middleware.call('gluster.method.run', volume.status_detail, options)
 
     @accepts()
-    def list(self):
+    async def list(self):
         """
         Return list of gluster volumes.
         """
 
-        return run_method(volume.vollist)
+        return await self.middleware.call('gluster.method.run', volume.vollist, {})
 
     @item_method
-    @accepts(
+    @accepts(Dict(
+        'volume_optreset',
         Str('name', required=True),
-        Dict(
-            'data',
-            Str('opt'),
-            Bool('force'),
-        )
-    )
-    def optreset(self, name, data):
+        Str('opt'),
+        Bool('force'),
+    ))
+    async def optreset(self, data):
         """
         Reset volumes options.
             If `opt` is not provided, then all options
             will be reset.
 
-        `name` Name of the gluster volume
-        `opt` Name of the option to reset
-        `force` Forcefully reset option(s)
+        `name` String representing name of gluster volume
+        `opt` String representing name of the option to reset
+        `force` Boolean, if True forcefully reset option(s)
         """
 
-        return run_method(volume.optreset, name, **data)
+        options = {'args': (data.pop('name'),), 'kwargs': data}
+        return await self.middleware.call('gluster.method.run', volume.optreset, options)
 
     @item_method
-    @accepts(
+    @accepts(Dict(
+        'volume_optset',
         Str('name', required=True),
         Dict('opts', required=True, additional_attrs=True),
-    )
-    def optset(self, name, data):
+    ))
+    async def optset(self, data):
         """
         Set gluster volume options.
 
-        `name` Name of the gluster volume
+        `name` String representing name of gluster volume
         `opts` Dict where
             --key-- is the name of the option
             --value-- is the value to be given to the option
         """
 
-        data = data.pop("opts")
-
-        return run_method(volume.optset, name, data)
+        options = {'args': (data['name'],), 'kwargs': data['opts']}
+        return await self.middleware.call('gluster.method.run', volume.optset, options)
 
     @item_method
-    @accepts(
+    @accepts(Dict(
+        'volume_addbrick',
         Str('name', required=True),
-        Dict(
-            'data',
-            List('bricks', items=[
-                Dict(
-                    'brick',
-                    Str('peer_name', required=True),
-                    Str('peer_path', required=True),
-                ),
-            ], required=True),
-            Int('replica'),
-            Int('arbiter'),
-            Bool('force'),
-        )
-    )
-    def addbrick(self, name, data):
+        List('bricks', items=[
+            Dict(
+                'brick',
+                Str('peer_name', required=True),
+                Str('peer_path', required=True),
+            ),
+        ], required=True),
+        Int('replica'),
+        Int('arbiter'),
+        Bool('force'),
+    ))
+    async def addbrick(self, data):
         """
         Add bricks to a gluster volume.
 
-        `name` Gluster volume name
-        `bricks` List of brick paths.
-            `peer_name` IP or DNS name of the peer
-            `peer_path` The full path of the brick to be added
-
-        `replica` Replica count
-        `arbiter` Arbiter count
-        `force` Forcefully add brick(s)
+        `name` String representing name of gluster volume
+        `bricks` List representing the brick paths
+            `peer_name` String representing IP or DNS name of the peer
+            `peer_path` String representing the full path of the brick
+        `replica` Integer replicating replica count
+        `arbiter` Integer replicating arbiter count
+        `force` Boolean, if True, forcefully add brick(s)
         """
 
-        temp = data.pop('bricks')
-
         bricks = []
-        for i in temp:
-            peer = i['peer_name']
-            path = i['peer_path']
-            brick = peer + ':' + path
-            bricks.append(brick)
+        for i in data.pop('bricks'):
+            bricks.append(i['peer_name'] + ':' + i['peer_path'])
 
-        return run_method(
-            volume.bricks.add, name, bricks, **data)
+        options = {'args': (data.pop('name'), bricks,), 'kwargs': data}
+        return await self.middleware.call('gluster.method.run', volume.bricks.add, options)
 
     @item_method
-    @accepts(
+    @accepts(Dict(
+        'volume_removebrick',
         Str('name', required=True),
-        Dict(
-            'data',
-            List('bricks', items=[
-                Dict(
-                    'brick',
-                    Str('peer_name', required=True),
-                    Str('peer_path', required=True),
-                ),
-            ], required=True),
-            Str(
-                'operation',
-                enum=['START', 'STOP', 'COMMIT', 'STATUS'],
-                required=True,
+        List('bricks', items=[
+            Dict(
+                'brick',
+                Str('peer_name', required=True),
+                Str('peer_path', required=True),
             ),
-            Int('replica'),
-        )
-    )
-    def removebrick(self, name, data):
+        ], required=True),
+        Str(
+            'operation',
+            enum=['START', 'STOP', 'COMMIT', 'STATUS'],
+            required=True,
+        ),
+        Int('replica'),
+        Bool('force', default=False)
+    ))
+    async def removebrick(self, data):
         """
         Perform a remove operation on the brick(s) in the gluster volume.
 
-        `name` Gluster volume name
-        `bricks` List of brick paths.
-            `peer_name` IP or DNS name of the peer
-            `peer_path` The full path of the brick
-
-        `operation` The operation to be performed
+        `name` String representing name of gluster volume
+        `bricks` List representing the brick paths
+            `peer_name` String representing IP or DNS name of the peer
+            `peer_path` String representing the full path of the brick
+        `operation` String representing the operation to be performed
             `START` Start the removal of the brick(s)
             `STOP` Stop the removal of the brick(s)
             `COMMIT` Commit the removal of the brick(s)
             `STATUS` Display status of the removal of the brick(s)
-
-        `replica` Replica count
-        `force` Forcefully run the removal operation.
+        `replica` Integer representing replica count
+        `force` Boolean, if True, forcefully run the removal operation
         """
 
-        return self.removebrick_volume(name, data)
+        op = data.pop('operation')
+        name = data.pop('name')
+        bricks = []
+        for i in data.pop('bricks'):
+            bricks.append(i['peer_name'] + ':' + i['peer_path'])
+
+        # TODO
+        # glustercli-python has a bug where if provided the "force"
+        # option, it will concatenate it with the "start" option
+        # This is wrong, you can choose "start" or "force" exclusively
+        # (i.e. gluster volume name remove-brick peer:path start OR force)
+        options = {'args': (name, bricks,), 'kwargs': data}
+        if op.lower() == 'start':
+            method = volume.bricks.remove_start
+        elif op.lower() == 'stop':
+            method = volume.bricks.remove_stop
+        elif op.lower() == 'commit':
+            method = volume.bricks.remove_commit
+        elif op.lower() == 'status':
+            method = volume.bricks.remove_status
+
+        return await self.middleware.call('gluster.method.run', method, options)
 
     @item_method
-    @accepts(
+    @accepts(Dict(
+        'volume_replacebrick',
         Str('name', required=True),
         Dict(
-            'data',
-            Dict(
-                'src_brick',
-                Str('peer_name', required=True),
-                Str('peer_path', required=True),
-                required=True,
-            ),
-            Dict(
-                'new_brick',
-                Str('peer_name', required=True),
-                Str('peer_path', required=True),
-                required=True,
-            ),
-            Bool('force'),
-        )
-    )
-    def replacebrick(self, name, data):
+            'src_brick',
+            Str('peer_name', required=True),
+            Str('peer_path', required=True),
+            required=True,
+        ),
+        Dict(
+            'new_brick',
+            Str('peer_name', required=True),
+            Str('peer_path', required=True),
+            required=True,
+        ),
+        Bool('force', default=False),
+    ))
+    async def replacebrick(self, data):
         """
         Commit the replacement of a brick.
 
-        `name` Gluster volume name
-        `src_brick` Brick to be replaced
-            `peer_name` IP or DNS name of the peer
-            `peer_path` The full path of the brick
-
-        `new_brick` New replacement brick
-            `peer_name` IP or DNS name of the peer
-            `peer_path` The full path of the brick
-
-        `force` Forcefully replace bricks
+        `name` String representing name of gluster volume
+        `src_brick` Dict where
+            `peer_name` key is a string representing IP or DNS name of the peer
+            `peer_path` key is a string representing the full path of the brick
+        `new_brick` Dict where
+            `peer_name` key is a string representing IP or DNS name of the peer
+            `peer_path` key is a string representing the full path of the brick
+        `force` Boolean, if True, forcefully replace bricks
         """
 
-        return self.replacebrick_volume(name, data)
+        src = data.pop('src_brick')
+        new = data.pop('new_brick')
+        src_brick = src['peer_name'] + ':' + src['peer_path']
+        new_brick = new['peer_name'] + ':' + new['peer_path']
+
+        method = volume.bricks.replace_commit
+        options = {'args': (data.pop('name'), src_brick, new_brick), 'kwargs': data}
+        return await self.middleware.call('gluster.method.run', method, options)
 
     @item_method
-    @accepts(
+    @accepts(Dict(
+        'volume_quota',
         Str('name', required=True),
-        Dict(
-            'data',
-            Bool('enable', required=True),
-        )
-    )
-    def quota(self, name, data):
+        Bool('enable', required=True),
+    ))
+    async def quota(self, data):
         """
         Enable/Disable the quota for a given gluster volume.
 
-        `name` Gluster volume name
-        `enable` enable quota (True) or disable it (False)
+        `name` String representing name of gluster volume
+        `enable` Boolean, if True enable quota else disable it
         """
 
-        return run_method(
-            quota.enable if data['enable'] else quota.disable, name)
+        method = quota.enable if data['enable'] else quota.disable
+        options = {'args': (data['name'],)}
+        return await self.middleware.call('gluster.method.run', method, options)

--- a/src/middlewared/middlewared/plugins/gluster_linux/volume.py
+++ b/src/middlewared/middlewared/plugins/gluster_linux/volume.py
@@ -16,7 +16,7 @@ class GlusterVolumeService(CRUDService):
         namespace = 'gluster.volume'
 
     @filterable
-    async def query(self, filters=None, options=None):
+    async def query(self, filters, options):
         vols = []
         if await self.middleware.call('service.started', 'glusterd'):
             method = volume.status_detail


### PR DESCRIPTION
Since the gluster and ctdb related APIs aren't stable, yet. I've gone ahead and done a few things:

- make gluster.volume/peer plugins follow our standard for CRUD apis
- add a new plugin that is simply a wrapper for calling external library for gluster related information
- make ctdb.shared.volume and gluster.volume/peer plugins use new wrapper
- convert ctdb.shared.volume and gluster.volume/peer to `async`
- removed unnecessary methods in gluster.volume/peer plugins respectively
- updated doc strings to be uniform between the plugins
- along the way I've fixed a few various small bugs
