### PR TITLE
NAS-109066 / 21.02 / Fix "This rsync lacks old-style --compress due to its external zlib. … (by themylogin)

### DIFF
--- a/src/middlewared/middlewared/plugins/rsync.py
+++ b/src/middlewared/middlewared/plugins/rsync.py
@@ -632,7 +632,7 @@ class RsyncTaskService(TaskPathService):
         line = ['rsync']
         for name, flag in (
             ('archive', '-a'),
-            ('compress', '-z'),
+            ('compress', '-zz'),
             ('delayupdates', '--delay-updates'),
             ('delete', '--delete-delay'),
             ('preserveattr', '-X'),


### PR DESCRIPTION
…Try -zz. Continuing without compression."

Original PR: https://github.com/freenas/freenas/pull/6366