### PR TITLE
NAS-109164 / 21.02 / dont traceback in ctdb.general.healthy

### DIFF
--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_general.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_general.py
@@ -79,6 +79,15 @@ class CtdbGeneralService(Service):
         Returns a boolean if the ctdb cluster is healthy.
         """
 
+        # without ctdbd running, nothing to do
+        if not await self.middleware.call('service.started', 'ctdb'):
+            return False
+
+        # make sure the ctdb shared volume exists and is started
+        exists, started = await self.middleware.call('ctdb.shared.volume.exists_and_started')
+        if not exists and not started:
+            return False
+
         # TODO: ctdb has event scripts that can be run when the
         # health of the cluster has changed. We should use this
         # approach and use a lock on a file as a means of knowing

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_general.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_general.py
@@ -1,8 +1,9 @@
+import json
+
 from middlewared.schema import Dict, Bool
 from middlewared.service import CallError, Service, accepts, private
 from middlewared.utils import run
 
-import json
 
 
 class CtdbGeneralService(Service):
@@ -86,6 +87,11 @@ class CtdbGeneralService(Service):
         # make sure the ctdb shared volume exists and is started
         exists, started = await self.middleware.call('ctdb.shared.volume.exists_and_started')
         if not exists and not started:
+            return False
+
+        # if the ctdb shared volume isn't mounted locally then
+        # active-active shares will not work so assume the worst
+        if not await self.middleware.call('ctdb.shared.volume.is_mounted'):
             return False
 
         # TODO: ctdb has event scripts that can be run when the

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_general.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_general.py
@@ -5,7 +5,6 @@ from middlewared.service import CallError, Service, accepts, private
 from middlewared.utils import run
 
 
-
 class CtdbGeneralService(Service):
 
     class Config:

--- a/src/middlewared/middlewared/plugins/cluster_linux/ctdb_shared_volume.py
+++ b/src/middlewared/middlewared/plugins/cluster_linux/ctdb_shared_volume.py
@@ -116,6 +116,19 @@ class CtdbSharedVolumeService(Service):
         # now delete it
         await self.middleware.call('gluster.method.run', volume.delete, {'args': (CTDB_VOL_NAME,)})
 
+    async def is_mounted(self):
+        """
+        Return a boolean if ctdb shared volume is mounted locally.
+        """
+
+        try:
+            mounted = pathlib.Path(CTDB_LOCAL_MOUNT).is_mount()
+        except Exception:
+            # happens when mounted but glusterd service is stopped/crashed
+            mounted = False
+
+        return mounted
+
     @job(lock=MOUNT_UMOUNT_LOCK)
     async def mount(self, job):
         """


### PR DESCRIPTION
If `ctdb.general.healthy` is called and the `ctdbd` service isn't started, then this will raise a traceback.

- check to make sure `ctdbd` service is started
- make sure the ctdb shared volume exists and is started
- make sure the ctdb shared volume is mounted locally