### PR TITLE
NAS-109292 / 21.02 / Bug fix for chart release name regex

### DIFF
--- a/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
+++ b/src/middlewared/middlewared/plugins/chart_releases_linux/chart_release.py
@@ -263,7 +263,7 @@ class ChartReleaseService(CRUDService):
             Dict('values', additional_attrs=True),
             Str('catalog', required=True),
             Str('item', required=True),
-            Str('release_name', required=True, validators=[Match(r'[a-z0-9]([-a-z0-9]*[a-z0-9])?')]),
+            Str('release_name', required=True, validators=[Match(r'^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')]),
             Str('train', default='charts'),
             Str('version', default='latest'),
         )


### PR DESCRIPTION
This commit makes sure that we don't match string partially for chart release name