### PR TITLE
NAS-109173 / 12.0 / middleware job - re-raise existing CallError (by anodos325)

### DIFF
--- a/src/middlewared/middlewared/job.py
+++ b/src/middlewared/middlewared/job.py
@@ -312,6 +312,9 @@ class Job(object):
             await asyncio.wait_for(asyncio.shield(self._finished.wait()), timeout)
         if raise_error:
             if self.error:
+                if isinstance(self.exc_info[1], CallError):
+                    raise self.exc_info[1]
+
                 raise CallError(self.error)
         return self.result
 
@@ -329,6 +332,9 @@ class Job(object):
         event.wait()
         if raise_error:
             if self.error:
+                if isinstance(self.exc_info[1], CallError):
+                    raise self.exc_info[1]
+
                 raise CallError(self.error)
         return self.result
 


### PR DESCRIPTION
Preserve error string, errno, and extra info from original CallError by
re-reaising it from job.

Original PR: https://github.com/freenas/freenas/pull/6332