### PR TITLE
NAS-109098 / 21.02 / Start/stop s3 if underlying dataset is locked/unlocked

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/unlock.py
+++ b/src/middlewared/middlewared/plugins/pool_/unlock.py
@@ -30,7 +30,11 @@ class PoolDatasetService(Service):
             if service['enable'] or service['state'] == 'RUNNING':
                 result[k] = v
 
-        check_services = {'kubernetes': 'Applications', **services}
+        check_services = {
+            'kubernetes': 'Applications',
+            's3': 'S3',
+            **services
+        }
 
         result.update({
             k: check_services[k] for k in map(

--- a/src/middlewared/middlewared/plugins/s3.py
+++ b/src/middlewared/middlewared/plugins/s3.py
@@ -92,9 +92,7 @@ class S3Service(SystemServiceService):
                     f's3_update.{attr}', f'Attribute should be {minlen} to {maxlen} in length'
                 )
 
-        if not new['storage_path']:
-            verrors.add('s3_update.storage_path', 'Storage path is required')
-        else:
+        if new['storage_path']:
             await check_path_resides_within_volume(
                 verrors, self.middleware, 's3_update.storage_path', new['storage_path']
             )

--- a/src/middlewared/middlewared/plugins/s3_/attachments.py
+++ b/src/middlewared/middlewared/plugins/s3_/attachments.py
@@ -27,6 +27,7 @@ class MinioFSAttachmentDelegate(FSAttachmentDelegate):
         return attachment['id']
 
     async def delete(self, attachments):
+        await self.stop(attachments)
         await self.middleware.call('s3.update', {'storage_path': ''})
 
     async def toggle(self, attachments, enabled):

--- a/src/middlewared/middlewared/plugins/s3_/attachments.py
+++ b/src/middlewared/middlewared/plugins/s3_/attachments.py
@@ -1,0 +1,49 @@
+import os
+
+from middlewared.common.attachment import FSAttachmentDelegate
+
+
+class MinioFSAttachmentDelegate(FSAttachmentDelegate):
+    name = 's3'
+    title = 'S3'
+    service = 's3'
+
+    async def query(self, path, enabled, options=None):
+        results = []
+
+        s3_config = await self.middleware.call('s3.config')
+        if not s3_config['storage_path']:
+            return results
+        else:
+            s3_ds = await self.middleware.call('zfs.dataset.path_to_dataset', s3_config['storage_path'])
+
+        query_dataset = os.path.relpath(path, '/mnt')
+        if query_dataset in (s3_ds, s3_ds.split('/')[0]) or query_dataset.startswith(f'{s3_ds}/'):
+            results.append({'id': s3_ds})
+
+        return results
+
+    async def get_attachment_name(self, attachment):
+        return attachment['id']
+
+    async def delete(self, attachments):
+        await self.middleware.call('s3.update', {'storage_path': ''})
+
+    async def toggle(self, attachments, enabled):
+        await getattr(self, 'start' if enabled else 'stop')(attachments)
+
+    async def stop(self, attachments):
+        try:
+            await self.middleware.call('service.stop', 's3')
+        except Exception as e:
+            self.middleware.logger.error('Failed to stop s3: %s', e)
+
+    async def start(self, attachments):
+        try:
+            await self.middleware.call('service.start', 's3')
+        except Exception:
+            self.middleware.logger.error('Failed to start s3')
+
+
+async def setup(middleware):
+    await middleware.call('pool.dataset.register_attachment_delegate', MinioFSAttachmentDelegate(middleware))

--- a/src/middlewared/middlewared/plugins/s3_/attachments.py
+++ b/src/middlewared/middlewared/plugins/s3_/attachments.py
@@ -36,14 +36,14 @@ class MinioFSAttachmentDelegate(FSAttachmentDelegate):
     async def stop(self, attachments):
         try:
             await self.middleware.call('service.stop', 's3')
-        except Exception as e:
-            self.middleware.logger.error('Failed to stop s3: %s', e)
+        except Exception:
+            self.middleware.logger.error('Failed to stop s3', exc_info=True)
 
     async def start(self, attachments):
         try:
             await self.middleware.call('service.start', 's3')
         except Exception:
-            self.middleware.logger.error('Failed to start s3')
+            self.middleware.logger.error('Failed to start s3', exc_info=True)
 
 
 async def setup(middleware):

--- a/src/middlewared/middlewared/plugins/service_/services/s3.py
+++ b/src/middlewared/middlewared/plugins/service_/services/s3.py
@@ -1,3 +1,5 @@
+from middlewared.service import CallError
+
 from .base import SimpleService
 
 
@@ -10,3 +12,7 @@ class S3Service(SimpleService):
     freebsd_pidfile = "/var/run/minio.pid"
 
     systemd_unit = "minio"
+
+    async def before_start(self):
+        if not (await self.middleware.call('s3.config'))['storage_path']:
+            raise CallError('Storage path must bet set to start S3 service')

--- a/src/middlewared/middlewared/plugins/service_/services/s3.py
+++ b/src/middlewared/middlewared/plugins/service_/services/s3.py
@@ -15,4 +15,4 @@ class S3Service(SimpleService):
 
     async def before_start(self):
         if not (await self.middleware.call('s3.config'))['storage_path']:
-            raise CallError('Storage path must bet set to start S3 service')
+            raise CallError('Storage path must be set to start S3 service')

--- a/src/middlewared/middlewared/plugins/service_/services/s3.py
+++ b/src/middlewared/middlewared/plugins/service_/services/s3.py
@@ -14,5 +14,8 @@ class S3Service(SimpleService):
     systemd_unit = "minio"
 
     async def before_start(self):
-        if not (await self.middleware.call('s3.config'))['storage_path']:
+        storage_path = (await self.middleware.call('s3.config'))['storage_path']
+        if not storage_path:
             raise CallError('Storage path must be set to start S3 service')
+        if await self.middleware.call('pool.dataset.path_in_locked_datasets', storage_path):
+            raise CallError('Unable to start S3 service as storage path is accessing a locked dataset')


### PR DESCRIPTION
This PR introduces following changes:

1) Introduces attachment delegate for s3
2) Allows unsetting storage path for s3 service