### PR TITLE
NAS-109140 / 21.02 / fix RuntimeWarning on python3.8 (by yocalebo)

### DIFF
--- a/src/middlewared/middlewared/plugins/system.py
+++ b/src/middlewared/middlewared/plugins/system.py
@@ -801,11 +801,11 @@ class SystemService(Service):
         cp = subprocess.Popen(
             ['ixdiagnose', '-d', direc, '-s', '-F', '-p'],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-            bufsize=1
+            universal_newlines=True, bufsize=1,
         )
 
-        for line in iter(cp.stdout.readline, b''):
-            line = line.decode(errors='ignore').rstrip()
+        for line in iter(cp.stdout.readline, ''):
+            line = line.rstrip()
 
             if line.startswith('**') and '%: ' in line:
                 percent, desc = line.split('%: ', 1)


### PR DESCRIPTION
Line buffering in binary mode is not supported so python3.8 raises a `RuntimeWarning` when `bufsize=1`

Original PR: https://github.com/freenas/freenas/pull/6347