### PR TITLE
NAS-109234 / 21.02 / Fix potential division-by-zero error

### DIFF
--- a/src/middlewared/middlewared/plugins/pool_/unlock.py
+++ b/src/middlewared/middlewared/plugins/pool_/unlock.py
@@ -91,7 +91,14 @@ class PoolDatasetService(Service):
             if not to_restart:
                 return
 
-            await self.middleware.call('core.bulk', 'service.restart', to_restart)
+            restart_job = await self.middleware.call('core.bulk', 'service.restart', to_restart)
+            statuses = await restart_job.wait()
+            for idx, srv_status in enumerate(statuses):
+                if srv_status['error']:
+                    self.logger.error(
+                        'Failed to restart %r service after %r unlock: %s',
+                        to_restart[idx], dataset_name, srv_status['error']
+                    )
             if 'jails' in services_to_restart:
                 await self.middleware.call('jail.rc_action', ['RESTART'])
             if 'vms' in services_to_restart:

--- a/src/middlewared/middlewared/plugins/pool_/unlock.py
+++ b/src/middlewared/middlewared/plugins/pool_/unlock.py
@@ -87,9 +87,11 @@ class PoolDatasetService(Service):
     @private
     async def restart_services_after_unlock(self, dataset_name, services_to_restart):
         try:
-            await self.middleware.call('core.bulk', 'service.restart', [
-                [i] for i in set(services_to_restart) - {'jails', 'vms'}
-            ])
+            to_restart = [[i] for i in set(services_to_restart) - {'jails', 'vms'}]
+            if not to_restart:
+                return
+
+            await self.middleware.call('core.bulk', 'service.restart', to_restart)
             if 'jails' in services_to_restart:
                 await self.middleware.call('jail.rc_action', ['RESTART'])
             if 'vms' in services_to_restart:

--- a/src/middlewared/middlewared/service.py
+++ b/src/middlewared/middlewared/service.py
@@ -1318,6 +1318,9 @@ class CoreService(Service):
         exception
         """
         statuses = []
+        if not params:
+            return statuses
+
         progress_step = 100 / len(params)
         current_progress = 0
 


### PR DESCRIPTION
Ensure that we don't call core.bulk with empty list of params from
restart_services_after_unlock(). Also return early in core.bulk
if no params are passed in.