### PR TITLE
NAS-109228 / 21.02 / Allow running a migration for chart release upgrades

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
@@ -176,8 +176,13 @@ class ChartReleaseService(Service):
 
         # This is guaranteed to exist based on above check
         file_path = next(f for f in migration_files if os.access(f, os.X_OK))
-        cp = subprocess.Popen([file_path, json.dumps(config)], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        stdout, stderr = cp.communicate()
+
+        with tempfile.NamedTemporaryFile(mode='w+') as f:
+            f.write(json.dumps(config))
+            f.flush()
+            cp = subprocess.Popen([file_path, f.name], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdout, stderr = cp.communicate()
+
         if cp.returncode:
             raise CallError(f'Failed to apply migration: {stderr.decode()}')
 

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
@@ -93,7 +93,7 @@ class ChartReleaseService(Service):
         catalog_item = catalog['trains'][release['catalog_train']][chart]['versions'][new_version]
         await self.middleware.call('catalog.version_supported_error_check', catalog_item)
 
-        config = await self.middleware.call('chart.release.upgrade_values', release)
+        config = await self.middleware.call('chart.release.upgrade_values', release, catalog_item['location'])
 
         # We will be performing validation for values specified. Why we want to allow user to specify values here
         # is because the upgraded catalog item version might have different schema which potentially means that
@@ -167,10 +167,10 @@ class ChartReleaseService(Service):
         return chart_release
 
     @private
-    def upgrade_values(self, release):
+    def upgrade_values(self, release, new_version_path):
         config = copy.deepcopy(release['config'])
         chart_version = release['chart_metadata']['version']
-        migration_path = os.path.join(release['path'], 'charts', chart_version, 'migrations')
+        migration_path = os.path.join(new_version_path, 'migrations')
         migration_files = [os.path.join(migration_path, k) for k in (f'migrate_from_{chart_version}.py', 'migrate.py')]
         if not os.path.exists(migration_path) or all(not os.path.exists(p) for p in migration_files):
             return config


### PR DESCRIPTION
This commit adds changes allowing chart devs to have a migration in a chart release version which will allow them to change format of user specified input to a new format if they have made breaking changes in the configuration format while extending the chart or fixing some issues.