### PR TITLE
NAS-109283 / 21.02 / Better handle system managed internal datasets

### DIFF
--- a/src/middlewared/middlewared/plugins/pool.py
+++ b/src/middlewared/middlewared/plugins/pool.py
@@ -3218,6 +3218,12 @@ class PoolDatasetService(CRUDService):
                 [('id', '=', data['name'].rsplit('/', 1)[0])]
             )
 
+        if await self.is_internal_dataset(data['name']):
+            verrors.add(
+                f'{schema}.name',
+                f'{data["name"]!r} is using system internal managed dataset. Please specify a different parent.'
+            )
+
         if not parent:
             verrors.add(
                 f'{schema}.name',


### PR DESCRIPTION
This PR fixes following issues:

1) We make sure to remove system managed internal datasets from children attribute of a dataset.
2) We make sure that we are not able to create a dataset under system managed internal datasets using `pool.dataset.create` api.