### PR TITLE
NAS-109170 / 21.02 / start/stop ctdbd service with glusterd

### DIFF
--- a/src/middlewared/middlewared/plugins/service_/services/glusterd.py
+++ b/src/middlewared/middlewared/plugins/service_/services/glusterd.py
@@ -12,15 +12,17 @@ class GlusterdService(SimpleService):
         # the glustereventsd daemon is started via the
         # ctdb.shared.volume.mount method. See comment there
         # to know why we do this.
-        await (
+        if await (
             await self.middleware.call('ctdb.shared.volume.mount')
-        ).wait(raise_error=True)
+        ).wait(raise_error=True):
+            await self.middleware.call('service.start', 'ctdb')
 
     async def after_restart(self):
         # bounce the glustereventsd service
         await self.middleware.call('service.restart', 'glustereventsd')
 
     async def before_stop(self):
+        await self.middleware.call('service.stop', 'ctdb')
         await (
             await self.middleware.call('ctdb.shared.volume.umount')
         ).wait(raise_error=True)


### PR DESCRIPTION
`glusterd` service is the "source of truth" for the `ctdbd` service. Meaning, if the `glusterd` service is started and/or stopped, then we need to start/stop the `ctdbd` service accordingly. Without `glusterd` running, the `ctdbd` service is worthless for our implementation.