### PR TITLE
NAS-109329 / 21.02 / fix traceback in zfs.dataset.create

### DIFF
--- a/src/middlewared/middlewared/plugins/zfs.py
+++ b/src/middlewared/middlewared/plugins/zfs.py
@@ -785,7 +785,7 @@ class ZFSDatasetService(CRUDService):
         # performance reasons related to ea handling
         # pool.dataset.create already sets this by default
         # so mirror the behavior here
-        if 'xattr' not in params:
+        if data['type'] == 'FILESYSTEM' and 'xattr' not in params:
             params['xattr'] = 'sa'
 
         try:


### PR DESCRIPTION
`xattr` is only applicable to ZVOL types.