### PR TITLE
NAS-109231 / 21.02 / Schema changes for chart releases

### DIFF
--- a/src/middlewared/middlewared/plugins/catalogs_linux/items.py
+++ b/src/middlewared/middlewared/plugins/catalogs_linux/items.py
@@ -132,7 +132,6 @@ class CatalogService(Service):
     def item_version_details(self, version_path):
         version_data = {'location': version_path, 'required_features': set()}
         for key, filename, parser in (
-            ('values', 'values.yaml', yaml.safe_load),
             ('schema', 'questions.yaml', yaml.safe_load),
             ('app_readme', 'app-readme.md', str.strip),
             ('detailed_readme', 'README.md', markdown.markdown),
@@ -147,7 +146,7 @@ class CatalogService(Service):
         version_data['supported'] = self.middleware.call_sync('catalog.version_supported', version_data)
         version_data['required_features'] = list(version_data['required_features'])
         version_data['values'] = self.middleware.call_sync(
-            'chart.release.construct_schema_for_item_version', version_data, version_data['values'], False
+            'chart.release.construct_schema_for_item_version', version_data, {}, False
         )['new_values']
 
         return version_data

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/normalize_schema.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/normalize_schema.py
@@ -117,8 +117,11 @@ class ChartReleaseService(Service):
                 'method': 'update_volumes_for_release',
                 'args': [copy.deepcopy(context['release']), [ds_name]],
             })
-        else:
+        elif ds_name not in action_dict['args'][-1]:
             action_dict['args'][-1].append(ds_name)
+        else:
+            # We already have this in action dict, let's not add a duplicate
+            return value
 
         complete_config['ixVolumes'].append({
             'hostPath': os.path.join(context['release']['path'], 'volumes/ix_volumes', ds_name),

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/schema.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/schema.py
@@ -87,7 +87,12 @@ def get_schema(variable_details, update):
 
 def clean_value_of_attr_for_upgrade(orig_value, variable):
     value = deepcopy(orig_value)
-    valid_attrs = {v['variable']: v for v in variable['schema']['attrs']}
+    valid_attrs = {}
+    for v in variable['schema']['attrs']:
+        valid_attrs[v['variable']] = v
+        for sub in (v['schema'].get('subquestions') or []):
+            valid_attrs[sub['variable']] = sub
+
     for k, v in orig_value.items():
         if k not in valid_attrs:
             value.pop(k)

--- a/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/upgrade.py
@@ -143,6 +143,8 @@ class ChartReleaseService(Service):
             }
         })
 
+        job.set_progress(50, 'Upgrading chart release')
+
         with tempfile.NamedTemporaryFile(mode='w+') as f:
             f.write(yaml.dump(config))
             f.flush()


### PR DESCRIPTION
This PR adds following changes:

1) Do not read from `values.yaml` and re-construct defaults from `questions.yaml` as that is the source of truth.
2) Allow `ix_volume` to be a string which is much less verbose when specifying it in questions.
3) Fix an issue where on upgrades, schema values will not be cleaned properly as attributes specified in `subquestions` would be missed out.