### PR TITLE
NAS-109194 / 21.02 / handle k3s and VMs on SCALE HA appropriately

### DIFF
--- a/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/event_linux.py
+++ b/src/freenas/usr/local/lib/middlewared_truenas/plugins/failover_/event_linux.py
@@ -512,10 +512,10 @@ class FailoverService(Service):
         # restart the non-critical services in the background
         self.run_call('failover.events.restart_background', fobj['services'])
 
-        # restart any k3s applications
+        # restart any kubernetes applications
         if self.run_call('kubernetes.config')['dataset']:
             logger.info('Restarting applications')
-            self.run_call('service.start', 'k3s')
+            self.run_call('service.start', 'kubernetes')
 
         # start any VMs (this will log errors if the vm(s) fail to start)
         self.run_call('vm.start_on_boot')

--- a/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/kubernetes_linux/lifecycle.py
@@ -209,8 +209,9 @@ class KubernetesService(Service):
 
 
 async def _event_system(middleware, event_type, args):
-
-    if args['id'] == 'ready':
+    # we ignore the 'ready' event on an HA system since the failover event plugin
+    # is responsible for starting this service
+    if args['id'] == 'ready' and not await middleware.call('failover.licensed'):
         asyncio.ensure_future(middleware.call('kubernetes.start_kubernetes'))
     elif args['id'] == 'shutdown' and await middleware.call('service.started', 'kubernetes'):
         asyncio.ensure_future(middleware.call('service.stop', 'kubernetes'))

--- a/src/middlewared/middlewared/plugins/vm/lifecycle.py
+++ b/src/middlewared/middlewared/plugins/vm/lifecycle.py
@@ -142,20 +142,20 @@ async def __event_system_ready(middleware, event_type, args):
     Method called when system is ready, supposed to start VMs
     flagged that way.
     """
-
     async def stop_vm(mw, vm):
         stop_job = await mw.call('vm.stop', vm['id'], {'force_after_timeout': True})
         await stop_job.wait()
         if stop_job.error:
             mw.logger.error(f'Stopping VM {vm["name"]} failed: {stop_job.error}')
 
-    # we ignore the 'ready' event on an HA system since the failover event plugin
-    # is responsible for starting this service
-    if args['id'] == 'ready' and not await middleware.call('failover.licensed'):
+    if args['id'] == 'ready':
         await middleware.call('vm.update_zfs_arc_max_initial')
 
         await middleware.call('vm.initialize_vms')
 
+        # we ignore the 'ready' event on an HA system since the failover event plugin
+        # is responsible for starting this service, however, the VMs still need to be
+        # initialized (which is what the above callers are doing)
         if await middleware.call('failover.licensed'):
             return
 


### PR DESCRIPTION
- don't start VMs or k3s automatically on system event `ready` on SCALE HA systems since the failover event plugin is responsible for starting those services
- on failover master event start VMs and k3s as necessary
- fix minor `logger.info` typo when disallowing network traffic on failover backup event
- when a VM fails to start, don't log as `logger.debug` but instead use `logger.error`