### PR TITLE
Disable nscd service by default

### DIFF
--- a/src/freenas/usr/lib/systemd/system-preset/10-truenas.preset
+++ b/src/freenas/usr/lib/systemd/system-preset/10-truenas.preset
@@ -22,6 +22,7 @@ disable avahi-daemon.service
 disable nmbd.service
 disable nfs*
 disable rsync.service
+disable nscd.service
 disable minio.service
 disable snmpd.service
 disable snmp-agent.service


### PR DESCRIPTION
For case of directory services we use winbindd for caching nss lookups.