### PR TITLE
NAS-109142 / 21.02 / Only run oneshot systemd units once

### DIFF
--- a/debian/debian/ix-conf.service
+++ b/debian/debian/ix-conf.service
@@ -7,6 +7,7 @@ After=systemd-remount-fs.service
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=rm -rf /var/log
 ExecStart=cp -a /conf/base/var/log /var/
 

--- a/debian/debian/ix-etc.service
+++ b/debian/debian/ix-etc.service
@@ -9,6 +9,7 @@ Before=local-fs.target
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 TimeoutStartSec=300
 ExecStart=midclt call -job certificate.dhparam_setup
 ExecStart=midclt call etc.generate_checkpoint initial

--- a/debian/debian/ix-freebsd-to-scale-update.service
+++ b/debian/debian/ix-freebsd-to-scale-update.service
@@ -16,6 +16,7 @@ ConditionPathExists=/data/freebsd-to-scale-update
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 TimeoutStartSec=300
 ExecStart=midclt call -job update.freebsd_to_scale
 StandardOutput=null

--- a/debian/debian/ix-netif.service
+++ b/debian/debian/ix-netif.service
@@ -10,6 +10,7 @@ Conflicts=systemd-networkd.service
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=-midclt -t 60 call failover.internal_interface.pre_sync
 ExecStart=-midclt -t 120 call interface.sync true
 ExecStartPost=midclt call etc.generate_checkpoint interface_sync

--- a/debian/debian/ix-postinit.service
+++ b/debian/debian/ix-postinit.service
@@ -5,6 +5,7 @@ After=multi-user.target
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=midclt call core.notify_postinit
 ExecStart=midclt call -job initshutdownscript.execute_init_tasks POSTINIT
 StandardOutput=null

--- a/debian/debian/ix-preinit.service
+++ b/debian/debian/ix-preinit.service
@@ -9,6 +9,7 @@ Before=local-fs.target
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=midclt call -job initshutdownscript.execute_init_tasks PREINIT
 StandardOutput=null
 StandardError=null

--- a/debian/debian/ix-ssh-keys.service
+++ b/debian/debian/ix-ssh-keys.service
@@ -4,6 +4,7 @@ After=ssh.service
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=midclt call ssh.save_keys
 
 [Install]

--- a/debian/debian/ix-syncdisks.service
+++ b/debian/debian/ix-syncdisks.service
@@ -7,6 +7,7 @@ Before=ix-etc.service
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=midclt call --job true --job-print description disk.sync_all
 StandardOutput=null
 

--- a/debian/debian/ix-update.service
+++ b/debian/debian/ix-update.service
@@ -6,6 +6,7 @@ Before=middlewared.service
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=ix-update
 
 [Install]


### PR DESCRIPTION
`ix-conf` was being ran again when `middlewared` was restarted
resulting in losing `/var/log` contents