### PR TITLE
NAS-109286 / 21.02 / Fix validation for kerberos default_ccache_type

### DIFF
--- a/src/middlewared/middlewared/plugins/kerberos.py
+++ b/src/middlewared/middlewared/plugins/kerberos.py
@@ -187,9 +187,16 @@ class KerberosService(ConfigService):
                     raise CallError(f'[{e}] is not a supported encryption type')
 
         if data['ptype'] == 'cctype':
-            for cctype in ['DIR', 'FILE', 'MEMORY']:
-                if cctype not in data['value']:
-                    raise CallError(f'{data["value"]} is an unsupported cctype')
+            available_types = ['FILE', 'MEMORY']
+            if osc.IS_FREEBSD:
+                available_types.append('SCC')
+            else:
+                available_types.append('DIR')
+
+            if data['value'] not in available_types:
+                raise CallError(f'[{data["value"]}] is an unsupported cctype. '
+                                f'Available types are {", ".join(available_types)}. '
+                                'This parameter is case-sensitive')
 
         if data['ptype'] == 'keytab':
             try:


### PR DESCRIPTION
This fixes validation for the parameter. Does not guarantee the parameter works in any comprehensible way on the server.