### PR TITLE
Be more permissive for rotation rate errors

### DIFF
--- a/src/middlewared/middlewared/plugins/device_/device_info_linux.py
+++ b/src/middlewared/middlewared/plugins/device_/device_info_linux.py
@@ -134,7 +134,7 @@ class DeviceService(Service, DeviceInfoBase):
         try:
             disk = libsgio.SCSIDevice(device_path)
             rotation_rate = disk.rotation_rate()
-        except RuntimeError:
+        except (OSError, RuntimeError):
             self.logger.error('Ioctl failed while retrieving rotational rate for disk %s', device_path)
             return
 


### PR DESCRIPTION
An USB stick plugged into VirtualBox
```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/middlewared/plugins/device_/device_info_linux.py", line 79, in get_disks
    disks[block_device.sys_name] = self.get_disk_details(block_device, self.disk_default.copy(), disks_data)
  File "/usr/lib/python3/dist-packages/middlewared/plugins/device_/device_info_linux.py", line 181, in get_disk_details
    disk['rotationrate'] = self.get_rotational_rate(device_path)
  File "/usr/lib/python3/dist-packages/middlewared/plugins/device_/device_info_linux.py", line 136, in get_rotational_rate
    rotation_rate = disk.rotation_rate()
  File "libsgio.pyx", line 656, in libsgio.SCSIDevice.rotation_rate
OSError: {'status': '0x02', 'masked_status': '0x01', 'host_status': '0x00', 'driver_status': '0x08', 'raw_data': ['0xf0', '0x00', '0x05', '0x00', '0x00', '0x00', '0x00', '0x0a', '0x00', '0x00', '0x00', '0x00', '0x20', '0x00', '0x00', '0x00', '0x00', '0x00', '0x00']}
```