### PR TITLE
NAS-109304 / 21.02 / set xattr=sa by default in zfs.dataset.create API

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -781,6 +781,13 @@ class ZFSDatasetService(CRUDService):
         for k, v in data['properties'].items():
             params[k] = v
 
+        # it's important that we set xattr=sa for various
+        # performance reasons related to ea handling
+        # pool.dataset.create already sets this by default
+        # so mirror the behavior here
+        if 'xattr' not in params.keys():
+            params['xattr'] = 'sa'
+
         try:
             with libzfs.ZFS() as zfs:
                 pool = zfs.get(data['name'].split('/')[0])

--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -785,7 +785,7 @@ class ZFSDatasetService(CRUDService):
         # performance reasons related to ea handling
         # pool.dataset.create already sets this by default
         # so mirror the behavior here
-        if 'xattr' not in params.keys():
+        if 'xattr' not in params:
             params['xattr'] = 'sa'
 
         try:


### PR DESCRIPTION
The public API `pool.dataset.create` will set the `xattr` zfs property to 'sa' if it's not provided by end-user. This mitigates, potentially, quite severe performance problems wrt to EA's. The private API `zfs.dataset.create` needs to do the same.