### PR TITLE
NAS-109066 / 12.0 / Fix "This rsync lacks old-style --compress due to its external zlib. …

### DIFF
--- a/src/middlewared/middlewared/plugins/rsync.py
+++ b/src/middlewared/middlewared/plugins/rsync.py
@@ -631,7 +631,7 @@ class RsyncTaskService(TaskPathService):
         ]
         for name, flag in (
             ('archive', '-a'),
-            ('compress', '-z'),
+            ('compress', '-zz'),
             ('delayupdates', '--delay-updates'),
             ('delete', '--delete-delay'),
             ('preserveattr', '-X'),


### PR DESCRIPTION
…Try -zz. Continuing without compression."